### PR TITLE
Pin the SDK's endpoint surface so a rename can't 404 half the users

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,21 @@ export AGENTX_API_BASE_URL=http://localhost:4700/api/v1
 export AGENTX_API_KEY=<printed by agentx-server on first run>
 ```
 
+Trace, Evaluate and Monitor all answer here, and five parts of the SDK are self-host-only, with no
+hosted equivalent yet: `client.evaluations.prompts`, `client.monitor.online_evaluators`,
+`client.outcomes`, `client.feedback`, and the CI gate (`run.gate(...)`).
+
+Eight SDK calls go the other way and 404 here rather than degrade:
+`client.evaluations.list_models()` and `get_missing_results()`, `client.tracer.evaluate_trace()`,
+and the CI-run surface behind `client.tracer.run_eval()` - `create_ci_run`, `submit_result`,
+`finalize_ci_run`, `get_ci_run`, `get_dataset_test_cases`. Gate a self-host CI job with
+`run.gate(fail_under=..., no_regression=True)` instead; that path is fully supported. The hosted
+platform surface (`client.get_agent()`, `list_workforces()`, conversations) is out of scope here
+entirely.
+
+The full table, and the three test suites that keep it true, are in
+[`contracts/sdk-endpoints.json`](contracts/sdk-endpoints.json).
+
 **OpenTelemetry** - Trace also accepts real OTLP/HTTP traces directly, no AgentX SDK required:
 
 ```bash
@@ -251,6 +266,24 @@ yarn workspace @agentx/engine test
 yarn workspace @agentx/judge-core test
 ```
 
+### SDK contract
+
+[`contracts/sdk-endpoints.json`](contracts/sdk-endpoints.json) lists every endpoint the Python SDK
+calls and which backend implements it - this engine, AgentX's hosted API, or (for the gaps above)
+only one of the two. Three suites read that one file, so a rename or a new call can't quietly 404
+for half the users:
+
+| Suite | Repo | Checks |
+| --- | --- | --- |
+| `engine/src/test/sdkContract.integration.test.ts` | here | boots the engine; `selfHost` rows are mounted, gap rows aren't |
+| `engine/src/test/hostedApiContract.test.ts` | here | parses AgentX-web-api's route tables; same check for `cloud` |
+| `tests/test_endpoint_contract.py` | AgentX-Python | drives every public SDK method through a recording transport; the paths it emits are exactly the rows |
+
+The first runs in plain `yarn test`. The other two need the repo they check out alongside this one
+and skip otherwise - point them somewhere else with `AGENTX_WEB_API_PATH` and `AGENTX_SDK_CONTRACT`
+respectively. Closing a gap means flipping its flag in the same change: both directions are
+asserted, so a row that starts answering fails just as loudly as one that stops.
+
 The engine's integration suites boot the real engine as a subprocess. The ones that exercise
 Postgres skip unless you point them at a server:
 
@@ -338,7 +371,9 @@ end-user feedback).
   fundamentally tied to AgentX's native agent config-branching system, which self-host doesn't
   have. The version-comparison and Prompt Registry features are the self-host analogs.
 - Guardrail hasn't been started.
-- Evaluate's async whole-run analysis (`analyze_run`/`get_report`) is out of scope for now.
+- Evaluate's whole-run analysis (`analyze_run`/`get_report`) works, but runs synchronously where
+  hosted AgentX queues a durable job: `analyze` returns only once the judges are done, and the
+  SDK's poll loop sees a terminal status on its first check. Long runs hold the request open.
 
 See [CHANGELOG.md](CHANGELOG.md) for the detailed, narrative build/verification history behind
 every feature above.

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ Trace, Evaluate and Monitor all answer here, and five parts of the SDK are self-
 hosted equivalent yet: `client.evaluations.prompts`, `client.monitor.online_evaluators`,
 `client.outcomes`, `client.feedback`, and the CI gate (`run.gate(...)`).
 
-Eight SDK calls go the other way and 404 here rather than degrade:
-`client.evaluations.list_models()` and `get_missing_results()`, `client.tracer.evaluate_trace()`,
+Seven SDK calls go the other way and 404 here rather than degrade:
+`client.evaluations.list_models()`, `client.tracer.evaluate_trace()`,
 and the CI-run surface behind `client.tracer.run_eval()` - `create_ci_run`, `submit_result`,
 `finalize_ci_run`, `get_ci_run`, `get_dataset_test_cases`. Gate a self-host CI job with
 `run.gate(fail_under=..., no_regression=True)` instead; that path is fully supported. The hosted

--- a/contracts/sdk-endpoints.json
+++ b/contracts/sdk-endpoints.json
@@ -173,16 +173,6 @@
       "selfHost": true
     },
     {
-      "sdk": "client.evaluations._client.get_missing_results(run_id)",
-      "method": "GET",
-      "path": "/custom-agent-evaluations/runs/{runId}/missing-results",
-      "probe": "/custom-agent-evaluations/runs/contract-probe/missing-results",
-      "cloud": true,
-      "selfHost": false,
-      "gap": "not-ported",
-      "note": "Reached on every run: EvaluationRunContext._fetch_submitted_keys() calls it from execute()."
-    },
-    {
       "sdk": "run.gate(...) / client.evaluations.gate_run(run_id, ...)",
       "method": "GET",
       "path": "/custom-agent-evaluations/runs/{runId}/gate",

--- a/contracts/sdk-endpoints.json
+++ b/contracts/sdk-endpoints.json
@@ -1,0 +1,532 @@
+{
+  "$comment": [
+    "Canonical HTTP contract between the AgentX Python SDK (AgentX-ai/AgentX-Python) and the two",
+    "backends that answer it: the hosted API (AgentX-web-api) and this self-host engine.",
+    "",
+    "Every row is one endpoint the SDK actually calls, with which backend implements it. Three",
+    "test suites read this file and each one checks a different side of it, so a change on any",
+    "side that isn't reflected here fails somewhere:",
+    "",
+    "  engine/src/test/sdkContract.integration.test.ts  boots this engine and asserts selfHost",
+    "                                                   rows are mounted and !selfHost rows are not",
+    "  engine/src/test/hostedApiContract.test.ts        parses AgentX-web-api's route files and",
+    "                                                   asserts the same for `cloud`",
+    "  AgentX-Python tests/test_endpoint_contract.py    drives every public SDK method through a",
+    "                                                   recording transport and asserts the paths",
+    "                                                   it emits are exactly the rows below",
+    "",
+    "The two cross-repo suites resolve this file via $AGENTX_SDK_CONTRACT, else a sibling checkout,",
+    "and skip when neither is present. `path` is relative to the API root (/api/v1).",
+    "",
+    "cloud/selfHost record what is TRUE TODAY, not what is desirable - a false is a gap, and the",
+    "`gap` field says which. Closing one means flipping the flag here in the same change.",
+    "",
+    "Routing only. Auth is not modelled: the hosted API answers some of these on session auth and",
+    "some on an API key, and a row being routed there does not mean an SDK key can call it (see the",
+    "analyze-fallback rows)."
+  ],
+  "apiRoot": "/api/v1",
+  "gapKinds": {
+    "not-ported": "Implemented on the hosted API; deliberately or not-yet ported to self-host.",
+    "self-host-only": "Self-host feature with no hosted-SaaS equivalent yet (documented as such in the SDK).",
+    "platform-only": "Hosted agent/team/conversation platform. Out of scope for the governance engine."
+  },
+  "endpoints": [
+    {
+      "sdk": "client.evaluations.list_models()",
+      "method": "GET",
+      "path": "/custom-agent-evaluations/models",
+      "probe": "/custom-agent-evaluations/models",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "not-ported"
+    },
+    {
+      "sdk": "client.evaluations.datasets.builder(...).publish()",
+      "method": "POST",
+      "path": "/custom-agent-evaluations/datasets",
+      "probe": "/custom-agent-evaluations/datasets",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.evaluations.datasets.list()",
+      "method": "GET",
+      "path": "/custom-agent-evaluations/datasets",
+      "probe": "/custom-agent-evaluations/datasets",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.evaluations.datasets.get(dataset_id)",
+      "method": "GET",
+      "path": "/custom-agent-evaluations/datasets/{datasetId}",
+      "probe": "/custom-agent-evaluations/datasets/contract-probe",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.evaluations.settings.builder(...).publish()",
+      "method": "POST",
+      "path": "/custom-agent-evaluations/evaluation-settings",
+      "probe": "/custom-agent-evaluations/evaluation-settings",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.evaluations.settings.list()",
+      "method": "GET",
+      "path": "/custom-agent-evaluations/evaluation-settings",
+      "probe": "/custom-agent-evaluations/evaluation-settings",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.evaluations.settings.get(evaluation_settings_id)",
+      "method": "GET",
+      "path": "/custom-agent-evaluations/evaluation-settings/{evaluationSettingsId}",
+      "probe": "/custom-agent-evaluations/evaluation-settings/contract-probe",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.evaluations.prompts.create(name, text)",
+      "method": "POST",
+      "path": "/custom-agent-evaluations/prompts",
+      "probe": "/custom-agent-evaluations/prompts",
+      "cloud": false,
+      "selfHost": true,
+      "gap": "self-host-only"
+    },
+    {
+      "sdk": "client.evaluations.prompts.list()",
+      "method": "GET",
+      "path": "/custom-agent-evaluations/prompts",
+      "probe": "/custom-agent-evaluations/prompts",
+      "cloud": false,
+      "selfHost": true,
+      "gap": "self-host-only"
+    },
+    {
+      "sdk": "client.evaluations.prompts.get(name)",
+      "method": "GET",
+      "path": "/custom-agent-evaluations/prompts/{identifier}",
+      "probe": "/custom-agent-evaluations/prompts/contract-probe",
+      "cloud": false,
+      "selfHost": true,
+      "gap": "self-host-only"
+    },
+    {
+      "sdk": "client.evaluations.run(dataset_id, subject)",
+      "method": "POST",
+      "path": "/custom-agent-evaluations/runs",
+      "probe": "/custom-agent-evaluations/runs",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "run.execute(adapter)",
+      "method": "POST",
+      "path": "/custom-agent-evaluations/runs/{runId}/results",
+      "probe": "/custom-agent-evaluations/runs/contract-probe/results",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "run.finalize()",
+      "method": "POST",
+      "path": "/custom-agent-evaluations/runs/{runId}/finalize",
+      "probe": "/custom-agent-evaluations/runs/contract-probe/finalize",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "run.analyze()",
+      "method": "POST",
+      "path": "/custom-agent-evaluations/runs/{runId}/analyze",
+      "probe": "/custom-agent-evaluations/runs/contract-probe/analyze",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.evaluations.get_analysis_status(run_id)",
+      "method": "GET",
+      "path": "/custom-agent-evaluations/runs/{runId}/analyze-status",
+      "probe": "/custom-agent-evaluations/runs/contract-probe/analyze-status",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.evaluations._client.get_report(run_id)",
+      "method": "GET",
+      "path": "/custom-agent-evaluations/runs/{runId}/report",
+      "probe": "/custom-agent-evaluations/runs/contract-probe/report",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.evaluations._client.get_run(run_id)",
+      "method": "GET",
+      "path": "/custom-agent-evaluations/runs/{runId}",
+      "probe": "/custom-agent-evaluations/runs/contract-probe",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.evaluations._client.get_missing_results(run_id)",
+      "method": "GET",
+      "path": "/custom-agent-evaluations/runs/{runId}/missing-results",
+      "probe": "/custom-agent-evaluations/runs/contract-probe/missing-results",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "not-ported",
+      "note": "Reached on every run: EvaluationRunContext._fetch_submitted_keys() calls it from execute()."
+    },
+    {
+      "sdk": "run.gate(...) / client.evaluations.gate_run(run_id, ...)",
+      "method": "GET",
+      "path": "/custom-agent-evaluations/runs/{runId}/gate",
+      "probe": "/custom-agent-evaluations/runs/contract-probe/gate",
+      "cloud": false,
+      "selfHost": true,
+      "gap": "self-host-only",
+      "note": "Pass/fail a finalized run in CI. The hosted API's CI story is the /ingest/ci-runs rows instead."
+    },
+    {
+      "sdk": "client.evaluations._client.analyze_run(run_id) [dashboard-router fallback]",
+      "method": "POST",
+      "path": "/evaluate/analyze/{runId}",
+      "probe": "/evaluate/analyze/contract-probe",
+      "cloud": true,
+      "selfHost": true,
+      "note": "Only after the /custom-agent-evaluations/runs/:runId/analyze row 404s. Routed on the hosted API but behind session auth, so an SDK key cannot reach it there - harmless, since the primary route answers there."
+    },
+    {
+      "sdk": "client.evaluations._client.get_analysis_status(run_id) [dashboard-router fallback]",
+      "method": "GET",
+      "path": "/evaluate/analyze/{runId}/status",
+      "probe": "/evaluate/analyze/contract-probe/status",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.evaluations._client.get_report(run_id) [dashboard-router fallback]",
+      "method": "GET",
+      "path": "/evaluate/{runId}",
+      "probe": "/evaluate/contract-probe",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.monitor.patterns.builder(...).publish()",
+      "method": "POST",
+      "path": "/monitor/patterns",
+      "probe": "/monitor/patterns",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.monitor.patterns.list()",
+      "method": "GET",
+      "path": "/monitor/patterns",
+      "probe": "/monitor/patterns",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.monitor.patterns.get(pattern_id)",
+      "method": "GET",
+      "path": "/monitor/patterns/{patternId}",
+      "probe": "/monitor/patterns/contract-probe",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.monitor.signals.list()",
+      "method": "GET",
+      "path": "/monitor/signals",
+      "probe": "/monitor/signals",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.monitor.signals.get(signal_id)",
+      "method": "GET",
+      "path": "/monitor/signals/{signalId}",
+      "probe": "/monitor/signals/contract-probe",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.monitor.profile.get(agent_id)",
+      "method": "GET",
+      "path": "/monitor/profiles/{agentId}",
+      "probe": "/monitor/profiles/contract-probe",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.monitor.profile.update(agent_id, ...)",
+      "method": "PUT",
+      "path": "/monitor/profiles/{agentId}",
+      "probe": "/monitor/profiles/contract-probe",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.monitor.online_evaluators.builder(...).publish()",
+      "method": "POST",
+      "path": "/monitor/online-evaluators",
+      "probe": "/monitor/online-evaluators",
+      "cloud": false,
+      "selfHost": true,
+      "gap": "self-host-only",
+      "note": "The hosted API has online evaluators only under /agent-monitoring with session auth, not on this API-key surface."
+    },
+    {
+      "sdk": "client.monitor.online_evaluators.list()",
+      "method": "GET",
+      "path": "/monitor/online-evaluators",
+      "probe": "/monitor/online-evaluators",
+      "cloud": false,
+      "selfHost": true,
+      "gap": "self-host-only"
+    },
+    {
+      "sdk": "client.monitor.online_evaluators.get(evaluator_id)",
+      "method": "GET",
+      "path": "/monitor/online-evaluators/{evaluatorId}",
+      "probe": "/monitor/online-evaluators/contract-probe",
+      "cloud": false,
+      "selfHost": true,
+      "gap": "self-host-only"
+    },
+    {
+      "sdk": "client.monitor.online_evaluators.update(evaluator_id, ...)",
+      "method": "PUT",
+      "path": "/monitor/online-evaluators/{evaluatorId}",
+      "probe": "/monitor/online-evaluators/contract-probe",
+      "cloud": false,
+      "selfHost": true,
+      "gap": "self-host-only"
+    },
+    {
+      "sdk": "client.monitor.online_evaluators.delete(evaluator_id)",
+      "method": "DELETE",
+      "path": "/monitor/online-evaluators/{evaluatorId}",
+      "probe": "/monitor/online-evaluators/contract-probe",
+      "cloud": false,
+      "selfHost": true,
+      "gap": "self-host-only"
+    },
+    {
+      "sdk": "client.monitor.online_evaluators.ratings(evaluator_id)",
+      "method": "GET",
+      "path": "/monitor/online-evaluators/{evaluatorId}/ratings",
+      "probe": "/monitor/online-evaluators/contract-probe/ratings",
+      "cloud": false,
+      "selfHost": true,
+      "gap": "self-host-only"
+    },
+    {
+      "sdk": "client.monitor.online_evaluators.events(evaluator_id)",
+      "method": "GET",
+      "path": "/monitor/online-evaluators/{evaluatorId}/events",
+      "probe": "/monitor/online-evaluators/contract-probe/events",
+      "cloud": false,
+      "selfHost": true,
+      "gap": "self-host-only"
+    },
+    {
+      "sdk": "client.tracer.trace(...)",
+      "method": "POST",
+      "path": "/ingest/traces",
+      "probe": "/ingest/traces",
+      "cloud": true,
+      "selfHost": true
+    },
+    {
+      "sdk": "client.tracer.evaluate_trace(trace_id, dataset_id)",
+      "method": "POST",
+      "path": "/ingest/traces/{traceId}/evaluate",
+      "probe": "/ingest/traces/contract-probe/evaluate",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "not-ported"
+    },
+    {
+      "sdk": "client.tracer.create_ci_run(dataset_id)",
+      "method": "POST",
+      "path": "/ingest/ci-runs",
+      "probe": "/ingest/ci-runs",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "not-ported",
+      "note": "Self-host records gate history via GET /custom-agent-evaluations/runs/{runId}/gate, which the SDK does not call."
+    },
+    {
+      "sdk": "client.tracer.submit_result(run_id, ...)",
+      "method": "POST",
+      "path": "/ingest/ci-runs/{runId}/results",
+      "probe": "/ingest/ci-runs/contract-probe/results",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "not-ported"
+    },
+    {
+      "sdk": "client.tracer.finalize_ci_run(run_id)",
+      "method": "POST",
+      "path": "/ingest/ci-runs/{runId}/finalize",
+      "probe": "/ingest/ci-runs/contract-probe/finalize",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "not-ported"
+    },
+    {
+      "sdk": "client.tracer.get_ci_run(run_id)",
+      "method": "GET",
+      "path": "/ingest/ci-runs/{runId}",
+      "probe": "/ingest/ci-runs/contract-probe",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "not-ported"
+    },
+    {
+      "sdk": "client.tracer._client.get_dataset_test_cases(dataset_id)",
+      "method": "GET",
+      "path": "/ingest/datasets/{datasetId}/test-cases",
+      "probe": "/ingest/datasets/contract-probe/test-cases",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "not-ported"
+    },
+    {
+      "sdk": "client.outcomes.report(...)",
+      "method": "POST",
+      "path": "/outcomes",
+      "probe": "/outcomes",
+      "cloud": false,
+      "selfHost": true,
+      "gap": "self-host-only",
+      "note": "Ground truth for the dashboard's Judge Calibration card."
+    },
+    {
+      "sdk": "client.feedback.report(trace_id, rating)",
+      "method": "POST",
+      "path": "/feedback",
+      "probe": "/feedback",
+      "cloud": false,
+      "selfHost": true,
+      "gap": "self-host-only"
+    },
+    {
+      "sdk": "AgentX.list_agents()",
+      "method": "GET",
+      "path": "/access/agents",
+      "probe": "/access/agents",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "platform-only"
+    },
+    {
+      "sdk": "AgentX.get_agent(id)",
+      "method": "GET",
+      "path": "/access/agents/{agentId}",
+      "probe": "/access/agents/contract-probe",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "platform-only"
+    },
+    {
+      "sdk": "AgentX.list_workforces()",
+      "method": "GET",
+      "path": "/access/teams",
+      "probe": "/access/teams",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "platform-only"
+    },
+    {
+      "sdk": "AgentX.get_profile()",
+      "method": "GET",
+      "path": "/access/getProfile",
+      "probe": "/access/getProfile",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "platform-only"
+    },
+    {
+      "sdk": "Agent.new_conversation()",
+      "method": "POST",
+      "path": "/access/agents/{agentId}/conversations/new",
+      "probe": "/access/agents/contract-probe/conversations/new",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "platform-only"
+    },
+    {
+      "sdk": "Agent.list_conversations()",
+      "method": "GET",
+      "path": "/access/agents/{agentId}/conversations",
+      "probe": "/access/agents/contract-probe/conversations",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "platform-only"
+    },
+    {
+      "sdk": "Conversation.list_messages()",
+      "method": "GET",
+      "path": "/access/agents/{agentId}/conversations/{conversationId}",
+      "probe": "/access/agents/contract-probe/conversations/contract-probe",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "platform-only"
+    },
+    {
+      "sdk": "Conversation.chat(message)",
+      "method": "POST",
+      "path": "/access/conversations/{conversationId}/message",
+      "probe": "/access/conversations/contract-probe/message",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "platform-only"
+    },
+    {
+      "sdk": "Conversation.chat_stream(message)",
+      "method": "POST",
+      "path": "/access/conversations/{conversationId}/jsonmessagesse",
+      "probe": "/access/conversations/contract-probe/jsonmessagesse",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "platform-only"
+    },
+    {
+      "sdk": "Workforce.new_conversation()",
+      "method": "POST",
+      "path": "/access/teams/{teamId}/conversations/new",
+      "probe": "/access/teams/contract-probe/conversations/new",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "platform-only"
+    },
+    {
+      "sdk": "Workforce.list_conversations()",
+      "method": "GET",
+      "path": "/access/teams/{teamId}/conversations",
+      "probe": "/access/teams/contract-probe/conversations",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "platform-only"
+    },
+    {
+      "sdk": "Workforce.chat_stream(conversation_id, message)",
+      "method": "POST",
+      "path": "/access/teams/conversations/{conversationId}/jsonmessagesse",
+      "probe": "/access/teams/conversations/contract-probe/jsonmessagesse",
+      "cloud": true,
+      "selfHost": false,
+      "gap": "platform-only"
+    }
+  ],
+  "verifiedAgainstSdk": "0.6.28"
+}

--- a/contracts/sdk-endpoints.json
+++ b/contracts/sdk-endpoints.json
@@ -21,8 +21,10 @@
     "cloud/selfHost record what is TRUE TODAY, not what is desirable - a false is a gap, and the",
     "`gap` field says which. Closing one means flipping the flag here in the same change.",
     "",
-    "Routing only. Auth is not modelled: the hosted API answers some of these on session auth and",
-    "some on an API key, and a row being routed there does not mean an SDK key can call it (see the",
+    "Every `cloud` row is also asserted reachable with an SDK API key: the hosted API mounts these",
+    "behind authenticateUser / authenticateApiKey / authenticateAgent, and all three accept an",
+    "x-api-key header. A route moved behind an auth that doesn't (authenticateAdmin, say) would 401",
+    "an SDK caller while still looking correctly routed, so hostedApiContract.test.ts checks both.",
     "analyze-fallback rows)."
   ],
   "apiRoot": "/api/v1",
@@ -189,7 +191,7 @@
       "probe": "/evaluate/analyze/contract-probe",
       "cloud": true,
       "selfHost": true,
-      "note": "Only after the /custom-agent-evaluations/runs/:runId/analyze row 404s. Routed on the hosted API but behind session auth, so an SDK key cannot reach it there - harmless, since the primary route answers there."
+      "note": "Only after the /custom-agent-evaluations/runs/:runId/analyze row 404s, which is why the hosted API never serves it in practice - the primary route answers there."
     },
     {
       "sdk": "client.evaluations._client.get_analysis_status(run_id) [dashboard-router fallback]",
@@ -271,7 +273,7 @@
       "cloud": false,
       "selfHost": true,
       "gap": "self-host-only",
-      "note": "The hosted API has online evaluators only under /agent-monitoring with session auth, not on this API-key surface."
+      "note": "The hosted API has online evaluators only under /agent-monitoring, which is a different path than the one the SDK calls - not an auth difference; that surface takes an API key too."
     },
     {
       "sdk": "client.monitor.online_evaluators.list()",

--- a/engine/src/test/contract.ts
+++ b/engine/src/test/contract.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Shared loader for contracts/sdk-endpoints.json - the checked-in list of every endpoint the
+// AgentX Python SDK calls, and which of the two backends implements it. See that file's own
+// $comment for the whole arrangement; this module only resolves and types it.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../..");
+
+export type ContractEndpoint = {
+  /** The SDK call that produces this request, e.g. "client.monitor.signals.list()". */
+  sdk: string;
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  /** Templated path relative to apiRoot, e.g. "/monitor/patterns/{patternId}". */
+  path: string;
+  /** Concrete path to probe with - same route, placeholders filled with a throwaway id. */
+  probe: string;
+  /** Implemented by the hosted API (AgentX-web-api). */
+  cloud: boolean;
+  /** Implemented by this engine. */
+  selfHost: boolean;
+  gap?: string;
+  note?: string;
+};
+
+export type Contract = {
+  sdkVersion: string;
+  apiRoot: string;
+  gapKinds: Record<string, string>;
+  endpoints: ContractEndpoint[];
+};
+
+export const CONTRACT_PATH = path.join(repoRoot, "contracts", "sdk-endpoints.json");
+
+export function loadContract(): Contract {
+  return JSON.parse(fs.readFileSync(CONTRACT_PATH, "utf8")) as Contract;
+}
+
+/**
+ * Root of a sibling AgentX-web-api checkout, or "" when there isn't one. The hosted API lives in
+ * its own repo, so the suite that checks its half of the contract is opt-in: point
+ * AGENTX_WEB_API_PATH at a checkout (or keep one as a sibling directory) and it runs, otherwise
+ * it skips rather than failing a clone that only has this repo.
+ */
+export function hostedApiRoot(): string {
+  const candidates = [
+    process.env.AGENTX_WEB_API_PATH ?? "",
+    path.resolve(repoRoot, "../AgentX-web-api-ts/AgentX-web-api"),
+    path.resolve(repoRoot, "../AgentX-web-api"),
+  ].filter(Boolean);
+  return candidates.find(candidate => fs.existsSync(path.join(candidate, "src", "routes"))) ?? "";
+}

--- a/engine/src/test/contract.ts
+++ b/engine/src/test/contract.ts
@@ -45,10 +45,18 @@ export function loadContract(): Contract {
  * it skips rather than failing a clone that only has this repo.
  */
 export function hostedApiRoot(): string {
-  const candidates = [
-    process.env.AGENTX_WEB_API_PATH ?? "",
-    path.resolve(repoRoot, "../AgentX-web-api-ts/AgentX-web-api"),
-    path.resolve(repoRoot, "../AgentX-web-api"),
-  ].filter(Boolean);
-  return candidates.find(candidate => fs.existsSync(path.join(candidate, "src", "routes"))) ?? "";
+  const explicit = process.env.AGENTX_WEB_API_PATH ?? "";
+  if (explicit) {
+    return fs.existsSync(path.join(explicit, "src", "routes")) ? explicit : "";
+  }
+  // Walk up rather than checking one fixed sibling: in a git worktree (.claude/worktrees/<name>)
+  // repoRoot is several levels below the directory the checkouts actually sit in, and a fixed
+  // "../" lookup silently finds nothing and skips the whole suite.
+  for (let dir = repoRoot; ; dir = path.dirname(dir)) {
+    for (const rel of ["AgentX-web-api-ts/AgentX-web-api", "AgentX-web-api"]) {
+      const candidate = path.join(dir, rel);
+      if (fs.existsSync(path.join(candidate, "src", "routes"))) return candidate;
+    }
+    if (dir === path.dirname(dir)) return "";
+  }
 }

--- a/engine/src/test/hostedApiContract.test.ts
+++ b/engine/src/test/hostedApiContract.test.ts
@@ -40,8 +40,23 @@ function resolveModule(fromDir: string, specifier: string): string {
   return "";
 }
 
-/** Every "VERB /mount/path" the hosted API's /api/v1 router mounts, normalized. */
-function hostedRoutes(): Set<string> {
+/** Auth middlewares live one file each under src/config/auth - that's how a route's are found. */
+function isAuthMiddleware(ident: string): boolean {
+  return fs.existsSync(path.join(apiRoot, "src", "config", "auth", `${ident}.ts`));
+}
+
+/**
+ * Whether a middleware admits an `x-api-key` header, read from its own source rather than a
+ * hardcoded list. authenticateUser, authenticateApiKey and authenticateAgent all do; the
+ * session/admin-only ones don't, and a route moved behind one of those would 401 every SDK
+ * caller while still looking correctly routed.
+ */
+function acceptsApiKey(ident: string): boolean {
+  return readIfPresent(path.join(apiRoot, "src", "config", "auth", `${ident}.ts`)).includes("x-api-key");
+}
+
+/** Every "VERB /mount/path" the hosted API's /api/v1 router mounts, with the auth guarding it. */
+function hostedRoutes(): Map<string, string[]> {
   const indexFile = path.join(apiRoot, "src", "routes", "api_v1", "index.ts");
   const source = readIfPresent(indexFile);
   const indexDir = path.dirname(indexFile);
@@ -56,15 +71,21 @@ function hostedRoutes(): Set<string> {
     imports.set(match[1]!, match[2]!);
   }
 
-  const routes = new Set<string>();
+  const routes = new Map<string, string[]>();
   for (const mounted of source.matchAll(/router\.use\(\s*"([^"]*)"\s*,\s*(\w+)\s*\)/g)) {
     const mount = mounted[1]!;
     const specifier = imports.get(mounted[2]!);
     if (!specifier) continue;
     const moduleFile = resolveModule(indexDir, specifier);
     if (!moduleFile) continue;
-    for (const route of readIfPresent(moduleFile).matchAll(/router\.(get|post|put|patch|delete)\(\s*"([^"]*)"/g)) {
-      routes.add(`${route[1]!.toUpperCase()} ${normalize(`${mount}${route[2]!}`)}`);
+    const body = readIfPresent(moduleFile);
+    // A module can guard every one of its routes at once - customAgentEvaluations.ts does.
+    const wholeRouter = [...body.matchAll(/router\.use\(\s*(\w+)\s*\)/g)].map(m => m[1]!).filter(isAuthMiddleware);
+    for (const route of body.matchAll(/router\.(get|post|put|patch|delete)\(\s*"([^"]*)"([^\n]*)/g)) {
+      const perRoute = [...route[3]!.matchAll(/(\w+)/g)].map(m => m[1]!).filter(isAuthMiddleware);
+      routes.set(`${route[1]!.toUpperCase()} ${normalize(`${mount}${route[2]!}`)}`, [
+        ...new Set([...perRoute, ...wholeRouter]),
+      ]);
     }
   }
   return routes;
@@ -101,6 +122,23 @@ describeHosted(`hosted API contract (agentx-python ${contract.sdkVersion})`, () 
           `still calls it a "${endpoint.gap}" gap. Flip cloud to true there, and drop the "self-host only" ` +
           `note from the SDK docs for ${endpoint.sdk}.`
       ).toBe(false);
+    }
+  );
+
+  // Routing alone isn't reachability. An endpoint the SDK calls has to accept the only credential
+  // the SDK has, and the two are set independently - this repo's own contract notes claimed the
+  // analyze-fallback rows were session-only until this check said otherwise.
+  it.each(cloudEndpoints.map(e => [`${e.method} ${e.path}`, e] as const))(
+    "lets an SDK API key reach %s",
+    (_label, endpoint) => {
+      const auth = routes.get(`${endpoint.method} ${normalize(endpoint.path)}`) ?? [];
+      expect(auth, `no auth middleware resolved for ${endpoint.method} ${endpoint.path}`).not.toEqual([]);
+      expect(
+        auth.some(acceptsApiKey),
+        `${endpoint.sdk} calls ${endpoint.method} ${endpoint.path}, which AgentX-web-api now guards with ` +
+          `${auth.join(" + ")} - none of which reads an x-api-key header. The route is mounted, so the ` +
+          `routing check above still passes, but every SDK caller gets a 401.`
+      ).toBe(true);
     }
   );
 });

--- a/engine/src/test/hostedApiContract.test.ts
+++ b/engine/src/test/hostedApiContract.test.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { hostedApiRoot, loadContract } from "./contract.js";
+
+// The hosted API's half of contracts/sdk-endpoints.json. Same idea as sdkContract.integration
+// .test.ts, one repo over: the SDK's `cloud` rows have to be routes AgentX-web-api actually
+// mounts, and its `cloud: false` rows have to stay unmounted there.
+//
+// This matters most where the two backends have diverged on purpose - prompts and online
+// evaluators are self-host-only today, and the SDK documents them that way. If the hosted API
+// grows them, the docs and this contract both need updating, and nothing else would say so.
+//
+// AgentX-web-api is a separate repo and booting it needs Mongo, so this reads its route tables
+// off disk instead: `router.use("/mount", handler)` in api_v1/index.ts plus `router.<verb>("/p")`
+// in the file that handler came from. That is exactly how those files are written; anything
+// fancier (dynamic mounts, re-exported routers) is out of scope and would show up as a missing
+// route rather than a silent pass.
+
+const contract = loadContract();
+const apiRoot = hostedApiRoot();
+
+/** ":id" and "{id}" both become "*" so param naming never has to agree across the two repos. */
+function normalize(routePath: string): string {
+  const collapsed = routePath.replace(/:[A-Za-z0-9_]+/g, "*").replace(/\{[A-Za-z0-9_]+\}/g, "*");
+  const trimmed = collapsed.replace(/\/+$/, "");
+  return trimmed === "" ? "/" : trimmed;
+}
+
+function readIfPresent(file: string): string {
+  return fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "";
+}
+
+/** Resolves a TS import specifier the way the bundler does: ./x -> x.ts, else x/index.ts. */
+function resolveModule(fromDir: string, specifier: string): string {
+  const base = path.resolve(fromDir, specifier);
+  for (const candidate of [`${base}.ts`, path.join(base, "index.ts")]) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return "";
+}
+
+/** Every "VERB /mount/path" the hosted API's /api/v1 router mounts, normalized. */
+function hostedRoutes(): Set<string> {
+  const indexFile = path.join(apiRoot, "src", "routes", "api_v1", "index.ts");
+  const source = readIfPresent(indexFile);
+  const indexDir = path.dirname(indexFile);
+
+  const imports = new Map<string, string>();
+  for (const match of source.matchAll(/^import\s+(\w+)\s+from\s+"([^"]+)"/gm)) {
+    imports.set(match[1]!, match[2]!);
+  }
+  // The tail of that file mounts a second group lazily, inside an async IIFE - /ingest, the SDK's
+  // whole tracing surface, is one of them.
+  for (const match of source.matchAll(/const\s+(\w+)\s*=\s*\(await import\(\s*"([^"]+)"\s*\)\)\.default/g)) {
+    imports.set(match[1]!, match[2]!);
+  }
+
+  const routes = new Set<string>();
+  for (const mounted of source.matchAll(/router\.use\(\s*"([^"]*)"\s*,\s*(\w+)\s*\)/g)) {
+    const mount = mounted[1]!;
+    const specifier = imports.get(mounted[2]!);
+    if (!specifier) continue;
+    const moduleFile = resolveModule(indexDir, specifier);
+    if (!moduleFile) continue;
+    for (const route of readIfPresent(moduleFile).matchAll(/router\.(get|post|put|patch|delete)\(\s*"([^"]*)"/g)) {
+      routes.add(`${route[1]!.toUpperCase()} ${normalize(`${mount}${route[2]!}`)}`);
+    }
+  }
+  return routes;
+}
+
+const describeHosted = apiRoot ? describe : describe.skip;
+
+describeHosted(`hosted API contract (agentx-python ${contract.sdkVersion})`, () => {
+  const routes = hostedRoutes();
+
+  it("found the hosted API's /api/v1 route table", () => {
+    // A refactor that moves those files would otherwise empty the table and pass every
+    // "not mounted" assertion below by accident.
+    expect(routes.size, `no routes parsed out of ${apiRoot} - has api_v1/index.ts moved?`).toBeGreaterThan(100);
+  });
+
+  const cloudEndpoints = contract.endpoints.filter(e => e.cloud);
+  const cloudGaps = contract.endpoints.filter(e => !e.cloud);
+
+  it.each(cloudEndpoints.map(e => [`${e.method} ${e.path}`, e] as const))("routes %s", (_label, endpoint) => {
+    expect(
+      routes.has(`${endpoint.method} ${normalize(endpoint.path)}`),
+      `${endpoint.sdk} calls ${endpoint.method} ${endpoint.path}, which AgentX-web-api no longer routes. ` +
+        `Restore it there, or flip cloud to false in contracts/sdk-endpoints.json and record the gap.`
+    ).toBe(true);
+  });
+
+  it.each(cloudGaps.map(e => [`${e.method} ${e.path}`, e] as const))(
+    "records %s as absent from the hosted API",
+    (_label, endpoint) => {
+      expect(
+        routes.has(`${endpoint.method} ${normalize(endpoint.path)}`),
+        `AgentX-web-api now routes ${endpoint.method} ${endpoint.path}, but contracts/sdk-endpoints.json ` +
+          `still calls it a "${endpoint.gap}" gap. Flip cloud to true there, and drop the "self-host only" ` +
+          `note from the SDK docs for ${endpoint.sdk}.`
+      ).toBe(false);
+    }
+  );
+});

--- a/engine/src/test/sdkContract.integration.test.ts
+++ b/engine/src/test/sdkContract.integration.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { loadContract, type ContractEndpoint } from "./contract.js";
+import { startEngine, type TestEngine } from "./server.js";
+
+// This engine's half of contracts/sdk-endpoints.json: every endpoint the Python SDK calls is
+// either mounted here or explicitly recorded as a gap, and nothing drifts either way silently.
+//
+// Renaming a route, or dropping one, breaks a real SDK caller and nothing else in this suite
+// notices - the eval/monitor suites drive the routes they test by hand, so a rename that updates
+// both the route and the test stays green. This one asserts against the paths the SDK actually
+// sends, which are fixed by a published package we don't control.
+//
+// Both directions are checked. A `selfHost: false` row that starts answering is as much a drift
+// as a `selfHost: true` row that 404s: it means a gap closed and the contract still advertises
+// it, so the SDK-side and hosted-API-side suites reading the same file are now wrong too.
+
+const contract = loadContract();
+
+let engine: TestEngine;
+
+beforeAll(async () => {
+  engine = await startEngine();
+}, 90_000);
+
+afterAll(async () => {
+  await engine?.stop();
+});
+
+/**
+ * Whether a route is mounted at all, as opposed to a mounted handler answering 404 for a
+ * throwaway id. The engine's catch-all for unimplemented /api paths (see index.ts) answers with
+ * `{statusCode, message}`; every real handler's own 404 uses `{error}`. Without this the two are
+ * indistinguishable and a deleted route reads as "run not found".
+ */
+function isMounted(status: number, body: unknown): boolean {
+  if (status !== 404) return true;
+  const shape = body as { statusCode?: unknown; message?: unknown } | null;
+  return !(shape?.statusCode === 404 && shape?.message === "Not found");
+}
+
+async function probe(endpoint: ContractEndpoint): Promise<{ status: number; body: unknown }> {
+  const init: RequestInit = { method: endpoint.method };
+  if (endpoint.method === "POST" || endpoint.method === "PUT") {
+    // Empty body on purpose: every handler validates before it does any work, so this reaches the
+    // route without creating anything or calling out to an LLM provider.
+    init.body = "{}";
+    init.headers = { "content-type": "application/json" };
+  }
+  return engine.json(`${contract.apiRoot}${endpoint.probe}`, init);
+}
+
+describe(`SDK contract (agentx-python ${contract.sdkVersion})`, () => {
+  const implemented = contract.endpoints.filter(e => e.selfHost);
+  const gaps = contract.endpoints.filter(e => !e.selfHost);
+
+  it.each(implemented.map(e => [`${e.method} ${e.path}`, e] as const))(
+    "serves %s",
+    async (_label, endpoint) => {
+      const { status, body } = await probe(endpoint);
+      expect(
+        isMounted(status, body),
+        `${endpoint.sdk} calls ${endpoint.method} ${endpoint.path}, which this engine no longer mounts. ` +
+          `Restore the route, or flip selfHost to false in contracts/sdk-endpoints.json and record the gap.`
+      ).toBe(true);
+    }
+  );
+
+  it.each(gaps.map(e => [`${e.method} ${e.path}`, e] as const))(
+    "records %s as a gap and does not answer it",
+    async (_label, endpoint) => {
+      const { status, body } = await probe(endpoint);
+      expect(
+        isMounted(status, body),
+        `${endpoint.method} ${endpoint.path} now answers, but contracts/sdk-endpoints.json still lists it ` +
+          `as a "${endpoint.gap}" gap. Flip selfHost to true there so ${endpoint.sdk} is covered by the ` +
+          `suites above instead of being asserted absent.`
+      ).toBe(false);
+    }
+  );
+
+  it("declares a gap kind for every unimplemented endpoint", () => {
+    const undeclared = gaps.filter(e => !e.gap || !(e.gap in contract.gapKinds));
+    expect(undeclared.map(e => `${e.method} ${e.path}`)).toEqual([]);
+  });
+
+  it("keeps every SDK path under the API root the engine actually mounts", () => {
+    // The SDK derives every path below from AGENTX_API_BASE_URL, so a prefix change here would
+    // silently 404 every call rather than failing loudly.
+    const stray = contract.endpoints.filter(e => !e.probe.startsWith("/"));
+    expect(stray.map(e => e.probe)).toEqual([]);
+    expect(contract.apiRoot).toBe("/api/v1");
+  });
+});

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -65,14 +65,15 @@ def main() -> None:
     ).execute(answer)
     ctx.finalize()
 
-    # ctx.average_rating (public) needs liveStatistics on the finalize response, which self-host
-    # doesn't compute yet (see engine/src/routes/evaluations.ts's scope note); GET /runs/:id
-    # (also not yet SDK-public, no list_runs()/get_run() beyond the internal client) is what this
-    # engine actually returns the average on, so that's what this test checks against instead.
+    # ctx.average_rating and friends read liveStatistics off the finalize response - this engine
+    # computes it (core/evaluate/runs.ts), so the public accessors are what a real user would read.
+    check("result scored", ctx.rated_count == 1)
+    check("correct answer scored highly", ctx.average_rating is not None and ctx.average_rating >= 8)
+
+    # Run status itself has no public accessor (no list_runs()/get_run() beyond the internal
+    # client), so this one still goes through GET /runs/:id.
     info = client.evaluations._client.get_run(ctx._run.run_id)
     check("run finalized", info["status"] == "completed")
-    check("result scored", info["resultCount"] == 1)
-    check("correct answer scored highly", info["averageRating"] is not None and info["averageRating"] >= 8)
 
     print("Monitor")
     with client.tracer.trace("smoke-test-agent", monitor=True) as span2:


### PR DESCRIPTION
The Python SDK talks to two backends — AgentX's hosted API and this engine — and neither repo can see the other. Renaming a route here, or adding an SDK call nobody implemented, compiles and tests clean on both sides; the failure shows up as a 404 in someone's agent.

`contracts/sdk-endpoints.json` is the missing shared fact: every endpoint `agentx-python` 0.6.28 calls, each with whether this engine and the hosted API implement it.

## What it found

The three sides do line up today. I booted the engine and drove the real SDK through it — traces, dataset → run → execute → finalize with live judge scoring, gate, outcomes, feedback, patterns, signals, profiles, online evaluators, prompts, analyze → report. All green. The divergences are all deliberate, and are now recorded rather than implicit:

| | Count | What |
| --- | --- | --- |
| SDK calls this engine doesn't serve | 7 | `list_models()`, `evaluate_trace()`, and the CI-run surface behind `run_eval()` |
| …plus hosted-platform routes, out of scope here | 12 | `get_agent`, conversations, workforces |
| SDK calls the hosted API doesn't serve | 13 | `evaluations.prompts`, `monitor.online_evaluators`, `run.gate()`, `outcomes.report()`, `feedback.report()` |

## Three suites, one file

| Suite | Checks | Runs |
| --- | --- | --- |
| `engine/src/test/sdkContract.integration.test.ts` | boots the engine, probes every row | always, in `yarn test` |
| `engine/src/test/hostedApiContract.test.ts` | parses AgentX-web-api's route tables off disk (booting it needs Mongo) | with a sibling checkout, else skips |
| `tests/test_endpoint_contract.py` (AgentX-Python) | drives every public method through a recording transport | with a sibling checkout, else skips |

The engine probe needs to tell "route deleted" from "run not found": a mounted handler's own 404 carries `{error}`, while the unimplemented-`/api` catch-all in `index.ts` carries `{statusCode, message}`. That's the discriminator.

Both directions are asserted. A gap row that starts answering fails as loudly as an implemented row that stops — because the other two suites read the same file and would now be wrong too. I verified that by flipping flags in each direction and watching each suite fail with the right message.

## Routing isn't reachability

The first version of this file carried notes claiming three hosted rows sat behind session auth where an SDK key couldn't reach them. That was wrong — `authenticateUser` accepts an `x-api-key` header, as do `authenticateApiKey` and `authenticateAgent`, and all 44 cloud rows are reachable today. The notes were guesses, and nothing tested them.

So the hosted suite now resolves each route's auth middleware from `src/config/auth/` and reads whether it admits an API key **from that middleware's own source**, rather than from a list here that would rot the same way the notes did. A route moved behind `authenticateAdmin` keeps passing the routing check and fails this one — which is the 401 a user would otherwise hit. Verified against a real admin-guarded route.

That also exposed why the wrong notes survived: the sibling lookup checked one fixed level up, so running from a git worktree found nothing and skipped the entire hosted half in silence. It walks ancestors now.

## Also

Two claims that stopped being true:

- **Known gaps** said whole-run analysis (`analyze_run`/`get_report`) was out of scope. It works — I ran it end to end. It's synchronous rather than a durable queued job, which is what the bullet now says.
- `scripts/smoke_test.py` said self-host doesn't compute `liveStatistics` yet. It does; `ctx.average_rating` returned 10.0. The smoke test now reads the public accessors like a real caller instead of reaching past them into the private client.

## Test plan

- `yarn test` — 596 passed, 37 skipped (Postgres, opt-in).
- `yarn typecheck` — clean.
- `pytest tests/test_endpoint_contract.py` in a sibling AgentX-Python checkout — passes, resolving this file automatically.

The Python half is [AgentX-ai/AgentX-Python#20](https://github.com/AgentX-ai/AgentX-Python/pull/20), which also drops the `missing-results` row's counterpart call. Merge that one first, or together — each suite skips without the other repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)