### PR TITLE
Give each signup its own workspace unless told otherwise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -868,19 +868,39 @@ better-auth organization plugin lets a user create further organizations, so tha
 their projects across them. It now takes the signup organization (oldest membership, ownership as
 tiebreak).
 
-The boot banner stopped printing a key when auth is enabled. It printed the default project's key
-unconditionally, which is right for the zero-setup local mode and wrong the moment the instance is
-shared: `docker logs`, a pod log or a log shipper would hand anyone who can read it a working
-data-plane credential for the instance owner's project. Disabled mode is unchanged - that printed
-key is what makes the local flow work - and `test/server.ts` already documented the enabled-mode
-behaviour as "prints no key", which had simply never been true.
+The boot banner stopped printing a key at all. It printed the default project's key
+unconditionally, which is wrong the moment the instance is shared: `docker logs`, a pod log or a log
+shipper would hand anyone who can read it a working data-plane credential for the instance owner's
+project. `test/server.ts` already documented the enabled-mode behaviour as "prints no key", which
+had simply never been true.
+
+Disabled mode was left printing it at first, on the grounds that the zero-setup local flow needs it
+- but CodeQL flags the line as clear-text logging of a credential either way, and the reasoning does
+not really survive contact: a boot log is not the terminal it was written for, since it gets
+redirected to a file, scraped by an aggregator and pasted into bug reports. What makes dropping it
+cheap is that disabled mode already serves the same key to anything that can reach the port, over
+`GET /api/v1/auth/config` - that is how the dashboard loads it - so the flow stays a one-liner
+(`AGENTX_API_KEY=$(curl -s .../auth/config | jq -r .apiKey)`) instead of a copy-paste out of the
+scrollback. That endpoint is now the single source for the key everywhere it was previously scraped
+out of stdout: `test/server.ts`, `scripts/smoke-binary.sh`, `scripts/smoke-test.sh` and the README's
+SDK and OTLP snippets. `scripts/smoke-test.sh` turned out to have been broken all along - it grepped
+for a `Local API key` line the engine has never printed, so its `API_KEY` had always been empty.
+
+Two things worth recording from that switch. The harness now fetches the key with
+`connection: close`; without it the pooled keep-alive socket left against the engine delays
+`server.close()` past the point where the SIGTERM `killTree` sends to the whole process group has
+already taken the tsx wrapper down, and `restart.integration.test.ts` reads the wrapper's 143 instead
+of the engine's own clean 0. That race pre-dates this change and still loses about one full-suite run
+in three on a loaded laptop; closing the socket is only what stops it losing every time. And a disabled-mode case in `projects.integration.test.ts` now pins
+both halves at once - no key in the banner, the same key still served by `/auth/config` - since the
+banner assertion alone would pass just as well if the key stopped being reachable entirely.
 
 Verified against the real engine: a second signup gets a project list that shares neither an id nor
 a key with the first's, cannot see the first's ingested trace through its own key, and is refused
 (403) on both instance-wide write surfaces while the owner is allowed and the catalog row is checked
 afterwards to confirm nothing moved. A separate engine boots with `AGENTX_TENANCY=shared` and pins
 the opposite result, since the two modes differ only in what the second signup means and that is
-exactly the branch that rots once the default stops exercising it. 444 passed on SQLite; the
+exactly the branch that rots once the default stops exercising it. 445 passed on SQLite; the
 Postgres-gated suites need `AGENTX_TEST_DB_URL` and were not run locally, so the isolated path -
 which writes more per signup than the shared one - has a Postgres case added for CI to run.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -830,3 +830,68 @@ that runs `bun build --compile` and `scripts/smoke-binary.sh` against the result
 and a read back over bun:sqlite, a malformed timestamp, a clean SIGTERM, and an assertion that dev
 mode does not write to `/`. Checked both ways: it passes on the fixed binary and fails on the
 pre-fix one with `dev mode wrote the dashboard bundle to the filesystem root`.
+
+`AGENTX_AUTH=enabled` turned out to have login without tenancy. Every signup after the first was
+inserted into the first user's organization as a member, and `GET /projects` returns each project's
+raw API key so the switcher can populate itself - so the second person to sign up on a shared
+instance received working credentials for the first person's traces, datasets, evaluations and
+prompts. Nothing was misrouted at the storage layer: every domain is properly scoped by
+`db.projectId` and always was. The leak was entirely in who is allowed to *list* projects, which is
+also where keys are handed out. The suite had the behaviour pinned as correct
+(`joins a later signup to the same organization as a member`), which is why it survived.
+
+`AGENTX_TENANCY` now decides what a second signup means, and defaults to `isolated`: its own
+organization, its own starter project, no view of anyone else's. `shared` restores the old
+single-organization team server for operators who actually want it. The first signup is unchanged in
+both modes - it becomes an owner and claims every orgless project, which is what keeps enabling auth
+on a populated instance from stranding its data. Existing rows are untouched on upgrade; only new
+signups follow the setting, so an instance relying on the old behaviour sets `AGENTX_TENANCY=shared`.
+
+The starter project matters more than it looks: an organization that owns nothing has no API key,
+and the key is the only data-plane credential, so an isolated signup without one lands on a dashboard
+it cannot use. It is seeded exactly the way `POST /projects` seeds (system evaluators, metric packs)
+rather than approximately.
+
+Isolation then exposed a second-order problem the schema comments had already flagged as
+"revisit if that turns out wrong in practice": two tables are deliberately instance-wide, and both
+are written by routes that authenticate with a *project key*, not a session. Any tenant could
+therefore rewrite the shared provider keys every other tenant's judges spend against, and - the
+sharper one - rewrite a `portability_models` row's `baseUrl`, which Model Portability replays
+captured trace input against, redirecting another tenant's prompts to an endpoint of the writer's
+choosing. Writes to both are now `instanceOwnerOnly`; reads stay open, and already masked every
+stored key. The instance owner is derived rather than stored: it is the organization that owns the
+default project, which is the one row the first signup is guaranteed to have claimed, so there is no
+second source of truth and no migration.
+
+`POST /projects` also stopped picking `orgs[0]` out of an unordered membership query - the
+better-auth organization plugin lets a user create further organizations, so that would scatter
+their projects across them. It now takes the signup organization (oldest membership, ownership as
+tiebreak).
+
+The boot banner stopped printing a key when auth is enabled. It printed the default project's key
+unconditionally, which is right for the zero-setup local mode and wrong the moment the instance is
+shared: `docker logs`, a pod log or a log shipper would hand anyone who can read it a working
+data-plane credential for the instance owner's project. Disabled mode is unchanged - that printed
+key is what makes the local flow work - and `test/server.ts` already documented the enabled-mode
+behaviour as "prints no key", which had simply never been true.
+
+Verified against the real engine: a second signup gets a project list that shares neither an id nor
+a key with the first's, cannot see the first's ingested trace through its own key, and is refused
+(403) on both instance-wide write surfaces while the owner is allowed and the catalog row is checked
+afterwards to confirm nothing moved. A separate engine boots with `AGENTX_TENANCY=shared` and pins
+the opposite result, since the two modes differ only in what the second signup means and that is
+exactly the branch that rots once the default stops exercising it. 444 passed on SQLite; the
+Postgres-gated suites need `AGENTX_TEST_DB_URL` and were not run locally, so the isolated path -
+which writes more per signup than the shared one - has a Postgres case added for CI to run.
+
+Then the same thing again through the actual dashboard, because the fix is worthless if a second
+person cannot reach a sign-up form: three engines booted (isolated, shared, disabled) and driven
+over HTTP for 34 checks, then a browser against a real instance where the owner already existed.
+The visitor gets the Sign in / Create account screen, creates an account, and lands on a working
+dashboard with its own seeded starter project (7 patterns, 1 online evaluator) and its own key in
+Platform Settings; the owner's project list does not grow; clicking Clear on the instance-wide
+OpenAI key as the non-owner leaves it configured. Two strings in the dashboard bundle are now stale
+and belong to AgentX-web-front, not here: the sign-up screen still says "New accounts join this
+instance's organization as members", and the API-key panel still says self-host "has no multi-tenant
+boundary this key protects". `GET /api/v1/auth/config` now carries `tenancy` so the first of those
+can be fixed by reading it rather than by picking a different hardcoded sentence.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ browser, and prints a local API key for the SDK. Prefer a container? See [Docker
 - [Features](#features)
 - [Docker](#docker)
 - [Configuration](#configuration)
+- [Multi-user setup](#setting-up-a-multi-user-instance)
 - [SDK & OpenTelemetry](#sdk--opentelemetry)
 - [What's in this repo](#whats-in-this-repo)
 - [Building from source](#building-from-source)
@@ -120,6 +121,7 @@ Set these in the environment before starting `agentx-server`:
 | `AGENTX_IMPROVEMENT_SWEEP` | `true` | Set to `false` to disable the background sweep that auto-generates and validates improvement proposals when failure evidence crosses a threshold (the Improvement Inbox). `POST /evaluate/improve/inbox/sweep/run` still triggers one manually. |
 | `AGENTX_SESSION_SWEEP` | `true` | Set to `false` to disable the background sweep that judges idle multi-turn sessions (session-scoped Online Evaluators). `POST /agent-monitoring/session-sweep/run` still triggers one manually. |
 | `AGENTX_AUTH` | `disabled` | Set to `enabled` to require dashboard sign-in (see "Dashboard authentication" below). The default keeps the zero-setup local posture. |
+| `AGENTX_TENANCY` | `isolated` | What a *second* signup gets when `AGENTX_AUTH=enabled`. `isolated`: its own organization and its own starter project, invisible to everyone else. `shared`: it joins the first user's organization and sees its projects (the team-server posture). Ignored when auth is disabled. |
 | `AGENTX_AUTH_SECRET` | (auto-generated) | Session-signing secret for `AGENTX_AUTH=enabled`. Generated and persisted on first enabled boot if unset; set explicitly when running multiple replicas. |
 | `AGENTX_PUBLIC_URL` | - | The externally reachable base URL when running behind a proxy/domain with auth enabled (used for auth callbacks/cookies). |
 | `AGENTX_TRUSTED_ORIGINS` | - | Comma-separated extra origins allowed to make authenticated browser requests (e.g. a dev dashboard on another port). |
@@ -136,14 +138,111 @@ one operator), and the dashboard bootstraps its API key automatically. That stay
 hosting the dashboard on the internet):
 
 - The first visit shows an owner-setup screen. The first account created becomes the owner of a
-  default organization and takes over every existing project on the instance. Later signups join
-  that organization as members.
+  default organization and takes over every existing project on the instance - so enabling auth on
+  an install that already has data hands that data to whoever runs setup, not to whoever signs up
+  second.
 - Signing in is what grants the dashboard its project list (and each project's API key); the
   unauthenticated bootstrap endpoint is disabled in this mode.
 - SDK ingest is unchanged in both modes: it authenticates with project API keys, never sessions.
   Enabling or disabling auth never breaks a deployed integration.
 - Identity is standard [better-auth](https://better-auth.com) (email/password out of the box),
   stored in the same database as everything else - works on both SQLite and Postgres.
+
+#### Setting up a multi-user instance
+
+Four things to decide, then one boot. Only the first is required.
+
+| | Why |
+| --- | --- |
+| `AGENTX_AUTH=enabled` | Required. Turns on sign-in. Without it the engine hands its API key to anyone who can reach the port. |
+| `AGENTX_TENANCY` | `isolated` (default) gives every signup its own workspace; `shared` puts everyone in one. See [below](#who-sees-what-agentx_tenancy). |
+| `AGENTX_AUTH_SECRET` | Auto-generated and persisted on first boot. Set it explicitly if you run more than one replica, or sessions issued by one are rejected by the next. Any 32+ random bytes: `openssl rand -hex 32`. |
+| `AGENTX_PUBLIC_URL` | The URL people actually type, when that is not `http://localhost:4700` - behind a proxy or a domain, auth cookies and callbacks need it. |
+
+**Docker**
+
+```bash
+docker run -d -p 4700:4700 -v agentx-data:/data \
+  -e AGENTX_AUTH=enabled \
+  -e AGENTX_AUTH_SECRET="$(openssl rand -hex 32)" \
+  -e AGENTX_PUBLIC_URL=https://agentx.example.com \
+  -e OPENAI_API_KEY=sk-... \
+  agentx-selfhost
+```
+
+**Binary**
+
+```bash
+AGENTX_AUTH=enabled AGENTX_PUBLIC_URL=https://agentx.example.com agentx-server
+```
+
+**Kubernetes** - the keys are already in [`k8s/configmap.yaml`](k8s/configmap.yaml); flip
+`AGENTX_AUTH` to `"enabled"` and move `AGENTX_AUTH_SECRET` into a Secret rather than the ConfigMap.
+
+Then, in the browser:
+
+1. **Open the dashboard and create the first account.** The first visit shows an owner-setup
+   screen rather than a login form. This account becomes the **instance owner**: it owns the
+   pre-existing `Default` project, and - under isolated tenancy - it is the only account that can
+   change the instance-wide provider keys and pricing catalog. Create it yourself, before handing
+   the URL out; whoever fills this screen in gets the instance.
+2. **Set the provider keys** under Platform Settings (or pass them as env vars above). Judge
+   scoring and semantic pattern detection need them; trace ingest and phrase/regex patterns do not.
+3. **Hand out the URL.** Everyone else signs up through the same screen, which now offers *Sign in*
+   and *Create account*. Under the default isolated tenancy each new account lands in its own
+   workspace with its own starter project, and sees nothing of anyone else's.
+4. **Each person points their SDK at their own project key**, copied from Platform Settings (or
+   the project switcher) once signed in:
+
+   ```bash
+   export AGENTX_API_BASE_URL=https://agentx.example.com/api/v1
+   export AGENTX_API_KEY=agtx_local_...   # this user's own project, not the boot-log key
+   ```
+
+   With auth enabled the boot log prints no API key at all - not even the instance owner's. Keys
+   only ever come from the dashboard, to the signed-in user they belong to. (Auth-disabled mode
+   still prints the `Default` project's key, which is what makes the zero-setup local flow work.)
+
+To verify isolation on your own instance: sign up a second throwaway account and confirm its
+project list has nothing in common with the first's.
+
+Nothing about the SDK changes between auth modes - ingest authenticates with a project API key and
+never does a login flow, so turning auth on does not break an already-deployed integration.
+
+#### Who sees what: `AGENTX_TENANCY`
+
+Everything a project owns - traces, agents, datasets, evaluations, prompts, patterns - is scoped to
+that project, and a project's API key is what selects it. So the only question that decides
+isolation is which projects a signed-in user can *list*, because the project list carries each
+project's key.
+
+**`AGENTX_TENANCY=isolated` (the default)** - every signup gets its own organization and its own
+starter project. Users cannot see, or obtain a key for, anyone else's projects. This is what to run
+for a hosted deployment, or a self-host instance several people sign up on independently.
+
+**`AGENTX_TENANCY=shared`** - every signup joins the first user's organization and shares its
+projects. Choose this deliberately for a team server whose members are meant to see the same data.
+
+Two things stay instance-wide in both modes, because one machine has one of each: the provider keys
+in Platform Settings (what judge scoring spends against) and the Model Portability pricing catalog.
+Everyone can read them - the keys only ever as a masked value - but with isolated tenancy only the
+instance owner's own projects can write them. The instance owner is the organization that claimed
+the default project on first signup.
+
+`GET /api/v1/auth/config` reports the active mode (`{ mode, needsSetup, tenancy }` when auth is
+enabled), so the sign-up screen can say truthfully what a new account gets.
+
+Roles (`owner`/`member`) exist on organization membership and govern the organization surface.
+Inside an organization they are not a permission boundary: any member of an organization can use
+any of its projects, which is the point of `shared`. Isolation between *tenants* is the
+organization, not the role.
+
+#### Upgrading an instance that already ran with auth enabled
+
+Existing users, organizations, and projects are untouched - nobody loses access to anything. Only
+signups from this version onward follow `AGENTX_TENANCY`, so an instance that was relying on the old
+"everyone lands in one organization" behaviour should set `AGENTX_TENANCY=shared` explicitly to keep
+new teammates joining the existing organization.
 
 ## SDK & OpenTelemetry
 

--- a/README.md
+++ b/README.md
@@ -196,12 +196,11 @@ Then, in the browser:
 
    ```bash
    export AGENTX_API_BASE_URL=https://agentx.example.com/api/v1
-   export AGENTX_API_KEY=agtx_local_...   # this user's own project, not the boot-log key
+   export AGENTX_API_KEY=agtx_local_...   # this user's own project
    ```
 
-   With auth enabled the boot log prints no API key at all - not even the instance owner's. Keys
-   only ever come from the dashboard, to the signed-in user they belong to. (Auth-disabled mode
-   still prints the `Default` project's key, which is what makes the zero-setup local flow work.)
+   The boot log prints no API key in either mode - not even the instance owner's. With auth
+   enabled, keys only ever come from the dashboard, to the signed-in user they belong to.
 
 To verify isolation on your own instance: sign up a second throwaway account and confirm its
 project list has nothing in common with the first's.
@@ -251,14 +250,14 @@ a self-host instance:
 
 ```bash
 export AGENTX_API_BASE_URL=http://localhost:4700/api/v1
-export AGENTX_API_KEY=<printed by agentx-server on first run>
+export AGENTX_API_KEY=$(curl -s http://localhost:4700/api/v1/auth/config | jq -r .apiKey)
 ```
 
 **OpenTelemetry** - Trace also accepts real OTLP/HTTP traces directly, no AgentX SDK required:
 
 ```bash
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4700/api/v1/otel
-export OTEL_EXPORTER_OTLP_HEADERS="x-api-key=<printed by agentx-server on first run>"
+export OTEL_EXPORTER_OTLP_HEADERS="x-api-key=$(curl -s http://localhost:4700/api/v1/auth/config | jq -r .apiKey)"
 ```
 
 Both OTLP/HTTP wire formats are supported (protobuf and `application/json`, via
@@ -384,10 +383,15 @@ Once it's up:
 
 ```
 AgentX self-host engine listening on http://localhost:4700
-Local API key: agtx_local_...
+Point the SDK here with:
+  AGENTX_API_BASE_URL=http://localhost:4700/api/v1
+  AGENTX_API_KEY=$(curl -s http://localhost:4700/api/v1/auth/config | jq -r .apiKey)
+The default project's key is not printed here - Platform Settings shows the same value.
 ```
 
-`--dev` opens the dashboard in your browser automatically.
+`--dev` opens the dashboard in your browser automatically. The key is kept out of the log because
+logs get redirected, shipped and pasted into bug reports; with auth disabled the engine still
+serves it to anything that can reach the port, so the line above is all the setup there is.
 
 ### End-to-end smoke test
 

--- a/engine/src/auth/betterAuth.ts
+++ b/engine/src/auth/betterAuth.ts
@@ -6,7 +6,10 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { organization } from "better-auth/plugins";
 import { fromNodeHeaders } from "better-auth/node";
 import type { Request } from "express";
-import type { Db } from "../storage/db.js";
+import { withProjectId, type Db } from "../storage/db.js";
+import { createProject, getDefaultProject, getProjectRow } from "../core/project/projects.js";
+import { ensureSessionBaselineJudge } from "../core/monitor/builtinEvaluators.js";
+import { ensureMetricPackConfigs } from "../core/evaluate/metricPack.js";
 
 // Dashboard identity for AGENTX_AUTH=enabled mode (cloud, or a team self-host): better-auth with
 // email/password, cookie sessions, and the organization plugin, persisted through this engine's
@@ -24,52 +27,127 @@ export function authMode(): AuthMode {
   return process.env.AGENTX_AUTH === "enabled" ? "enabled" : "disabled";
 }
 
+// What a *second* signup means on the same instance - the one decision that separates "a team
+// server" from "a place several unrelated people happen to share", and the reason the original
+// enabled-mode implementation leaked: it only ever had the team answer.
+//
+//   isolated (default): every signup gets its own organization and its own starter project.
+//     Nobody sees, or can obtain a key for, anybody else's projects - which is what both cloud
+//     and a self-host instance that strangers can sign up on need.
+//   shared: every signup joins the first user's organization as a member, sharing its projects.
+//     The small-team server posture (the previous, and now opt-in, behaviour).
+//
+// Deliberately independent of AGENTX_AUTH so the two questions stay separate: AGENTX_AUTH decides
+// whether there are users at all, AGENTX_TENANCY decides what a user owns. Meaningless (and
+// ignored) in disabled mode, which has no users to isolate.
+export type TenancyMode = "isolated" | "shared";
+
+export function tenancyMode(): TenancyMode {
+  return process.env.AGENTX_TENANCY?.trim().toLowerCase() === "shared" ? "shared" : "isolated";
+}
+
 // Typed off the concrete builder below (the generic Auth<BetterAuthOptions> and the inferred
 // instance type aren't mutually assignable in better-auth's typings).
 let authInstance: BetterAuthInstance | null = null;
 let authDb: Db | null = null;
 
-// First-user-becomes-owner (the Grafana/n8n/Portainer pattern): the first signup creates the
-// default organization, becomes its owner, and CLAIMS every orgless project - including the
-// default project an existing install migrated in with, so enabling auth on a populated instance
-// hands its data to the person who runs the setup screen, not to whoever signs up second. Later
-// signups join that same org as plain members (the single-org self-host model; cloud can layer
-// org-per-signup on top later).
-async function onUserCreated(db: Db, userId: string): Promise<void> {
-  const now = new Date();
-  const anyMember =
+type NewUser = { id: string; name?: string | null; email?: string | null };
+
+async function anyMemberRow(db: Db): Promise<{ organizationId: string } | undefined> {
+  const row =
     db.kind === "sqlite"
       ? db.db.select().from(db.schema.authMembers).limit(1).all()[0]
       : (await db.db.select().from(db.schema.authMembers).limit(1))[0];
+  return row as { organizationId: string } | undefined;
+}
 
-  if (!anyMember) {
-    const orgId = nanoid();
-    const orgRow = { id: orgId, name: "Default Organization", slug: "default", logo: null, createdAt: now, metadata: null };
-    const memberRow = { id: nanoid(), organizationId: orgId, userId, role: "owner", createdAt: now };
-    if (db.kind === "sqlite") {
-      await db.db.insert(db.schema.authOrganizations).values(orgRow);
-      await db.db.insert(db.schema.authMembers).values(memberRow);
-      await db.db
-        .update(db.schema.projects)
-        .set({ organizationId: orgId })
-        .where(isNull(db.schema.projects.organizationId));
-    } else {
-      await db.db.insert(db.schema.authOrganizations).values(orgRow);
-      await db.db.insert(db.schema.authMembers).values(memberRow);
-      await db.db
-        .update(db.schema.projects)
-        .set({ organizationId: orgId })
-        .where(isNull(db.schema.projects.organizationId));
-    }
-    return;
+async function insertOrganization(db: Db, org: { id: string; name: string; slug: string }, now: Date): Promise<void> {
+  const orgRow = { id: org.id, name: org.name, slug: org.slug, logo: null, createdAt: now, metadata: null };
+  if (db.kind === "sqlite") {
+    await db.db.insert(db.schema.authOrganizations).values(orgRow);
+  } else {
+    await db.db.insert(db.schema.authOrganizations).values(orgRow);
   }
+}
 
-  const memberRow = { id: nanoid(), organizationId: anyMember.organizationId as string, userId, role: "member", createdAt: now };
+async function insertMember(db: Db, organizationId: string, userId: string, role: string, now: Date): Promise<void> {
+  const memberRow = { id: nanoid(), organizationId, userId, role, createdAt: now };
   if (db.kind === "sqlite") {
     await db.db.insert(db.schema.authMembers).values(memberRow);
   } else {
     await db.db.insert(db.schema.authMembers).values(memberRow);
   }
+}
+
+// Everything on the instance that no organization owns yet, handed to the first signup - see
+// onUserCreated's comment for why that is the first user rather than nobody.
+async function claimOrphanProjects(db: Db, organizationId: string): Promise<void> {
+  if (db.kind === "sqlite") {
+    await db.db
+      .update(db.schema.projects)
+      .set({ organizationId })
+      .where(isNull(db.schema.projects.organizationId));
+  } else {
+    await db.db
+      .update(db.schema.projects)
+      .set({ organizationId })
+      .where(isNull(db.schema.projects.organizationId));
+  }
+}
+
+// A brand-new organization owns nothing, and a project is the only thing that carries an API key -
+// so without this an isolated-tenancy signup lands on an empty dashboard with no credential and no
+// obvious next step. Seeded exactly like POST /projects does (system evaluators + metric packs),
+// because a project that skipped those behaves subtly differently from every other one.
+async function createStarterProject(db: Db, organizationId: string): Promise<void> {
+  const project = await createProject(db, "Default", organizationId);
+  await ensureSessionBaselineJudge(withProjectId(db, project._id));
+  await ensureMetricPackConfigs(withProjectId(db, project._id));
+}
+
+function organizationNameFor(user: NewUser): string {
+  const label = user.name?.trim() || user.email?.trim().split("@")[0] || "";
+  return label ? `${label}'s Organization` : "Organization";
+}
+
+// Who owns what, at the one moment it is decided. Two rules, in this order:
+//
+// 1. The FIRST signup always becomes an owner and CLAIMS every orgless project - including the
+//    default project an existing install migrated in with. That is what makes enabling auth on a
+//    populated instance hand its data to the person who runs the setup screen rather than
+//    stranding it (or handing it to whoever signs up second). True in both tenancy modes.
+// 2. Every LATER signup depends on tenancyMode():
+//    - isolated (default): its own organization, as owner, with its own starter project. It can
+//      never see or obtain a key for anything the first user owns.
+//    - shared: joins the first user's organization as a member, and sees its projects. The old
+//      behaviour, now something an operator opts into rather than the only option.
+//
+// Note that rule 1 is deliberately not "the first user owns the instance forever": it only decides
+// the pre-existing rows. In isolated mode the first user's org keeps exactly one extra power over
+// later ones - it owns the default project, which is what marks it as the instance operator for
+// instance-wide settings (see instanceOwnerOrganizationId below).
+async function onUserCreated(db: Db, user: NewUser): Promise<void> {
+  const now = new Date();
+  const existingMember = await anyMemberRow(db);
+
+  if (!existingMember) {
+    const orgId = nanoid();
+    await insertOrganization(db, { id: orgId, name: "Default Organization", slug: "default" }, now);
+    await insertMember(db, orgId, user.id, "owner", now);
+    await claimOrphanProjects(db, orgId);
+    return;
+  }
+
+  if (tenancyMode() === "shared") {
+    await insertMember(db, existingMember.organizationId, user.id, "member", now);
+    return;
+  }
+
+  const orgId = nanoid();
+  // Slug is UNIQUE across the table, so it cannot be derived from a name two people can both pick.
+  await insertOrganization(db, { id: orgId, name: organizationNameFor(user), slug: `org-${orgId}` }, now);
+  await insertMember(db, orgId, user.id, "owner", now);
+  await createStarterProject(db, orgId);
 }
 
 type InitAuthOpts = { secret: string; baseURL?: string; trustedOrigins?: string[] };
@@ -109,7 +187,7 @@ function buildAuth(db: Db, opts: InitAuthOpts) {
       user: {
         create: {
           after: async user => {
-            await onUserCreated(db, user.id);
+            await onUserCreated(db, user);
           },
         },
       },
@@ -161,6 +239,52 @@ export async function getUserOrganizationIds(userId: string): Promise<string[]> 
       ? db.db.select().from(db.schema.authMembers).where(cond).all()
       : await db.db.select().from(db.schema.authMembers).where(cond);
   return (rows as { organizationId: string }[]).map(r => r.organizationId);
+}
+
+// Which organization a signed-in user's NEW projects belong to. Deterministic on purpose: the
+// better-auth organization plugin lets a user create further organizations of their own, so
+// "whichever membership row the database happened to return first" would quietly scatter their
+// projects across them. The signup organization wins - the oldest membership, which is the one
+// onUserCreated made - with ownership as the tiebreak.
+export async function getPrimaryOrganizationId(userId: string): Promise<string | null> {
+  const db = authDb;
+  if (!db) return null;
+  const cond = eq(db.schema.authMembers.userId, userId);
+  const rows =
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.authMembers).where(cond).all()
+      : await db.db.select().from(db.schema.authMembers).where(cond);
+  const memberships = (rows as { organizationId: string; role: string; createdAt: Date }[]).slice().sort((a, b) => {
+    const byAge = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    if (byAge !== 0) return byAge;
+    return Number(b.role === "owner") - Number(a.role === "owner");
+  });
+  return memberships[0]?.organizationId ?? null;
+}
+
+// The organization that owns the instance's default project - i.e. whoever ran the setup screen
+// first. Deliberately derived rather than stored on a new column: the default project is already
+// the one row the first signup is guaranteed to claim (claimOrphanProjects above), so there is no
+// second source of truth to keep in sync and an install that predates this code needs no migration
+// to acquire one.
+export async function instanceOwnerOrganizationId(db: Db): Promise<string | null> {
+  const project = await getDefaultProject(db);
+  return project?.organizationId ?? null;
+}
+
+// Instance-wide settings (app_settings' provider keys) are a single row every tenant on the box
+// shares, and the route that writes them authenticates with a PROJECT key rather than a session -
+// so with isolated tenancy any signup could otherwise swap the credential every other tenant's
+// judges spend money on. Writes are therefore limited to the instance operator's own projects;
+// everyone else keeps the masked read. Always allowed when auth is off (single tenant by
+// definition), in shared tenancy (one org owns every project anyway), and before the first signup
+// has claimed anything - there is nothing to protect yet.
+export async function canWriteInstanceSettings(db: Db, projectId: string): Promise<boolean> {
+  if (authMode() !== "enabled") return true;
+  const ownerOrganizationId = await instanceOwnerOrganizationId(db);
+  if (!ownerOrganizationId) return true;
+  const project = await getProjectRow(db, projectId);
+  return project?.organizationId === ownerOrganizationId;
 }
 
 // True while no user exists yet - drives the frontend's owner-setup screen vs login screen.

--- a/engine/src/core/project/projects.ts
+++ b/engine/src/core/project/projects.ts
@@ -128,7 +128,7 @@ export async function resolveProjectByApiKey(db: Db, apiKey: string): Promise<Pr
   return row ?? null;
 }
 
-// The startup log's "Default project API key" source - whichever project the one-time migration
+// What GET /api/v1/auth/config serves the dashboard and the SDK in auth-disabled mode - whichever project the one-time migration
 // created first (storage/db.ts's backfillDefaultProjectSqlite/Postgres). That printed key is what
 // the operator copies into the dashboard's connect screen and the SDK; there is no endpoint that
 // hands it out anymore.

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -176,10 +176,10 @@ async function main() {
     console.log(`Each user copies their own project's API key from the dashboard; none is printed here.`);
   } else {
     const defaultProject = await getDefaultProject(getDb());
-    console.log(`Default project API key: ${defaultProject?.apiKey}`);
+    console.log(`Default project is ready${defaultProject ? "" : " (not found yet)"}. API keys are not printed to logs.`);
     console.log(`Point the SDK here with:`);
     console.log(`  AGENTX_API_BASE_URL=http://localhost:${PORT}/api/v1`);
-    console.log(`  AGENTX_API_KEY=${defaultProject?.apiKey}`);
+    console.log(`Retrieve the API key from the dashboard instead of logs.`);
   }
   // Printed in both modes, not just dev: web/ isn't committed, so a source checkout started with
   // `yarn start` (no --dev, hence no auto-download) serves the API fine and 404s every non-API

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -166,12 +166,21 @@ async function main() {
   // unref'd interval, so it never blocks shutdown. AGENTX_SESSION_SWEEP=false disables.
   startSessionSweep();
   startImprovementSweep();
-  const defaultProject = await getDefaultProject(getDb());
   console.log(`AgentX self-host engine listening on http://localhost:${PORT}`);
-  console.log(`Default project API key: ${defaultProject?.apiKey}`);
-  console.log(`Point the SDK here with:`);
-  console.log(`  AGENTX_API_BASE_URL=http://localhost:${PORT}/api/v1`);
-  console.log(`  AGENTX_API_KEY=${defaultProject?.apiKey}`);
+  if (authMode() === "enabled") {
+    // No key in the banner in this mode. Everyone signs in and copies their OWN project's key from
+    // the dashboard, and on a shared instance the log is not a private channel - anyone with
+    // `docker logs`, a kubectl pod log, or a log aggregator would otherwise be holding a working
+    // data-plane credential for the instance owner's project.
+    console.log(`Dashboard sign-in is required (AGENTX_AUTH=enabled) - open the dashboard to create the first account.`);
+    console.log(`Each user copies their own project's API key from the dashboard; none is printed here.`);
+  } else {
+    const defaultProject = await getDefaultProject(getDb());
+    console.log(`Default project API key: ${defaultProject?.apiKey}`);
+    console.log(`Point the SDK here with:`);
+    console.log(`  AGENTX_API_BASE_URL=http://localhost:${PORT}/api/v1`);
+    console.log(`  AGENTX_API_KEY=${defaultProject?.apiKey}`);
+  }
   // Printed in both modes, not just dev: web/ isn't committed, so a source checkout started with
   // `yarn start` (no --dev, hence no auto-download) serves the API fine and 404s every non-API
   // GET. Without this the only symptom is a bare "Cannot GET /" in the browser and nothing at all

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -5,7 +5,7 @@ import { requireApiKey } from "./auth/apiKey.js";
 import { asyncHandler } from "./routes/asyncRouter.js";
 import { rateLimit, CREDENTIAL_LIMIT, DATA_PLANE_LIMIT } from "./auth/rateLimit.js";
 import { initDb, closeDb, getDb, withProjectId } from "./storage/db.js";
-import { getDefaultProject, listProjectRows } from "./core/project/projects.js";
+import { listProjectRows } from "./core/project/projects.js";
 import { ensureSessionBaselineJudge } from "./core/monitor/builtinEvaluators.js";
 import { ensureMetricPackConfigs, metricPackBackfillDone, markMetricPackBackfillDone } from "./core/evaluate/metricPack.js";
 import { authMode, initAuth, resolveAuthSecret } from "./auth/betterAuth.js";
@@ -175,11 +175,15 @@ async function main() {
     console.log(`Dashboard sign-in is required (AGENTX_AUTH=enabled) - open the dashboard to create the first account.`);
     console.log(`Each user copies their own project's API key from the dashboard; none is printed here.`);
   } else {
-    const defaultProject = await getDefaultProject(getDb());
-    console.log(`Default project is ready${defaultProject ? "" : " (not found yet)"}. API keys are not printed to logs.`);
+    // No key here either, even though this mode is single-tenant by definition. A boot log is not
+    // the terminal it was written for: it gets redirected to a file, scraped by an aggregator and
+    // pasted into bug reports. Disabled mode still hands the key to any caller that can reach this
+    // port - GET /api/v1/auth/config, the same endpoint the dashboard loads it from - so the
+    // zero-setup flow survives as a one-liner rather than a copy-paste out of the scrollback.
     console.log(`Point the SDK here with:`);
     console.log(`  AGENTX_API_BASE_URL=http://localhost:${PORT}/api/v1`);
-    console.log(`Retrieve the API key from the dashboard instead of logs.`);
+    console.log(`  AGENTX_API_KEY=$(curl -s http://localhost:${PORT}/api/v1/auth/config | jq -r .apiKey)`);
+    console.log(`The default project's key is not printed here - Platform Settings shows the same value.`);
   }
   // Printed in both modes, not just dev: web/ isn't committed, so a source checkout started with
   // `yarn start` (no --dev, hence no auto-download) serves the API fine and 404s every non-API

--- a/engine/src/routes/agentMonitoringDashboard.ts
+++ b/engine/src/routes/agentMonitoringDashboard.ts
@@ -1,4 +1,4 @@
-import type { Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 import { asyncRouter } from "./asyncRouter.js";
 import { getDb, type Db } from "../storage/db.js";
 import { scopedDb } from "../auth/apiKey.js";
@@ -69,6 +69,7 @@ import {
   testCustomModelConnection,
 } from "../core/evaluate/models.js";
 import { getAppSettings, updateAppSettings } from "../core/settings/appSettings.js";
+import { canWriteInstanceSettings } from "../auth/betterAuth.js";
 import {
   getProject,
   regenerateProjectApiKey,
@@ -926,6 +927,21 @@ agentMonitoringDashboardRouter.post("/estimate", async (req: Request, res: Respo
   res.status(200).json({ action: req.body?.action, estimatedCredits: 0 });
 });
 
+// Instance-wide rows - the shared model catalog below and the shared provider keys further down -
+// sit outside any project's scope, so with AGENTX_TENANCY=isolated a valid project key alone is not
+// enough to WRITE them: see betterAuth.ts's canWriteInstanceSettings for the reasoning. The sharp
+// edge is a catalog row's baseUrl, which Model Portability replays trace input against - rewriting
+// one would redirect another tenant's captured prompts to an endpoint of the writer's choosing.
+// Reads stay open in both cases: shared reference pricing is the point, and the wire shapes already
+// mask every stored key. A no-op outside AGENTX_AUTH=enabled, and in shared tenancy.
+const instanceOwnerOnly = async (req: Request, res: Response, next: NextFunction) => {
+  if (await canWriteInstanceSettings(getDb(), req.projectId!)) {
+    next();
+    return;
+  }
+  res.status(403).json({ error: "Instance-wide settings are managed by the instance owner" });
+};
+
 // Model portability (core/evaluate/portability.ts) - an input-only replay of a captured trace
 // against alternative models, not a full agent re-run (self-host doesn't own the agent). Explicit,
 // per-trace, user-triggered only: never runs automatically, and nothing about the *comparison
@@ -945,7 +961,7 @@ agentMonitoringDashboardRouter.get("/portability/models/unpriced", async (req: R
 
 const VALID_PROVIDERS = ["openai", "anthropic", "gemini", "custom"];
 
-agentMonitoringDashboardRouter.post("/portability/models", async (req: Request, res: Response) => {
+agentMonitoringDashboardRouter.post("/portability/models", instanceOwnerOnly, async (req: Request, res: Response) => {
   const body = req.body ?? {};
   if (typeof body.id !== "string" || !body.id.trim()) {
     res.status(400).json({ error: "id is required (the exact model string sent to the provider's API)" });
@@ -987,7 +1003,7 @@ agentMonitoringDashboardRouter.post("/portability/models", async (req: Request, 
   res.status(201).json({ model });
 });
 
-agentMonitoringDashboardRouter.put("/portability/models/:id", async (req: Request, res: Response) => {
+agentMonitoringDashboardRouter.put("/portability/models/:id", instanceOwnerOnly, async (req: Request, res: Response) => {
   const body = req.body ?? {};
   if (!VALID_PROVIDERS.includes(body.provider)) {
     res.status(400).json({ error: 'provider must be "openai", "anthropic", "gemini", or "custom"' });
@@ -1025,7 +1041,7 @@ agentMonitoringDashboardRouter.put("/portability/models/:id", async (req: Reques
   res.status(200).json({ model });
 });
 
-agentMonitoringDashboardRouter.delete("/portability/models/:id", async (req: Request, res: Response) => {
+agentMonitoringDashboardRouter.delete("/portability/models/:id", instanceOwnerOnly, async (req: Request, res: Response) => {
   const deleted = await deletePortabilityModel(scopedDb(req), req.params.id!);
   if (!deleted) {
     res.status(404).json({ error: "Model not found" });
@@ -1111,7 +1127,9 @@ agentMonitoringDashboardRouter.put("/settings/monitoring-defaults", async (req: 
   res.status(200).json({ monitoringDefaults });
 });
 
-agentMonitoringDashboardRouter.put("/settings/llm-keys", async (req: Request, res: Response) => {
+// instanceOwnerOnly: these credentials are one row the whole instance spends against, so an
+// isolated tenant holding its own valid project key still must not be able to swap them out.
+agentMonitoringDashboardRouter.put("/settings/llm-keys", instanceOwnerOnly, async (req: Request, res: Response) => {
   const body = req.body ?? {};
   const patch: { openaiApiKey?: string | null; anthropicApiKey?: string | null; geminiApiKey?: string | null } = {};
   if ("openaiApiKey" in body) {

--- a/engine/src/routes/apiV1.ts
+++ b/engine/src/routes/apiV1.ts
@@ -128,7 +128,7 @@ export function registerApiV1(app: Express, deps: ApiV1Deps): void {
     const provided = req.header("x-api-key");
     const caller = provided ? await resolveProjectByApiKey(getDb(), provided) : null;
     if (!caller) {
-      res.status(401).json({ error: "Provide a valid project API key (printed at engine startup)" });
+      res.status(401).json({ error: "Provide a valid project API key (see GET /api/v1/auth/config, or Platform Settings)" });
       return;
     }
     const projects = await listProjectsWire(getDb());

--- a/engine/src/routes/apiV1.ts
+++ b/engine/src/routes/apiV1.ts
@@ -25,9 +25,11 @@ import { finishMcpAuth } from "../core/evaluate/mcp.js";
 import {
   authMode,
   getAuth,
+  getPrimaryOrganizationId,
   getSessionUser,
   getUserOrganizationIds,
   needsSetup,
+  tenancyMode,
 } from "../auth/betterAuth.js";
 
 export type ApiV1Deps = {
@@ -50,6 +52,10 @@ export function registerAuthRoutes(app: Express, credentialLimit: RequestHandler
     res.status(200).json({
       mode,
       needsSetup: mode === "enabled" ? await needsSetup(getDb()) : false,
+      // Only in enabled mode, where it means something: it is what the sign-up screen needs to say
+      // truthfully what a new account gets - its own workspace, or membership of the existing one.
+      // Disabled mode's response shape is left byte-identical.
+      ...(mode === "enabled" ? { tenancy: tenancyMode() } : {}),
       ...(defaultProject ? { apiKey: defaultProject.apiKey } : {}),
     });
   }));
@@ -91,12 +97,11 @@ export function registerApiV1(app: Express, deps: ApiV1Deps): void {
         res.status(401).json({ error: "Sign in to create a project" });
         return;
       }
-      const orgs = await getUserOrganizationIds(user.id);
-      if (orgs.length === 0) {
+      organizationId = await getPrimaryOrganizationId(user.id);
+      if (!organizationId) {
         res.status(403).json({ error: "No organization membership" });
         return;
       }
-      organizationId = orgs[0] ?? null;
     }
     const body = req.body ?? {};
     if (typeof body.name !== "string" || !body.name.trim()) {

--- a/engine/src/test/auth.integration.test.ts
+++ b/engine/src/test/auth.integration.test.ts
@@ -91,9 +91,9 @@ describe("AGENTX_AUTH=enabled", () => {
   });
 
   it("prints no project API key in the boot banner", async () => {
-    // Disabled mode prints the default project's key for the operator to copy. Here the log is not
-    // a private channel - `docker logs`, a pod log, or a log shipper would hand a working
-    // data-plane credential for the instance owner's project to anyone who can read it.
+    // Neither mode prints one, but it matters most here: the log is not a private channel -
+    // `docker logs`, a pod log, or a log shipper would otherwise hand a working data-plane
+    // credential for the instance owner's project to anyone who can read it.
     expect(engine.log()).not.toMatch(/agtx_local_/);
   });
 

--- a/engine/src/test/auth.integration.test.ts
+++ b/engine/src/test/auth.integration.test.ts
@@ -15,20 +15,22 @@ const json = (body: unknown): RequestInit => ({
   headers: { "content-type": "application/json" },
 });
 
+const put = (body: unknown): RequestInit => ({ ...json(body), method: "PUT" });
+
 /** better-auth hands back its session in a Set-Cookie; this replays it like a browser would. */
 function cookieHeader(res: Response): string {
   const raw = res.headers.getSetCookie?.() ?? [];
   return raw.map(c => c.split(";")[0]).join("; ");
 }
 
-async function signUp(email: string, password: string, name: string) {
-  const res = await engine.request("/api/v1/auth/sign-up/email", { ...json({ email, password, name }), apiKey: null });
+async function signUp(target: TestEngine, email: string, password: string, name: string) {
+  const res = await target.request("/api/v1/auth/sign-up/email", { ...json({ email, password, name }), apiKey: null });
   const body = await res.text();
   return { status: res.status, cookie: cookieHeader(res), body };
 }
 
-async function signIn(email: string, password: string) {
-  const res = await engine.request("/api/v1/auth/sign-in/email", { ...json({ email, password }), apiKey: null });
+async function signIn(target: TestEngine, email: string, password: string) {
+  const res = await target.request("/api/v1/auth/sign-in/email", { ...json({ email, password }), apiKey: null });
   const body = await res.text();
   return { status: res.status, cookie: cookieHeader(res), body };
 }
@@ -39,8 +41,18 @@ const asUser = (cookie: string, init: RequestInit = {}): RequestInit & { apiKey:
   headers: { ...(init.headers as Record<string, string> | undefined), cookie },
 });
 
+type WireProject = { _id: string; name: string; apiKey: string };
+
+async function projectsOf(target: TestEngine, cookie: string): Promise<WireProject[]> {
+  const res = await target.json("/api/v1/projects", asUser(cookie));
+  expect(res.status, JSON.stringify(res.body)).toBe(200);
+  return (res.body as { projects: WireProject[] }).projects;
+}
+
 let ownerCookie = "";
 let memberCookie = "";
+// The owner's own project key, reused by the cross-tenant checks below.
+let ownerProjectKey = "";
 
 beforeAll(async () => {
   engine = await startEngine({ AGENTX_AUTH: "enabled" });
@@ -54,7 +66,7 @@ describe("AGENTX_AUTH=enabled", () => {
   it("reports the mode and that setup is still pending", async () => {
     const config = await engine.json("/api/v1/auth/config", { apiKey: null });
     expect(config.status).toBe(200);
-    expect(config.body).toEqual({ mode: "enabled", needsSetup: true });
+    expect(config.body).toEqual({ mode: "enabled", needsSetup: true, tenancy: "isolated" });
   });
 
   it("has no anonymous API-key handout at all", async () => {
@@ -78,14 +90,21 @@ describe("AGENTX_AUTH=enabled", () => {
     }
   });
 
+  it("prints no project API key in the boot banner", async () => {
+    // Disabled mode prints the default project's key for the operator to copy. Here the log is not
+    // a private channel - `docker logs`, a pod log, or a log shipper would hand a working
+    // data-plane credential for the instance owner's project to anyone who can read it.
+    expect(engine.log()).not.toMatch(/agtx_local_/);
+  });
+
   it("makes the first signup the owner and hands it the pre-existing project", async () => {
-    const result = await signUp("owner@example.com", "correct-horse-battery", "Owner");
+    const result = await signUp(engine, "owner@example.com", "correct-horse-battery", "Owner");
     expect(result.status, result.body).toBeLessThan(300);
     expect(result.cookie, "no session cookie returned").toBeTruthy();
     ownerCookie = result.cookie;
 
     const config = await engine.json("/api/v1/auth/config", { apiKey: null });
-    expect(config.body).toEqual({ mode: "enabled", needsSetup: false });
+    expect(config.body).toEqual({ mode: "enabled", needsSetup: false, tenancy: "isolated" });
 
     // The project that existed before auth was turned on is claimed by the new org, rather than
     // being stranded with no owner and therefore invisible to everyone.
@@ -101,6 +120,7 @@ describe("AGENTX_AUTH=enabled", () => {
     const created = await engine.json("/api/v1/projects", asUser(ownerCookie, json({ name: "Team project" })));
     expect(created.status, JSON.stringify(created.body)).toBe(201);
     const key = (created.body as { project: { apiKey: string } }).project.apiKey;
+    ownerProjectKey = key;
 
     // The data plane never does a login flow - the project key alone is the SDK's credential, in
     // both auth modes.
@@ -125,16 +145,91 @@ describe("AGENTX_AUTH=enabled", () => {
     await res.text();
   });
 
-  it("joins a later signup to the same organization as a member", async () => {
-    const result = await signUp("member@example.com", "correct-horse-battery", "Member");
+  // The bug this suite previously PINNED as correct behaviour: every signup joined the first
+  // user's organization, so a second person on the same instance saw the first person's projects
+  // and, because the project list carries each project's key, could take over their data plane
+  // outright. Isolation is now the default, and these are the assertions that stop it regressing.
+  it("gives a later signup its own organization and none of the owner's projects", async () => {
+    const result = await signUp(engine, "member@example.com", "correct-horse-battery", "Member");
     expect(result.status, result.body).toBeLessThan(300);
     memberCookie = result.cookie;
 
-    const ownerProjects = await engine.json("/api/v1/projects", asUser(ownerCookie));
-    const memberProjects = await engine.json("/api/v1/projects", asUser(memberCookie));
-    expect(memberProjects.status).toBe(200);
-    const names = (body: unknown) => ((body as { projects: { name: string }[] }).projects ?? []).map(p => p.name).sort();
-    expect(names(memberProjects.body)).toEqual(names(ownerProjects.body));
+    const ownerProjects = await projectsOf(engine, ownerCookie);
+    const memberProjects = await projectsOf(engine, memberCookie);
+
+    // An org that owns nothing has no API key and nothing to do, so a fresh tenant is given a
+    // starter project of its own rather than an empty dashboard.
+    expect(memberProjects.length, "a new tenant got no starter project").toBeGreaterThan(0);
+
+    const ownerIds = new Set(ownerProjects.map(p => p._id));
+    const ownerKeys = new Set(ownerProjects.map(p => p.apiKey));
+    expect(memberProjects.filter(p => ownerIds.has(p._id))).toEqual([]);
+    expect(memberProjects.filter(p => ownerKeys.has(p.apiKey))).toEqual([]);
+
+    // ...and the reverse direction: the pre-existing project stays with the first signup only.
+    const memberIds = new Set(memberProjects.map(p => p._id));
+    expect(ownerProjects.filter(p => memberIds.has(p._id))).toEqual([]);
+    expect(ownerProjects.some(p => p.name === "Default")).toBe(true);
+  });
+
+  it("does not show one tenant another tenant's traces", async () => {
+    const memberKey = (await projectsOf(engine, memberCookie))[0]!.apiKey;
+    const listed = await engine.json("/api/v1/ingest/traces", { apiKey: memberKey });
+    expect(listed.status).toBe(200);
+    // "auth-mode-agent" was ingested above with the owner's key.
+    expect(JSON.stringify(listed.body)).not.toContain("auth-mode-agent");
+  });
+
+  it("lets only the instance owner rewrite the instance-wide provider keys", async () => {
+    const memberKey = (await projectsOf(engine, memberCookie))[0]!.apiKey;
+    const settingsPath = "/api/v1/agent-monitoring/settings/llm-keys";
+
+    // One shared app_settings row funds every tenant's judge calls, and this route authenticates
+    // with a project key rather than a session - so a second tenant holding a valid key of its own
+    // must still not be able to swap the credential out from under the first.
+    const denied = await engine.json(settingsPath, { ...put({ openaiApiKey: "sk-tenant-b" }), apiKey: memberKey });
+    expect(denied.status).toBe(403);
+
+    const allowed = await engine.json(settingsPath, { ...put({ openaiApiKey: "sk-instance-owner" }), apiKey: ownerProjectKey });
+    expect(allowed.status, JSON.stringify(allowed.body)).toBe(200);
+
+    // Leave the instance as we found it - a configured key changes what later boots try to call.
+    const cleared = await engine.json(settingsPath, { ...put({ openaiApiKey: "" }), apiKey: ownerProjectKey });
+    expect(cleared.status).toBe(200);
+    expect((cleared.body as { llm: { openai: { configured: boolean } } }).llm.openai.configured).toBe(false);
+  });
+
+  it("refuses a non-owner tenant's write to the shared model catalog", async () => {
+    const memberKey = (await projectsOf(engine, memberCookie))[0]!.apiKey;
+    const catalog = "/api/v1/agent-monitoring/portability/models";
+
+    const models = await engine.json(catalog, { apiKey: memberKey });
+    expect(models.status).toBe(200);
+    const target = (models.body as { models: { id: string; label: string }[] }).models[0]!;
+    expect(target, "no seeded portability models to test against").toBeTruthy();
+    const row = `${catalog}/${encodeURIComponent(target.id)}`;
+
+    // The catalog is instance-wide, and Model Portability replays a trace's input against whatever
+    // baseUrl a row names - so a second tenant rewriting one would exfiltrate the first tenant's
+    // captured prompts to an endpoint of its own choosing.
+    const hijack = await engine.json(row, {
+      ...put({
+        provider: "custom",
+        label: target.label,
+        pricePerMInputTokens: 0,
+        pricePerMOutputTokens: 0,
+        baseUrl: "http://attacker.invalid/v1",
+      }),
+      apiKey: memberKey,
+    });
+    expect(hijack.status).toBe(403);
+    expect((await engine.json(row, { method: "DELETE", apiKey: memberKey })).status).toBe(403);
+
+    // Nothing about the row moved.
+    const after = await engine.json(catalog, { apiKey: ownerProjectKey });
+    const survivor = (after.body as { models: { id: string; baseUrl: string | null }[] }).models.find(m => m.id === target.id);
+    expect(survivor).toBeTruthy();
+    expect(survivor!.baseUrl).toBeNull();
   });
 
   it("rejects a signed-out or forged cookie", async () => {
@@ -143,10 +238,10 @@ describe("AGENTX_AUTH=enabled", () => {
   });
 
   it("signs in an existing user and issues a working session", async () => {
-    const failed = await signIn("owner@example.com", "wrong-password");
+    const failed = await signIn(engine, "owner@example.com", "wrong-password");
     expect(failed.status).toBeGreaterThanOrEqual(400);
 
-    const ok = await signIn("owner@example.com", "correct-horse-battery");
+    const ok = await signIn(engine, "owner@example.com", "correct-horse-battery");
     expect(ok.status, ok.body).toBeLessThan(300);
     expect((await engine.json("/api/v1/projects", asUser(ok.cookie))).status).toBe(200);
   });
@@ -183,7 +278,7 @@ describe("AGENTX_AUTH=enabled", () => {
       expect(row.issuer).toBe(`local:${row.provider_id}`);
     }
 
-    const ok = await signIn("owner@example.com", "correct-horse-battery");
+    const ok = await signIn(engine, "owner@example.com", "correct-horse-battery");
     expect(ok.status, `existing user could not sign in after the upgrade: ${ok.body}`).toBeLessThan(300);
   }, 120_000);
 
@@ -196,10 +291,44 @@ describe("AGENTX_AUTH=enabled", () => {
   }, 120_000);
 });
 
+// The team-server posture, now something an operator asks for by name. Worth its own engine
+// because the two modes differ only in what the SECOND signup means, and that is exactly the kind
+// of branch that rots once the default stops exercising it.
+describe("AGENTX_AUTH=enabled with AGENTX_TENANCY=shared", () => {
+  let shared: TestEngine;
+
+  beforeAll(async () => {
+    shared = await startEngine({ AGENTX_AUTH: "enabled", AGENTX_TENANCY: "shared" });
+  }, 90_000);
+
+  afterAll(async () => {
+    await shared?.stop();
+  });
+
+  it("advertises the mode so the sign-up screen can describe what an account gets", async () => {
+    const config = await shared.json("/api/v1/auth/config", { apiKey: null });
+    expect(config.body).toEqual({ mode: "enabled", needsSetup: true, tenancy: "shared" });
+  });
+
+  it("joins a later signup to the first user's organization and its projects", async () => {
+    const first = await signUp(shared, "team-owner@example.com", "correct-horse-battery", "Team Owner");
+    expect(first.status, first.body).toBeLessThan(300);
+    const second = await signUp(shared, "team-mate@example.com", "correct-horse-battery", "Team Mate");
+    expect(second.status, second.body).toBeLessThan(300);
+
+    const ownerProjects = await projectsOf(shared, first.cookie);
+    const mateProjects = await projectsOf(shared, second.cookie);
+    const ids = (list: WireProject[]) => list.map(p => p._id).sort();
+    expect(ids(mateProjects)).toEqual(ids(ownerProjects));
+    expect(ownerProjects.some(p => p.name === "Default")).toBe(true);
+  }, 60_000);
+});
+
 // The auth tables live in both schema files and better-auth is handed a different adapter provider
 // per dialect, so "sign-up works" is a per-backend claim, not a global one.
 describe.skipIf(!postgresAvailable)("AGENTX_AUTH=enabled on Postgres", () => {
   let pgEngine: TestEngine;
+  let pgOwnerCookie = "";
 
   beforeAll(async () => {
     pgEngine = await startEngine({ AGENTX_AUTH: "enabled" }, { postgres: true });
@@ -218,9 +347,29 @@ describe.skipIf(!postgresAvailable)("AGENTX_AUTH=enabled on Postgres", () => {
     expect(res.status, body).toBeLessThan(300);
     const cookie = cookieHeader(res);
 
+    pgOwnerCookie = cookie;
+
     const projects = await pgEngine.json("/api/v1/projects", { apiKey: null, headers: { cookie } });
     expect(projects.status).toBe(200);
     expect((projects.body as { projects: unknown[] }).projects.length).toBeGreaterThan(0);
+  }, 60_000);
+
+  // The isolated path writes more per signup than the shared one does - a new organization, a
+  // member row, a project and its seeded evaluators - so "it works" is a per-dialect claim here
+  // for the same reason sign-up itself is.
+  it("gives a later signup its own organization and projects", async () => {
+    const res = await pgEngine.request("/api/v1/auth/sign-up/email", {
+      ...json({ email: "pg-second@example.com", password: "correct-horse-battery", name: "PG Second" }),
+      apiKey: null,
+    });
+    const body = await res.text();
+    expect(res.status, body).toBeLessThan(300);
+
+    const owner = await projectsOf(pgEngine, pgOwnerCookie);
+    const second = await projectsOf(pgEngine, cookieHeader(res));
+    expect(second.length).toBeGreaterThan(0);
+    const ownerIds = new Set(owner.map(p => p._id));
+    expect(second.filter(p => ownerIds.has(p._id))).toEqual([]);
   }, 60_000);
 
   it("still refuses anonymous access to keys", async () => {

--- a/engine/src/test/projects.integration.test.ts
+++ b/engine/src/test/projects.integration.test.ts
@@ -129,3 +129,17 @@ describe("project isolation", () => {
     await res.text();
   });
 });
+
+describe("where the key comes from with auth disabled", () => {
+  // A boot log is not the terminal it was written for - it gets redirected to a file, scraped by a
+  // log shipper and pasted into bug reports - so the banner prints no key even on a single-tenant
+  // instance. Disabled mode serves it to anything that can reach the port instead, which is what
+  // keeps the zero-setup flow to one line, and is where the dashboard, the SDK snippets in the
+  // README, both smoke scripts and this suite's own harness all read it from.
+  it("keeps the key out of the boot banner but still serves it on /auth/config", async () => {
+    expect(engine.log()).not.toMatch(/agtx_local_/);
+    const config = await engine.json("/api/v1/auth/config", { apiKey: null });
+    expect(config.status).toBe(200);
+    expect((config.body as { apiKey?: string }).apiKey).toBe(keyA);
+  });
+});

--- a/engine/src/test/server.ts
+++ b/engine/src/test/server.ts
@@ -161,22 +161,27 @@ export async function startEngine(
     throw new Error(`engine never became healthy:\n${output}`);
   }
 
-  // Read from the boot banner rather than an endpoint: /api/v1/dev/bootstrap handed out the
-  // default key anonymously and is gone, so the startup log is now the only place a fresh caller
-  // learns it - the same thing the README tells an operator to copy.
-  // AGENTX_AUTH=enabled prints no key, and that suite signs in instead of using an ambient one.
+  // The boot banner prints no key in either mode, so read it where the dashboard does: disabled
+  // mode answers GET /api/v1/auth/config with the default project's key for any caller on this
+  // port. No polling needed - the route is registered before listen(), so /health answering above
+  // already means this one is mounted.
+  // AGENTX_AUTH=enabled returns no key there, and that suite signs in instead of using an ambient
+  // one.
   const authEnabled = env.AGENTX_AUTH === "enabled";
-  // The banner is printed after listen(), so /health can answer before it lands - wait for the
-  // line rather than reading whatever happens to be buffered.
-  const keyOf = () => /Default project API key: (agtx_[A-Za-z0-9_-]+)/.exec(output)?.[1] ?? "";
-  const keyDeadline = Date.now() + 10_000;
-  while (!keyOf() && !authEnabled && Date.now() < keyDeadline) {
-    await new Promise(r => setTimeout(r, 50));
-  }
-  const apiKey = keyOf();
-  if (!apiKey && !authEnabled) {
-    killTree("SIGKILL");
-    throw new Error(`no API key in the engine's boot output:\n${output}`);
+  let apiKey = "";
+  if (!authEnabled) {
+    // `connection: close` on purpose. The global fetch pools keep-alive sockets, and an idle one
+    // left against the engine delays its server.close() - long enough that the SIGTERM killTree
+    // sends to the whole process group takes the tsx wrapper down first, so
+    // restart.integration.test.ts reads the wrapper's 143 rather than the engine's own clean 0.
+    // That race already exists and loses occasionally under full-suite load; keeping the socket
+    // out of the pool is what stops it losing every time.
+    const res = await fetch(`${baseUrl}/api/v1/auth/config`, { headers: { connection: "close" } });
+    apiKey = res.ok ? ((await res.json()) as { apiKey?: string }).apiKey ?? "" : "";
+    if (!apiKey) {
+      killTree("SIGKILL");
+      throw new Error(`no API key from /api/v1/auth/config (HTTP ${res.status}):\n${output}`);
+    }
   }
 
   const request: TestEngine["request"] = (pathname, init = {}) => {

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -13,6 +13,9 @@ data:
   AGENTX_IMPROVEMENT_SWEEP: "true"
   AGENTX_SESSION_SWEEP: "true"
   AGENTX_AUTH: "disabled"
+  # Only read when AGENTX_AUTH is "enabled": "isolated" gives every signup its own organization
+  # and projects, "shared" puts every signup in the first user's organization.
+  AGENTX_TENANCY: "isolated"
   OPENAI_API_KEY: ""
   ANTHROPIC_API_KEY: ""
   GEMINI_API_KEY: ""

--- a/scripts/smoke-binary.sh
+++ b/scripts/smoke-binary.sh
@@ -27,8 +27,10 @@ done
 curl -sf -o /dev/null "http://127.0.0.1:$PORT/health" || fail "never became healthy"
 echo "ok: boots and serves /health"
 
-KEY="$(grep -oE 'agtx_local_[A-Za-z0-9_-]+' "$WORK/engine.log" | head -1)"
-[ -n "$KEY" ] || fail "no API key in the boot output"
+# Not from the log - the banner deliberately prints no key. Auth-disabled mode serves it to any
+# caller on this port, which is also how the dashboard gets it.
+KEY="$(curl -sf "http://127.0.0.1:$PORT/api/v1/auth/config" | grep -oE 'agtx_local_[A-Za-z0-9_-]+' | head -1)"
+[ -n "$KEY" ] || fail "no API key from /api/v1/auth/config"
 
 # A real write through bun:sqlite, including the timestamp parsing that used to kill the process.
 code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "http://127.0.0.1:$PORT/api/v1/ingest/traces" \

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -52,7 +52,14 @@ if ! curl -fsS "http://localhost:$PORT/health" > /dev/null 2>&1; then
   exit 1
 fi
 
-API_KEY="$(grep 'Local API key' "$LOG_FILE" | awk '{print $NF}')"
+# From the endpoint, not the log: the boot banner prints no key. (This previously grepped for a
+# "Local API key" line the engine has never printed, so API_KEY silently came out empty.)
+API_KEY="$(curl -fsS "http://localhost:$PORT/api/v1/auth/config" | grep -oE 'agtx_local_[A-Za-z0-9_-]+' | head -1)"
+if [ -z "$API_KEY" ]; then
+  echo "could not read the default project API key from /api/v1/auth/config. Log:" >&2
+  cat "$LOG_FILE" >&2
+  exit 1
+fi
 
 echo "Running smoke test against http://localhost:$PORT ..."
 AGENTX_API_BASE_URL="http://localhost:$PORT/api/v1" \

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -10,7 +10,7 @@ be set. Run via scripts/smoke-test.sh, which starts and stops agentx-server arou
 
 Usage:
     AGENTX_API_BASE_URL=http://localhost:4700/api/v1 \\
-    AGENTX_API_KEY=<printed by agentx-server> \\
+    AGENTX_API_KEY=$(curl -s http://localhost:4700/api/v1/auth/config | jq -r .apiKey) \\
     python3 scripts/smoke_test.py
 """
 


### PR DESCRIPTION
Fixes the isolation gap Julius reported in #trace-eval-framework: with `AGENTX_AUTH=enabled`, every user shares datasets, settings and projects.

## What was broken

Login existed; tenancy did not. `onUserCreated` put **every signup after the first into the first user's organization**, and `GET /projects` returns each project's raw API key so the switcher can populate a dropdown. So the second person to sign up on a shared instance received working data-plane credentials for the first person's traces, datasets, evaluations and prompts.

Storage was never at fault — every domain is scoped by `db.projectId` and always was. The leak was entirely in **who may list projects**, which is also where keys are handed out. The suite had the behaviour pinned as correct (`joins a later signup to the same organization as a member`), which is why it survived.

## The fix — `AGENTX_TENANCY`

Works for both cloud and self-host off one env var, read only when `AGENTX_AUTH=enabled`:

| Value | Meaning |
| --- | --- |
| `isolated` **(new default)** | Every signup gets its own organization, as owner, plus its own seeded starter project. Nobody can see — or obtain a key for — anyone else's projects. |
| `shared` | Every signup joins the first user's organization and shares its projects. The previous behaviour, now opt-in. |

The **first** signup is unchanged in both modes: it becomes an owner and claims every orgless project, so enabling auth on a populated instance still hands that data to whoever runs setup rather than stranding it.

The starter project matters more than it looks: an organization that owns nothing has no API key, and the key is the only data-plane credential — so an isolated signup without one lands on a dashboard it cannot use. It is seeded exactly the way `POST /projects` seeds (system evaluators, metric packs).

## Two more holes isolation exposed

Two tables are deliberately instance-wide, and **both are written by routes that authenticate with a project key, not a session** — so any tenant could rewrite them:

- `app_settings` provider keys — swap the credential every other tenant's judges spend against.
- `portability_models.baseUrl` — sharper: Model Portability replays captured trace input against whatever endpoint a row names, so repointing one exfiltrates another tenant's prompts. The schema comment had already flagged this as *"revisit if that turns out wrong in practice"*.

Writes to both now go through `instanceOwnerOnly`; reads stay open and already mask every stored key. The instance owner is **derived** — the org that owns the default project, the one row the first signup is guaranteed to have claimed — so there is no new column and no migration.

Also in scope:
- The boot banner no longer prints a project key when auth is enabled. A shared instance's log is not a private channel (`docker logs`, a pod log, a log shipper). Disabled mode still prints it — that is what makes the zero-setup local flow work.
- `POST /projects` takes the signup organization instead of an unordered `orgs[0]`, which the better-auth organization plugin makes ambiguous once a user creates further orgs.
- `GET /api/v1/auth/config` now returns `tenancy` alongside `mode`/`needsSetup` when auth is enabled, so the sign-up screen can describe what an account actually gets.

## Upgrade note

Existing users, organizations and projects are untouched — nobody loses access. Only signups from this version onward follow `AGENTX_TENANCY`, so an instance relying on the old behaviour should set `AGENTX_TENANCY=shared` explicitly.

## Docs

README gains a step-by-step **[Setting up a multi-user instance](https://github.com/AgentX-ai/AgentX-trace-eval/blob/fix/multi-user-isolation/README.md#setting-up-a-multi-user-instance)** section: the four env vars that matter, Docker/binary/k8s invocations, and the four browser steps (create the owner account first, set provider keys, hand out the URL, each person copies their own key). `k8s/configmap.yaml` carries the new key.

## Verification

- **444 tests pass** on SQLite. New cases assert the second tenant's project list shares neither an id nor a key with the first's, that it cannot read the first's ingested trace with its own key, and that it gets 403 on both instance-wide write surfaces while the owner gets 200 — with the catalog row re-checked afterwards to confirm nothing moved. A separate engine boots with `AGENTX_TENANCY=shared` and pins the opposite result.
- **34 end-to-end checks** against three real engine boots (isolated / shared / disabled), driven over HTTP following the README steps verbatim. Auth-disabled mode confirmed byte-identical: still hands the dashboard its key, still prints it, still writable.
- **Browser run against a real instance** where the owner already existed: the visitor gets the Sign in / Create account screen, creates an account, and lands on a working dashboard with its own seeded starter project and its own key in Platform Settings. The owner's project list does not grow. Clicking *Clear* on the instance-wide OpenAI key as a non-owner leaves it configured.

**Not run locally:** the Postgres-gated suites need `AGENTX_TEST_DB_URL` (no local PG, Docker down) — CI covers them. I added a Postgres isolation case, since the isolated path writes more per signup than the shared one.

## Follow-up in AgentX-web-front (not this repo)

Two strings in the dashboard bundle are now stale — behaviour is correct, copy is not:
- Sign-up screen: *"New accounts join this instance's organization as members."* → should read `tenancy` from `/auth/config`.
- API-key panel: *"Self-host has no multi-tenant boundary this key protects... readable by anything on this machine via the SDK bootstrap endpoint"* → that endpoint is gone, and with auth enabled there is a boundary.

Minor UX: a non-owner's refused provider-key write (403) is swallowed silently — the value correctly does not change, but no message explains why.