### PR TITLE
Create project-scoped unique indexes after project_id exists

### DIFF
--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -306,9 +306,13 @@ async function main() {
   console.log(`Point the SDK here with:`);
   console.log(`  AGENTX_API_BASE_URL=http://localhost:${PORT}/api/v1`);
   console.log(`  AGENTX_API_KEY=${defaultProject?.apiKey}`);
-  if (isDev && !webIndexHtml) {
-    console.log(`Dev mode: web UI not found (expected web/index.html next to this checkout).`);
-    console.log(`Fetch it manually with:`);
+  // Printed in both modes, not just dev: web/ isn't committed, so a source checkout started with
+  // `yarn start` (no --dev, hence no auto-download) serves the API fine and 404s every non-API
+  // GET. Without this the only symptom is a bare "Cannot GET /" in the browser and nothing at all
+  // in the log to explain it.
+  if (!webIndexHtml) {
+    console.log(`Web UI not found (expected web/index.html next to this checkout) - serving the API only.`);
+    console.log(isDev ? `Fetch it manually with:` : `Start with \`yarn dev --dev\` to fetch it automatically, or fetch it manually with:`);
     console.log(
       `  mkdir -p web && curl -fsSL https://github.com/AgentX-ai/AgentX-Trace-Eval/releases/latest/download/agentx-web.tar.gz | tar -xz -C web`
     );

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -278,12 +278,40 @@ type SqliteHandle = {
 // zero setup. Replace with real drizzle-kit migrations (`db:generate` script already wired in
 // package.json) once the schema stabilizes, see plan task #107. `exec()`/`prepare()` have the same
 // signature on both better-sqlite3's and bun:sqlite's Database, so this one function serves both.
+
+// Created at the END of bootstrap, not inline with the CREATE TABLEs that own them. All three key
+// on project_id, and on a pre-existing (pre-multi-project) install those tables already exist, so
+// CREATE TABLE IF NOT EXISTS no-ops and project_id only arrives via the ALTER TABLEs further down.
+// Creating these indexes any earlier fails the entire boot with "no such column: project_id" - a
+// fresh install never noticed, because there the CREATE TABLE really does run first.
+const PROJECT_SCOPED_UNIQUE_INDEXES = [
+  `CREATE UNIQUE INDEX IF NOT EXISTS monitor_profiles_agent_id ON monitor_profiles (project_id, agent_id)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS monitor_signals_pattern_key_agent_id ON monitor_signals (project_id, pattern_key, agent_id)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS prompt_versions_prompt_id_version ON prompt_versions (project_id, prompt_id, version)`,
+];
+
+// Same posture as ensureVersionUnique below: an install that somehow already collected duplicate
+// rows keeps booting (degraded, without the constraint) rather than being bricked at startup.
+function ensureProjectScopedUniqueIndexes(exec: (statement: string) => void): void {
+  for (const statement of PROJECT_SCOPED_UNIQUE_INDEXES) {
+    try {
+      exec(statement);
+    } catch (err) {
+      console.warn(
+        `Could not create the unique index from \`${statement}\`: ${err instanceof Error ? err.message : String(err)}\n` +
+          `  This usually means duplicate rows already exist for that key.`
+      );
+    }
+  }
+}
+
 function bootstrapSqlite(sqlite: SqliteHandle): void {
   // CREATE UNIQUE INDEX IF NOT EXISTS only checks the index *name* - on a pre-existing install
   // that already created these 3 with their old (pre-multi-project) column sets, the IF NOT
-  // EXISTS below would otherwise silently no-op and leave the old, narrower uniqueness constraint
-  // in place. Dropping first makes the recreation below actually pick up project_id. Cheap/no-op
-  // safe to run every boot (small dev-scale indexes).
+  // EXISTS in ensureProjectScopedUniqueIndexes (run at the end of this function) would otherwise
+  // silently no-op and leave the old, narrower uniqueness constraint in place. Dropping first
+  // makes that recreation actually pick up project_id. Cheap/no-op safe to run every boot (small
+  // dev-scale indexes).
   sqlite.exec(`
     DROP INDEX IF EXISTS monitor_profiles_agent_id;
     DROP INDEX IF EXISTS monitor_signals_pattern_key_agent_id;
@@ -481,8 +509,6 @@ function bootstrapSqlite(sqlite: SqliteHandle): void {
       project_id TEXT
     );
 
-    CREATE UNIQUE INDEX IF NOT EXISTS monitor_profiles_agent_id ON monitor_profiles (project_id, agent_id);
-
     CREATE TABLE IF NOT EXISTS monitor_signals (
       id TEXT PRIMARY KEY,
       pattern_key TEXT NOT NULL,
@@ -502,9 +528,6 @@ function bootstrapSqlite(sqlite: SqliteHandle): void {
       last_seen_at INTEGER NOT NULL,
       project_id TEXT
     );
-
-    CREATE UNIQUE INDEX IF NOT EXISTS monitor_signals_pattern_key_agent_id
-      ON monitor_signals (project_id, pattern_key, agent_id);
 
     CREATE TABLE IF NOT EXISTS monitor_signal_feedback (
       id TEXT PRIMARY KEY,
@@ -705,9 +728,6 @@ function bootstrapSqlite(sqlite: SqliteHandle): void {
       created_at INTEGER NOT NULL,
       project_id TEXT
     );
-
-    CREATE UNIQUE INDEX IF NOT EXISTS prompt_versions_prompt_id_version
-      ON prompt_versions (project_id, prompt_id, version);
 
     CREATE TABLE IF NOT EXISTS portability_models (
       id TEXT PRIMARY KEY,
@@ -971,6 +991,8 @@ function bootstrapSqlite(sqlite: SqliteHandle): void {
     );
     UPDATE monitor_profiles SET topics_enabled = 0 WHERE topics_enabled = 1;
   `);
+
+  ensureProjectScopedUniqueIndexes(statement => sqlite.exec(statement));
 }
 
 // prompt_versions has had this index since it shipped; tool_schema_versions never got the
@@ -1431,8 +1453,6 @@ async function bootstrapPostgres(pool: Pool): Promise<void> {
       project_id TEXT
     );
 
-    CREATE UNIQUE INDEX IF NOT EXISTS monitor_profiles_agent_id ON monitor_profiles (project_id, agent_id);
-
     CREATE TABLE IF NOT EXISTS monitor_signals (
       id TEXT PRIMARY KEY,
       pattern_key TEXT NOT NULL,
@@ -1452,9 +1472,6 @@ async function bootstrapPostgres(pool: Pool): Promise<void> {
       last_seen_at TIMESTAMP NOT NULL,
       project_id TEXT
     );
-
-    CREATE UNIQUE INDEX IF NOT EXISTS monitor_signals_pattern_key_agent_id
-      ON monitor_signals (project_id, pattern_key, agent_id);
 
     CREATE TABLE IF NOT EXISTS monitor_signal_feedback (
       id TEXT PRIMARY KEY,
@@ -1653,9 +1670,6 @@ async function bootstrapPostgres(pool: Pool): Promise<void> {
       created_at TIMESTAMP NOT NULL,
       project_id TEXT
     );
-
-    CREATE UNIQUE INDEX IF NOT EXISTS prompt_versions_prompt_id_version
-      ON prompt_versions (project_id, prompt_id, version);
 
     CREATE TABLE IF NOT EXISTS portability_models (
       id TEXT PRIMARY KEY,
@@ -1881,6 +1895,17 @@ async function bootstrapPostgres(pool: Pool): Promise<void> {
   await migrateOnlineEvaluatorsToConfigsPostgres(pool);
   await backfillAgentsPostgres(pool);
   await backfillDefaultProjectPostgres(pool);
+
+  for (const statement of PROJECT_SCOPED_UNIQUE_INDEXES) {
+    try {
+      await pool.query(statement);
+    } catch (err) {
+      console.warn(
+        `Could not create the unique index from \`${statement}\`: ${err instanceof Error ? err.message : String(err)}\n` +
+          `  This usually means duplicate rows already exist for that key.`
+      );
+    }
+  }
 }
 
 // Postgres mirror of migrateOnlineEvaluatorsToConfigsSqlite above - see that function's comment

--- a/engine/src/test/restart.integration.test.ts
+++ b/engine/src/test/restart.integration.test.ts
@@ -10,14 +10,17 @@ import { startEngine, type TestEngine } from "./server.js";
 // of those differently is how a working install breaks on upgrade.
 
 let home: string | undefined;
+let legacyHome: string | undefined;
 const engines: TestEngine[] = [];
 
 afterAll(async () => {
   for (const engine of engines) {
     await engine.stop({ keepHome: true });
   }
-  if (home) {
-    fs.rmSync(home, { recursive: true, force: true });
+  for (const dir of [home, legacyHome]) {
+    if (dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   }
 });
 
@@ -108,4 +111,52 @@ describe("restarting against an existing database", () => {
     expect((await third.json("/api/v1/ingest/traces")).status).toBe(200);
     expect(third.log()).not.toContain("Unhandled promise rejection");
   }, 120_000);
+
+  // Multi-project shipped project_id on these three tables by adding it to their CREATE TABLE
+  // statements *and* to columnMigrations. On an install predating it the CREATE TABLE is a no-op,
+  // so only the ALTER puts the column there - and the ALTERs run after the whole CREATE TABLE
+  // block. Building the indexes inline therefore killed the boot outright with "no such column:
+  // project_id" on every upgraded database, while every fresh one was fine.
+  it("boots against a database whose tables predate project_id", async () => {
+    const first = await startEngine();
+    legacyHome = first.home;
+    await first.signal("SIGTERM");
+    expect(await first.waitForExit()).toBe(0);
+
+    // Rewind those three tables to their pre-multi-project shape: no project_id, and the narrower
+    // unique indexes that shipped alongside it.
+    const db = new Database(path.join(legacyHome, "agentx.db"));
+    db.exec(`
+      DROP INDEX IF EXISTS monitor_profiles_agent_id;
+      DROP INDEX IF EXISTS monitor_signals_pattern_key_agent_id;
+      DROP INDEX IF EXISTS prompt_versions_prompt_id_version;
+      ALTER TABLE monitor_profiles DROP COLUMN project_id;
+      ALTER TABLE monitor_signals DROP COLUMN project_id;
+      ALTER TABLE prompt_versions DROP COLUMN project_id;
+      CREATE UNIQUE INDEX monitor_profiles_agent_id ON monitor_profiles (agent_id);
+      CREATE UNIQUE INDEX monitor_signals_pattern_key_agent_id ON monitor_signals (pattern_key, agent_id);
+      CREATE UNIQUE INDEX prompt_versions_prompt_id_version ON prompt_versions (prompt_id, version);
+    `);
+    db.close();
+
+    const upgraded = await startEngine({}, { home: legacyHome });
+    engines.push(upgraded);
+    expect(upgraded.alive(), `engine died on the upgrade path:\n${upgraded.log().slice(-3000)}`).toBe(true);
+    expect(upgraded.log()).not.toContain("no such column: project_id");
+    expect((await upgraded.json("/api/v1/ingest/traces")).status).toBe(200);
+
+    // And the narrow indexes were actually widened, not left in place by a name-only IF NOT EXISTS.
+    const check = new Database(path.join(legacyHome, "agentx.db"), { readonly: true });
+    const widened = [
+      ["monitor_profiles_agent_id", 2],
+      ["monitor_signals_pattern_key_agent_id", 3],
+      ["prompt_versions_prompt_id_version", 3],
+    ] as const;
+    for (const [index, columnCount] of widened) {
+      const columns = check.prepare(`SELECT name FROM pragma_index_info(?)`).all(index) as { name: string }[];
+      expect(columns.map(c => c.name), index).toContain("project_id");
+      expect(columns.length, index).toBe(columnCount);
+    }
+    check.close();
+  }, 180_000);
 });


### PR DESCRIPTION
## Problem

Any self-host install whose database predates multi-project support fails to boot:

```
agentx engine failed to start: SqliteError: no such column: project_id
    at bootstrapSqlite (engine/dist/storage/db.js:236:12)
    at initDb (engine/dist/storage/db.js:80:9)
```

`bootstrapSqlite` (and its Postgres mirror) created three `project_id`-keyed unique indexes inline with the `CREATE TABLE` blocks that own them:

- `monitor_profiles_agent_id` on `(project_id, agent_id)`
- `monitor_signals_pattern_key_agent_id` on `(project_id, pattern_key, agent_id)`
- `prompt_versions_prompt_id_version` on `(project_id, prompt_id, version)`

On a pre-existing database those tables already exist, so `CREATE TABLE IF NOT EXISTS` no-ops and `project_id` only arrives via the `ALTER TABLE`s in `columnMigrations`, ~400 lines further down. The indexes were therefore built against a column that did not exist yet.

A fresh clone never hit this, because there the `CREATE TABLE` genuinely runs first — which is why it got past CI and only shows up on upgrade.

## Fix

Moved all three statements into `PROJECT_SCOPED_UNIQUE_INDEXES` / `ensureProjectScopedUniqueIndexes`, run at the end of bootstrap after `columnMigrations` and `backfillDefaultProject*`. Failures warn and let the engine keep booting rather than bricking it — the same posture the file already uses for `ensureVersionUnique` / `ensureTraceSpanIdUnique`. The existing `DROP INDEX IF EXISTS` at the top of bootstrap is unchanged, so the narrow pre-multi-project indexes still get widened rather than silently surviving a name-only `IF NOT EXISTS`.

Postgres had the identical ordering bug and gets the identical fix.

## Also here

Ungates the "web UI not found" startup line, which was `isDev`-only. `web/` isn't committed, so a source checkout started with `yarn start` (no `--dev`, hence no auto-download) serves the API fine and 404s every non-API GET — the only symptom being a bare `Cannot GET /` in the browser and nothing at all in the log to explain it.

## Test plan

- New regression test in `engine/src/test/restart.integration.test.ts` boots an engine, rewinds those three tables to their pre-multi-project shape (drop `project_id`, restore the narrower unique indexes), and restarts. It asserts the engine survives, and that the three indexes came back carrying `project_id` at the right width.
- Verified the test reproduces the reported failure: on `main` it fails with the same `SQLITE_ERROR` / `no such column: project_id` at `bootstrapSqlite`.
- Verified against a real Aug-4 database: boots, backfills every row to the `Default` project, and creates all three widened indexes. Second boot is a clean no-op.
- Full engine suite: 434 passed, 37 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)