### PR TITLE
Serve whole-run analysis on the SDK's routes, not only the dashboard's

### DIFF
--- a/engine/src/routes/evaluations.ts
+++ b/engine/src/routes/evaluations.ts
@@ -15,17 +15,20 @@ import {
   MAX_BATCH_SIZE,
 } from "../core/evaluate/runs.js";
 import { createPrompt, getPromptForSdk, listPromptsForSdk } from "../core/evaluate/prompts.js";
+import { runEvaluationAnalysis, getEvaluationAnalysisStatus, getEvaluationAnalysisRow } from "../core/evaluate/analysis.js";
 import { handleCasePreview, handleSuggestExpected, handleAddCase } from "./curationHandlers.js";
 
 // Mounted at /api/v1/custom-agent-evaluations, matching AgentX-Python's
 // EvaluationsClient._DEFAULT_BASE_URL (agentx/evaluations/client.py) so pointing the SDK at a
 // self-host instance via AGENTX_API_BASE_URL works unmodified.
 //
-// Scope for this pass (plan task #109): dataset/evaluation-settings CRUD, and the synchronous
-// per-result judge-scoring loop (init_run -> append_results -> finalize_run -> get_run). The
-// hosted SaaS's async whole-run LLM analysis (analyze_run/get_analysis_status/get_report),
-// list_models, and get_missing_results are not ported: a materially larger, separate feature
-// (durable job queue, richer report schema) left for a future pass.
+// Scope: dataset/evaluation-settings CRUD, the synchronous per-result judge-scoring loop
+// (init_run -> append_results -> finalize_run -> get_run), and whole-run analysis
+// (analyze_run/get_analysis_status/get_report), which delegates to the same core/evaluate/
+// analysis.ts as the dashboard's /evaluate/analyze routes rather than reimplementing it.
+// Synchronous here where hosted AgentX queues a durable job; see the analyze route below.
+//
+// Still not ported: list_models and get_missing_results.
 export const evaluationsRouter = asyncRouter();
 
 evaluationsRouter.post("/datasets", async (req: Request, res: Response) => {
@@ -167,6 +170,67 @@ evaluationsRouter.post("/runs/:runId/finalize", async (req: Request, res: Respon
 
 evaluationsRouter.get("/runs", async (req: Request, res: Response) => {
   res.status(200).json({ runs: await listRuns(scopedDb(req)) });
+});
+
+// Whole-run LLM analysis, on the paths AgentX-Python calls: analyze_run, get_analysis_status
+// and get_report (agentx/evaluations/client.py). These delegate to the same core/evaluate/
+// analysis.ts the dashboard's /evaluate/analyze/:id routes use - the two surfaces share one
+// implementation and one stored row, so an analysis started from the SDK is the same object the
+// Evaluate tab renders, and vice versa.
+//
+// Hosted AgentX runs this as a durable queued job: analyze returns {status: "pending"} and the
+// caller polls analyze-status. Here it is synchronous, so analyze returns only once the judges
+// are done and the first poll already reads a terminal status. The SDK's poll loop handles that
+// correctly - it checks is_terminal before sleeping - so the same client code works against
+// both. The response carries mode:"sync" to say which one answered.
+evaluationsRouter.post("/runs/:runId/analyze", async (req: Request, res: Response) => {
+  const { judges, qualityMode } = req.body ?? {};
+  const result = await runEvaluationAnalysis(scopedDb(req), req.params.runId!, {
+    judges: Array.isArray(judges)
+      ? judges.filter((j: unknown): j is { model: string } => !!j && typeof (j as { model?: unknown }).model === "string")
+      : undefined,
+    qualityMode: qualityMode === "quality_first" ? "quality_first" : "balanced",
+  });
+  if (!result) {
+    res.status(404).json({ error: "Run not found" });
+    return;
+  }
+  res.status(200).json({
+    evaluationId: result.evaluationId,
+    jobId: result.evaluationId,
+    status: result.status,
+    mode: "sync",
+    qualityMode: qualityMode === "quality_first" ? "quality_first" : "balanced",
+  });
+});
+
+evaluationsRouter.get("/runs/:runId/analyze-status", async (req: Request, res: Response) => {
+  res.status(200).json(await getEvaluationAnalysisStatus(scopedDb(req), req.params.runId!));
+});
+
+// The SDK's Report: the analysis body hoisted to the top level, alongside the run's identifiers
+// and the statistics computed when the analysis ran. 404 rather than an empty report when
+// nothing has analyzed this run - an empty report is indistinguishable from a run that scored
+// nothing, and the SDK surfaces the distinction to the caller.
+evaluationsRouter.get("/runs/:runId/report", async (req: Request, res: Response) => {
+  const db = scopedDb(req);
+  const runId = req.params.runId!;
+  const [run, row] = await Promise.all([getRun(db, runId), getEvaluationAnalysisRow(db, runId)]);
+  if (!run) {
+    res.status(404).json({ error: "Run not found" });
+    return;
+  }
+  if (!row) {
+    res.status(404).json({ error: "No analysis found for this run. POST /runs/:runId/analyze first." });
+    return;
+  }
+  res.status(200).json({
+    ...(row.analysis ?? {}),
+    runId,
+    datasetId: run.datasetId,
+    status: row.status,
+    statistics: row.statistics ?? null,
+  });
 });
 
 evaluationsRouter.get("/runs/:runId", async (req: Request, res: Response) => {

--- a/engine/src/test/evaluate.integration.test.ts
+++ b/engine/src/test/evaluate.integration.test.ts
@@ -193,6 +193,49 @@ describe("evaluation run loop", () => {
     const runs = await engine.json("/api/v1/custom-agent-evaluations/runs");
     expect(JSON.stringify(runs.body)).toContain(runId);
   });
+
+  // The SDK calls analyze_run / get_analysis_status / get_report on the
+  // custom-agent-evaluations router. These lived only on /evaluate for a while, so the SDK's
+  // calls 404'd - and because the SDK swallows analyze failures and falls back to an empty
+  // report, the symptom was a run that looked like it had scored nothing rather than an error.
+  // These assertions exist to keep the three paths mounted; the judging itself is covered
+  // elsewhere and needs an API key this engine deliberately does not have.
+  describe("the SDK's analysis endpoints", () => {
+    it("serves analyze-status before anything has analyzed the run", async () => {
+      const status = await engine.json(`/api/v1/custom-agent-evaluations/runs/${runId}/analyze-status`);
+      expect(status.status, JSON.stringify(status.body)).toBe(200);
+      expect(status.body).toMatchObject({ evaluationId: runId, status: "not_started" });
+      // The SDK polls until is_terminal and reads progress.overallPercentage on the way.
+      expect(status.body).toHaveProperty("progress.overallPercentage");
+    });
+
+    it("404s the report with a reason, not the router's generic miss", async () => {
+      const report = await engine.json(`/api/v1/custom-agent-evaluations/runs/${runId}/report`);
+      expect(report.status).toBe(404);
+      // "Not found" is what an unmounted path returns. Distinguishing the two is the point:
+      // one means "analyze first", the other means the route regressed.
+      expect((report.body as { error?: string }).error).toMatch(/analyze/i);
+    });
+
+    it("404s analysis calls for a run that does not exist", async () => {
+      const analyze = await engine.json(
+        "/api/v1/custom-agent-evaluations/runs/no-such-run/analyze",
+        post({ judges: [{ model: "gpt-5.5" }] })
+      );
+      expect(analyze.status).toBe(404);
+      expect((analyze.body as { error?: string }).error).toMatch(/run not found/i);
+
+      expect((await engine.json("/api/v1/custom-agent-evaluations/runs/no-such-run/report")).status).toBe(404);
+    });
+
+    it("reports the same analysis state as the dashboard router", async () => {
+      // One implementation behind two routers: an analysis started from the SDK has to be the
+      // row the Evaluate tab renders, or the two surfaces drift.
+      const viaSdk = await engine.json(`/api/v1/custom-agent-evaluations/runs/${runId}/analyze-status`);
+      const viaDashboard = await engine.json(`/api/v1/evaluate/analyze/${runId}/status`);
+      expect(viaSdk.body).toEqual(viaDashboard.body);
+    });
+  });
 });
 
 describe("curating production traffic into a dataset", () => {


### PR DESCRIPTION
## The problem

AgentX-Python calls `analyze_run`, `get_analysis_status` and `get_report` on the
`/custom-agent-evaluations` router. We served none of them — whole-run analysis lived only on
the dashboard router at `/evaluate/analyze/:id` — so every SDK analysis call 404'd.

| Route the SDK calls | Before |
|---|---|
| `POST /custom-agent-evaluations/runs/:runId/analyze` | 404 |
| `GET /custom-agent-evaluations/runs/:runId/analyze-status` | 404 |
| `GET /custom-agent-evaluations/runs/:runId/report` | 404 |

**It failed badly rather than loudly.** The SDK catches the 404, catches the follow-up
`get_report()` failure, and prints an empty report with no statistics and no recommendations
— which reads exactly like an evaluation that scored nothing. A real evaluation whose harness
called `.analyze()` sat with `analysis_status: not_started`, and nobody noticed until the
results were read back over HTTP.

## Why now, given the router said this was deferred

The header comment deferred it as *"a materially larger, separate feature (durable job queue,
richer report schema)"*. That was accurate when written and is not any more: `runEvaluationAnalysis`
landed on the dashboard router in the meantime. Exposing it here is delegation, not a second
implementation — the two surfaces share one implementation and one stored row, so an analysis
started from the SDK is the same object the Evaluate tab renders, and vice versa. Comment
updated to match.

## Sync vs the hosted contract

Hosted AgentX queues a durable job: `analyze` returns `{status: "pending"}` and the caller
polls. Ours is synchronous — `analyze` returns only once the judges are done, so the first
poll already reads a terminal status. The SDK's loop handles that correctly (it checks
`is_terminal` before sleeping), so the same client code works against both. The response
carries `mode: "sync"` to say which one answered.

`/report` **404s with a reason** when nothing has analyzed the run yet, rather than returning
an empty report. An empty report is indistinguishable from a run that scored nothing, which is
the exact failure this PR exists to remove.

## Testing

**438 passing, up from 434.** Typecheck clean.

4 new tests in `evaluate.integration.test.ts`, covering what actually regressed — that the
three paths are *mounted*:

- `analyze-status` answers `not_started` before anything has analyzed the run
- `/report` 404s with a message matching `/analyze/i`, distinguishing "analyze first" from the
  router's generic `Not found` (which is what an unmounted path returns — that distinction is
  the whole point)
- analysis calls 404 for a run that does not exist
- the SDK and dashboard routers report **identical** status for the same run, so the two
  surfaces cannot drift

The judging itself needs an API key the test engine deliberately does not have, and is
covered elsewhere.

## Related

SDK companion: **AgentX-ai/AgentX-Python#16** adds a 404 fallback to the dashboard route, so
already-deployed engines keep working. Both are needed — the SDK ships independently of the engine, and this PR is what
makes the fallback stop firing.
