### PR TITLE
Use span.add_tool_call() in the smoke test instead of poking span.tool_calls

### DIFF
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -78,9 +78,9 @@ def main() -> None:
     with client.tracer.trace("smoke-test-agent", monitor=True) as span2:
         span2.input = "do the thing"
         span2.output = "done, but a tool failed"
-        span2.tool_calls = [
-            {"name": "lookup_thing", "input": "x", "output": "error: timeout", "latency_ms": 50, "success": False}
-        ]
+        span2.add_tool_call(
+            "lookup_thing", input="x", output="error: timeout", success=False, error="timeout", latency_ms=50
+        )
 
     signal = None
     for _ in range(10):


### PR DESCRIPTION
The Monitor section of `scripts/smoke_test.py` needs a tool call with `success=False` to trip the engine's built-in "Tool failure" check. `_TraceSpan.add_tool_call()` accepted only `name`/`input`/`output`/`latency_ms` and had no way to express a failed call, so the test assigned `span.tool_calls` directly — reaching past the SDK's public surface in a test whose stated purpose is to exercise it "the same way any external SDK user would."

```diff
-        span2.tool_calls = [
-            {"name": "lookup_thing", "input": "x", "output": "error: timeout", "latency_ms": 50, "success": False}
-        ]
+        span2.add_tool_call(
+            "lookup_thing", input="x", output="error: timeout", success=False, error="timeout", latency_ms=50
+        )
```

## Depends on AgentX-ai/agentx-python#18

That PR adds `success`/`error` to `add_tool_call()`. **This one should not merge before a release is cut from it** — `scripts/smoke-test.sh` documents `pip install agentx-python`, and the latest published version (0.6.28) does not have these kwargs, so the smoke test would fail with a `TypeError` on a clean machine. It passes locally only because this machine has an editable install pointed at the SDK checkout.

## Verification

Ran the SDK against a mocked ingest client with this exact call — the wire payload carries `success: False` and `error: 'timeout'`, so `detect.ts`'s `call.success === false` still matches and the `agent-tool-failure` signal this test polls for is still produced. Behavior is unchanged; only the way the test states it changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)