### PR TITLE
Apply the project sample rate to every trace, not just profiled agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -632,3 +632,37 @@ floor): the first call reported an 8018-token cache write, the second an 8018-to
 both landed in the traces row correctly, and a configured-vs-unconfigured cost comparison on the
 same token counts ($0.001665 vs. the unconfigured fallback of $0.00018, matching the pre-existing
 flat-rate formula exactly) confirmed both the discount and the regression guard.
+
+Monitor's project-level sample rate (Platform Settings > Monitoring Defaults) turned out to be a
+silent no-op for most traffic. `runMonitorCheck`'s gate read `if (profile &&
+!passesSampleRate(defaults.sampleRate))`, so it only applied to agents that happened to have a
+`monitor_profiles` row - and nothing writes one on ingest, only an explicit profile PUT or
+`core/seed.ts`. Left over from when the always-on monitor-checks change removed the
+`ctx.requireEnabledProfile` gate above it: harmless while "no profile" still meant "skip", but it
+inverted the setting's meaning once every ingested trace was checked. On a default install,
+turning coverage down to 10% (or 0%) changed nothing. Measured before the fix at `sampleRate: 0.5`
+over 300 failing traces each: agent without a profile row 300/300 monitored, agent with one
+145/300, agent-less traces 300/300. Fixed by dropping the `profile &&` prefix from the sampling
+gate only - the `profile && !profile.enabled` check above it stays, since an explicitly disabled
+profile is still the per-agent opt-out.
+
+Two related things left alone deliberately. `pruneRetentionData` is still called under
+`if (profile)`, so the project's `retentionDays` also only prunes for profiled agents - same root
+cause, but unblocking it starts *deleting* traces/events for agents that were never pruned before,
+which is a data-loss decision to make on its own. And the SDK-facing `POST
+/api/v1/monitor/patterns` still doesn't forward `sampleRate`/`scopeMode`/`agentIds`, with no
+pattern PUT/PATCH/DELETE on that router at all, so per-pattern sampling remains dashboard-only;
+no route validates `sampleRate` into `[0, 1]` either, where a stored `-1` silently means "monitor
+nothing" and a `50` (a UI sending percent) silently means "monitor everything".
+
+This is also the engine's first test suite: `routing.test.ts` (unit tests for
+`passesSampleRate`/`matchesAgentScope`, including out-of-range and NaN semantics and a guard for
+the `"selected"` vs `"specific"` scope-string bug recorded above) and `detect.test.ts`
+(`runMonitorCheck` against a real temporary SQLite database - project-rate sampling with a profile
+row, without one, and with no agentId; rates 0 and 1; the disabled-profile opt-out; per-pattern
+sampling; and the deliberate `pattern_ids` bypass). `Math.random` is stubbed with a seeded PRNG so
+the statistical assertions are deterministic rather than flaky, and all four project-rate tests
+were confirmed to fail against the old gate (200/200 and 20/20 monitored where ~100 and 0 were
+expected) before the fix went in. `engine`'s `test` script drops `--passWithNoTests`, and `build`
+moves to a new `tsconfig.build.json` excluding `*.test.ts` so `dist/` stays shipping code while
+`yarn typecheck` and editors still cover the tests.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,16 @@ Local API key: agtx_local_...
 
 `--dev` opens the dashboard in your browser automatically.
 
+### Tests
+
+Unit and integration tests for the engine (vitest, run against a temporary SQLite database - no
+API keys or network needed):
+
+```bash
+yarn workspace @agentx/engine test
+yarn workspace @agentx/judge-core test
+```
+
 ### End-to-end smoke test
 
 Confirms everything actually works, including a real Python SDK round-trip:

--- a/engine/package.json
+++ b/engine/package.json
@@ -6,11 +6,11 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch --env-file-if-exists=.env src/index.ts",
-    "build": "tsc -p .",
+    "build": "tsc -p tsconfig.build.json",
     "start": "node --env-file-if-exists=.env dist/index.js",
     "compile": "bun build src/index.ts --compile --outfile dist/agentx-engine",
     "db:migrate": "tsx --env-file-if-exists=.env src/storage/migrate.ts",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit -p ."
   },
   "dependencies": {

--- a/engine/src/core/monitor/detect.test.ts
+++ b/engine/src/core/monitor/detect.test.ts
@@ -1,0 +1,225 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { closeDb, initDb, withProjectId, type Db } from "../../storage/db.js";
+import { getDefaultProject, updateMonitoringDefaults } from "../project/projects.js";
+import { createAgent } from "./agents.js";
+import { createPattern } from "./patterns.js";
+import { updateProfile } from "./profiles.js";
+import { runMonitorCheck } from "./detect.js";
+import { listSignalRows } from "./signals.js";
+import type { PatternCondition } from "./conditions.js";
+
+// Real (temporary) SQLite rather than mocks: what's under test is which rows the detection path
+// reads before it decides to sample. AGENTX_DB_URL is read inside initDb(), so setting it in
+// beforeAll keeps every write in the temp directory.
+let db: Db;
+let tmpDir: string;
+
+// Same deterministic RNG as routing.test.ts.
+function seededRandom(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function seedRng(seed = 42): void {
+  vi.spyOn(Math, "random").mockImplementation(seededRandom(seed));
+}
+
+// Trips the built-in empty-response check: no judge call, no API key.
+const FAILING_TRACE = { input: "hi", output: "", error: null, toolCalls: null, latencyMs: 10 };
+// Matches a custom pattern while tripping no built-in (built-ins run first and short-circuit).
+const REFUND_TRACE = { input: "where is my money", output: "the refund was denied", error: null, toolCalls: null, latencyMs: 10 };
+
+const N = 200;
+
+// Signals dedupe per (patternKey, agentId), so occurrenceCount is "how many traces got monitored".
+async function monitoredCount(patternKey: string, agentId: string | null): Promise<number> {
+  const rows = await listSignalRows(db);
+  return rows
+    .filter(row => row.patternKey === patternKey && row.agentId === agentId)
+    .reduce((total, row) => total + row.occurrenceCount, 0);
+}
+
+async function runN(n: number, trace: typeof FAILING_TRACE, ctx: { agentId: string | null; patternIds?: string[] }): Promise<void> {
+  for (let i = 0; i < n; i++) {
+    await runMonitorCheck(db, trace, { ...ctx, traceId: `trace-${i}` });
+  }
+}
+
+function phraseCondition(value: string): PatternCondition {
+  return { connector: "and", negate: false, sources: ["response"], detector: "phrase", value, caseSensitive: false };
+}
+
+beforeAll(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentx-detect-test-"));
+  process.env.AGENTX_HOME = tmpDir;
+  process.env.AGENTX_DB_URL = `sqlite:${path.join(tmpDir, "test.db")}`;
+  const base = await initDb();
+  const project = await getDefaultProject(base);
+  db = withProjectId(base, project!.id);
+});
+
+afterAll(async () => {
+  await closeDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("runMonitorCheck - project-level sample rate", () => {
+  // The regression this suite exists for: the gate read `profile && !passesSampleRate(...)`, and
+  // only an explicit profile PUT or the seed ever writes a profile row, so this count was N.
+  it("samples an agent that has no monitor_profiles row", async () => {
+    await updateMonitoringDefaults(db, { sampleRate: 0.5 });
+    const agent = await createAgent(db, "sampling-no-profile");
+    seedRng();
+
+    await runN(N, FAILING_TRACE, { agentId: agent._id });
+
+    const monitored = await monitoredCount("empty-agent-response", agent._id);
+    expect(monitored).toBeGreaterThan(N * 0.35);
+    expect(monitored).toBeLessThan(N * 0.65);
+  });
+
+  it("samples an agent that does have a profile row", async () => {
+    await updateMonitoringDefaults(db, { sampleRate: 0.5 });
+    const agent = await createAgent(db, "sampling-with-profile");
+    await updateProfile(db, agent._id, { enabled: true });
+    seedRng();
+
+    await runN(N, FAILING_TRACE, { agentId: agent._id });
+
+    const monitored = await monitoredCount("empty-agent-response", agent._id);
+    expect(monitored).toBeGreaterThan(N * 0.35);
+    expect(monitored).toBeLessThan(N * 0.65);
+  });
+
+  // An agent-less trace can never have a profile row - the other half of the same hole.
+  it("samples traces that carry no agentId", async () => {
+    await updateMonitoringDefaults(db, { sampleRate: 0.5 });
+    seedRng();
+
+    await runN(N, FAILING_TRACE, { agentId: null });
+
+    const monitored = await monitoredCount("empty-agent-response", null);
+    expect(monitored).toBeGreaterThan(N * 0.35);
+    expect(monitored).toBeLessThan(N * 0.65);
+  });
+
+  it("monitors every trace at the default sample rate of 1", async () => {
+    await updateMonitoringDefaults(db, { sampleRate: 1 });
+    const agent = await createAgent(db, "sampling-default");
+
+    await runN(N, FAILING_TRACE, { agentId: agent._id });
+
+    expect(await monitoredCount("empty-agent-response", agent._id)).toBe(N);
+  });
+
+  it("monitors nothing at sample rate 0, with or without a profile row", async () => {
+    await updateMonitoringDefaults(db, { sampleRate: 0 });
+    const profileless = await createAgent(db, "sampling-zero-no-profile");
+    const profiled = await createAgent(db, "sampling-zero-with-profile");
+    await updateProfile(db, profiled._id, { enabled: true });
+
+    await runN(20, FAILING_TRACE, { agentId: profileless._id });
+    await runN(20, FAILING_TRACE, { agentId: profiled._id });
+
+    expect(await monitoredCount("empty-agent-response", profileless._id)).toBe(0);
+    expect(await monitoredCount("empty-agent-response", profiled._id)).toBe(0);
+  });
+
+  // Unchanged by the fix: the `profile &&` prefix stays on the enabled check.
+  it("skips an explicitly disabled profile even at sample rate 1", async () => {
+    await updateMonitoringDefaults(db, { sampleRate: 1 });
+    const agent = await createAgent(db, "sampling-disabled-profile");
+    await updateProfile(db, agent._id, { enabled: false });
+
+    await runN(20, FAILING_TRACE, { agentId: agent._id });
+
+    expect(await monitoredCount("empty-agent-response", agent._id)).toBe(0);
+  });
+});
+
+// Patterns are project-wide and these tests share one database, so each is scoped to its own agent.
+describe("runMonitorCheck - per-pattern sample rate", () => {
+  it("applies each pattern's own sample rate on the implicit sweep path", async () => {
+    await updateMonitoringDefaults(db, { sampleRate: 1 });
+    const agent = await createAgent(db, "pattern-sampled");
+    const pattern = await createPattern(db, {
+      name: "half sampled refunds",
+      conditions: [phraseCondition("refund")],
+      sampleRate: 0.5,
+      scopeMode: "selected",
+      agentIds: [agent._id],
+    });
+    seedRng();
+
+    await runN(N, REFUND_TRACE, { agentId: agent._id });
+
+    const matched = await monitoredCount(pattern.key, agent._id);
+    expect(matched).toBeGreaterThan(N * 0.35);
+    expect(matched).toBeLessThan(N * 0.65);
+  });
+
+  it("never matches a pattern sampled at 0 on the implicit sweep path", async () => {
+    await updateMonitoringDefaults(db, { sampleRate: 1 });
+    const agent = await createAgent(db, "pattern-sampled-zero");
+    const pattern = await createPattern(db, {
+      name: "never sampled refunds",
+      conditions: [phraseCondition("refund")],
+      sampleRate: 0,
+      scopeMode: "selected",
+      agentIds: [agent._id],
+    });
+
+    await runN(20, REFUND_TRACE, { agentId: agent._id });
+
+    expect(await monitoredCount(pattern.key, agent._id)).toBe(0);
+  });
+
+  // Naming a pattern by id asks "does this match right now", so it skips the rate (see routing.ts).
+  it("bypasses pattern sampling when the caller names pattern_ids explicitly", async () => {
+    await updateMonitoringDefaults(db, { sampleRate: 1 });
+    const agent = await createAgent(db, "pattern-explicit");
+    const pattern = await createPattern(db, {
+      name: "explicitly requested refunds",
+      conditions: [phraseCondition("refund")],
+      sampleRate: 0,
+      scopeMode: "selected",
+      agentIds: [agent._id],
+    });
+
+    await runN(10, REFUND_TRACE, { agentId: agent._id, patternIds: [pattern._id] });
+
+    expect(await monitoredCount(pattern.key, agent._id)).toBe(10);
+  });
+
+  it("still honors the project sample rate for a pattern of its own sampled at 1", async () => {
+    await updateMonitoringDefaults(db, { sampleRate: 0.5 });
+    const agent = await createAgent(db, "pattern-project-rate");
+    const pattern = await createPattern(db, {
+      name: "unsampled refunds",
+      conditions: [phraseCondition("refund")],
+      sampleRate: 1,
+      scopeMode: "selected",
+      agentIds: [agent._id],
+    });
+    seedRng();
+
+    await runN(N, REFUND_TRACE, { agentId: agent._id });
+
+    const matched = await monitoredCount(pattern.key, agent._id);
+    expect(matched).toBeGreaterThan(N * 0.35);
+    expect(matched).toBeLessThan(N * 0.65);
+  });
+});

--- a/engine/src/core/monitor/detect.ts
+++ b/engine/src/core/monitor/detect.ts
@@ -214,7 +214,11 @@ export async function runMonitorCheck(
   if (profile && !profile.enabled) {
     return;
   }
-  if (profile && !passesSampleRate(defaults.sampleRate)) {
+  // Not gated on `profile` (it was, until this was fixed): monitoring is always-on per trace,
+  // while profile rows only exist for agents someone configured explicitly - so gating this
+  // project-level setting on one made it a silent no-op for a default install. topics.ts's
+  // runClassification always read it unconditionally; both consumers now agree.
+  if (!passesSampleRate(defaults.sampleRate)) {
     return;
   }
 

--- a/engine/src/core/monitor/routing.test.ts
+++ b/engine/src/core/monitor/routing.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { matchesAgentScope, passesSampleRate } from "./routing.js";
+
+// Deterministic Math.random (mulberry32) so sampling assertions can't flake.
+function seededRandom(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function sampledOutOf(n: number, rate: number, seed = 42): number {
+  const spy = vi.spyOn(Math, "random").mockImplementation(seededRandom(seed));
+  try {
+    let passed = 0;
+    for (let i = 0; i < n; i++) {
+      if (passesSampleRate(rate)) passed++;
+    }
+    return passed;
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("passesSampleRate", () => {
+  it("always passes at 1, without consulting the RNG", () => {
+    const spy = vi.spyOn(Math, "random");
+    for (let i = 0; i < 50; i++) {
+      expect(passesSampleRate(1)).toBe(true);
+    }
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("never passes at 0", () => {
+    expect(sampledOutOf(200, 0)).toBe(0);
+  });
+
+  it("samples roughly the configured fraction", () => {
+    expect(sampledOutOf(1000, 0.5)).toBeGreaterThan(400);
+    expect(sampledOutOf(1000, 0.5)).toBeLessThan(600);
+    expect(sampledOutOf(1000, 0.1)).toBeGreaterThan(50);
+    expect(sampledOutOf(1000, 0.1)).toBeLessThan(160);
+  });
+
+  // No route validates sampleRate, so these are the semantics a bad stored value actually gets.
+  it("treats out-of-range values as always/never rather than throwing", () => {
+    expect(passesSampleRate(2)).toBe(true);
+    expect(sampledOutOf(50, -1)).toBe(0);
+  });
+
+  it("never samples on NaN", () => {
+    expect(sampledOutOf(50, Number.NaN)).toBe(0);
+  });
+});
+
+describe("matchesAgentScope", () => {
+  it("matches every agent, and agent-less traces, when scoped to all", () => {
+    expect(matchesAgentScope({ scopeMode: "all", agentIds: [] }, "agent-1")).toBe(true);
+    expect(matchesAgentScope({ scopeMode: "all", agentIds: ["agent-2"] }, "agent-1")).toBe(true);
+    expect(matchesAgentScope({ scopeMode: "all", agentIds: null }, null)).toBe(true);
+  });
+
+  it("matches only the listed agents when scoped to selected", () => {
+    const row = { scopeMode: "selected", agentIds: ["agent-1", "agent-2"] };
+    expect(matchesAgentScope(row, "agent-1")).toBe(true);
+    expect(matchesAgentScope(row, "agent-3")).toBe(false);
+    expect(matchesAgentScope(row, null)).toBe(false);
+    expect(matchesAgentScope({ scopeMode: "selected", agentIds: null }, "agent-1")).toBe(false);
+  });
+
+  // The dashboard writes "selected" (an earlier version of this check compared "specific" and
+  // silently no-op'd scoping); anything unrecognized fails open rather than stopping monitoring.
+  it("fails open on an unrecognized scopeMode", () => {
+    expect(matchesAgentScope({ scopeMode: "specific", agentIds: ["agent-2"] }, "agent-1")).toBe(true);
+    expect(matchesAgentScope({ scopeMode: "", agentIds: ["agent-2"] }, "agent-1")).toBe(true);
+  });
+});

--- a/engine/tsconfig.build.json
+++ b/engine/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  // Build-only: keeps *.test.ts out of dist/. The base config still includes them, so typecheck
+  // and editors cover the tests.
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
runMonitorCheck gated the project-level ("Monitoring Defaults") sample
rate on `profile &&`, so it only ever applied to agents that happened to
have a monitor_profiles row. Nothing writes one on ingest - only an
explicit profile PUT or core/seed.ts - so on a default install the
setting was a silent no-op: turning coverage down to 10% (or 0%) still
pattern-matched and built-in-checked 100% of traffic, and still
judge-billed every semantic pattern.

Left over from when monitor checks became always-on and the
ctx.requireEnabledProfile gate was removed from this function; while "no
profile" still meant "skip", the prefix was harmless, but once every
ingested trace was checked it inverted the setting's meaning.
topics.ts's runClassification always read the same setting
unconditionally, so the two consumers of one project setting disagreed.

Measured before the fix at sampleRate 0.5 over 300 failing traces each:
agent without a profile row 300/300 monitored, agent with one 145/300,
agent-less traces 300/300.

Only the sampling gate changes - the separate `profile &&
!profile.enabled` check above it stays as-is, since an explicitly
disabled profile is still the per-agent opt-out. pruneRetentionData's
`if (profile)` gate is knowingly left alone: same root cause, but
unblocking it starts deleting traces/events for agents that were never
pruned before, which deserves its own deliberate decision.

Adds the engine's first tests: routing.test.ts (passesSampleRate /
matchesAgentScope, including out-of-range and NaN semantics and a guard
for the "selected" vs "specific" scope string) and detect.test.ts
(runMonitorCheck against a real temporary SQLite database - project-rate
sampling with a profile row, without one, and with no agentId; rates 0
and 1; the disabled-profile opt-out; per-pattern sampling; and the
deliberate pattern_ids bypass). Math.random is stubbed with a seeded
PRNG so the statistical assertions are deterministic. All four
project-rate tests were confirmed to fail against the old gate.

engine's test script drops --passWithNoTests, and build moves to a new
tsconfig.build.json excluding *.test.ts so dist/ stays shipping code
while typecheck and editors still cover the tests.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FF8uBC6EuYS44PvFJHcBLt