### PR TITLE
Add DELETE /api/v1/projects/:id with a schema-derived cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -830,3 +830,30 @@ that runs `bun build --compile` and `scripts/smoke-binary.sh` against the result
 and a read back over bun:sqlite, a malformed timestamp, a clean SIGTERM, and an assertion that dev
 mode does not write to `/`. Checked both ways: it passes on the fixed binary and fails on the
 pre-fix one with `dev mode wrote the dashboard bundle to the filesystem root`.
+
+---
+
+Projects could be created and switched between but never removed - the API had `GET` and `POST
+/api/v1/projects` and nothing else, so a mistyped project was permanent. `DELETE
+/api/v1/projects/:id` closes that gap.
+
+The interesting part is the cascade. A project's rows live across 29 tables and are only ever
+reachable by project id, so deleting just the `projects` row leaves storage that nothing can read
+and nothing will ever collect. Rather than hand-listing those tables (a list that silently rots the
+next time one is added), `deleteProject` derives them from the schema itself - every table with a
+`projectId` column - so a new table cascades without anyone remembering this function exists.
+
+Two deletions are refused outright: the default project, whose key is what the startup log prints
+and the SDK docs reference, and the last remaining project, which would leave no key that resolves
+at all. The second is defensive rather than routine - the default guard normally fires first - but
+it is reachable on an instance whose `is_default` flag was never set, which is a state
+`getDefaultProject` already contemplates by returning null.
+
+Verified in `projects.integration.test.ts` against the real engine and its real SQLite file, not
+just the API surface: a project is created, a trace ingested into it, then deleted, and the test
+asserts directly against the database that `traces`, `evaluation_settings`,
+`monitor_online_evaluators` and `agents` all dropped to zero rows for that id - plus that the
+deleted project's API key stops authenticating, that the default project is refused with a 400,
+that an unknown id 404s, and that an unauthenticated delete is rejected without removing anything.
+The cascade assertion was checked both ways: with the table loop disabled it fails with `traces
+kept rows for a deleted project: expected 1 to be +0`.

--- a/engine/src/core/project/projects.ts
+++ b/engine/src/core/project/projects.ts
@@ -1,7 +1,11 @@
 import { nanoid } from "nanoid";
 import { randomBytes } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { eq, getTableColumns, is, Table } from "drizzle-orm";
+import type { AnyColumn } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
+
+// Any schema table carrying a projectId - the shape deleteProject cascades over.
+type AnyProjectScopedTable = Table & { _: { columns: { projectId: AnyColumn } } };
 
 // Self-host's project registry. A project's own apiKey IS what selects it on every request - see
 // auth/apiKey.ts's requireApiKey, which resolves the incoming x-api-key against this table and
@@ -144,6 +148,29 @@ export async function getDefaultProject(db: Db): Promise<ProjectRow | null> {
       | undefined;
   }
   return row ?? null;
+}
+
+// Deleting a project must clear every project-scoped table, not just the projects row: those rows
+// are only ever reachable by project id, so anything left behind is unreachable storage that still
+// counts toward usage. The table list is read off the schema (anything with a projectId column)
+// rather than hand-maintained, so a table added later cascades without a code change here.
+export async function deleteProject(db: Db, id: string): Promise<void> {
+  const scoped = Object.values(db.schema).filter(
+    (value): value is AnyProjectScopedTable => is(value, Table) && "projectId" in getTableColumns(value)
+  );
+  for (const table of scoped) {
+    const { projectId } = getTableColumns(table);
+    if (db.kind === "sqlite") {
+      await db.db.delete(table).where(eq(projectId, id));
+    } else {
+      await db.db.delete(table).where(eq(projectId, id));
+    }
+  }
+  if (db.kind === "sqlite") {
+    await db.db.delete(db.schema.projects).where(eq(db.schema.projects.id, id));
+  } else {
+    await db.db.delete(db.schema.projects).where(eq(db.schema.projects.id, id));
+  }
 }
 
 export async function listProjectRows(db: Db): Promise<ProjectRow[]> {

--- a/engine/src/routes/apiV1.ts
+++ b/engine/src/routes/apiV1.ts
@@ -1,6 +1,7 @@
 import type { Express, RequestHandler } from "express";
 import { Router } from "express";
 import { toNodeHandler } from "better-auth/node";
+import rateLimit from "express-rate-limit";
 import { asyncHandler } from "./asyncRouter.js";
 import { ingestRouter } from "./ingest.js";
 import { evaluationsRouter } from "./evaluations.js";
@@ -76,6 +77,10 @@ export function registerAuthRoutes(app: Express, credentialLimit: RequestHandler
 }
 
 export function registerApiV1(app: Express, deps: ApiV1Deps): void {
+  const projectMutationLimit = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 30,
+  });
   const { credentialLimit, dataPlaneLimit, apiKey } = deps;
   const router = Router();
 
@@ -152,7 +157,7 @@ export function registerApiV1(app: Express, deps: ApiV1Deps): void {
   // outright rather than left to the caller's judgement: the default project, whose key is what
   // the startup log prints and the SDK docs reference, and the last remaining project, which
   // would leave the instance with no key that resolves at all.
-  router.delete("/projects/:id", credentialLimit, asyncHandler(async (req, res) => {
+  router.delete("/projects/:id", projectMutationLimit, credentialLimit, asyncHandler(async (req, res) => {
     const id = req.params.id ?? "";
     const target = id ? await getProjectRow(getDb(), id) : null;
     if (!target) {

--- a/engine/src/routes/apiV1.ts
+++ b/engine/src/routes/apiV1.ts
@@ -14,7 +14,10 @@ import { otlpRouter } from "./otlp.js";
 import { getDb, withProjectId } from "../storage/db.js";
 import {
   createProject,
+  deleteProject,
   getDefaultProject,
+  getProjectRow,
+  listProjectRows,
   listProjectsWire,
   listProjectsWireForOrgs,
   resolveProjectByApiKey,
@@ -142,6 +145,49 @@ export function registerApiV1(app: Express, deps: ApiV1Deps): void {
     }
     const projects = await listProjectsWire(getDb());
     res.status(200).json({ projects });
+  }));
+
+  // Destructive and irreversible - every trace, agent, dataset, prompt and evaluation scoped to
+  // the project goes with it (core/project/projects.ts's deleteProject). Two rows are refused
+  // outright rather than left to the caller's judgement: the default project, whose key is what
+  // the startup log prints and the SDK docs reference, and the last remaining project, which
+  // would leave the instance with no key that resolves at all.
+  router.delete("/projects/:id", credentialLimit, asyncHandler(async (req, res) => {
+    const id = req.params.id ?? "";
+    const target = id ? await getProjectRow(getDb(), id) : null;
+    if (!target) {
+      res.status(404).json({ error: "Project not found" });
+      return;
+    }
+    if (authMode() === "enabled") {
+      const user = await getSessionUser(req);
+      if (!user) {
+        res.status(401).json({ error: "Sign in to delete a project" });
+        return;
+      }
+      const orgs = await getUserOrganizationIds(user.id);
+      if (!target.organizationId || !orgs.includes(target.organizationId)) {
+        res.status(404).json({ error: "Project not found" });
+        return;
+      }
+    } else {
+      const provided = req.header("x-api-key");
+      const caller = provided ? await resolveProjectByApiKey(getDb(), provided) : null;
+      if (!caller) {
+        res.status(401).json({ error: "Provide a valid project API key (printed at engine startup)" });
+        return;
+      }
+    }
+    if (target.isDefault) {
+      res.status(400).json({ error: "The default project cannot be deleted" });
+      return;
+    }
+    if ((await listProjectRows(getDb())).length <= 1) {
+      res.status(400).json({ error: "Cannot delete the only remaining project" });
+      return;
+    }
+    await deleteProject(getDb(), id);
+    res.status(204).end();
   }));
 
   router.use("/ingest", dataPlaneLimit, apiKey, ingestRouter);

--- a/engine/src/test/projects.integration.test.ts
+++ b/engine/src/test/projects.integration.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+import path from "node:path";
 import { startEngine, type TestEngine } from "./server.js";
 
 // Self-host went from one API key per instance to one key per project, and the key alone is what
@@ -127,5 +129,90 @@ describe("project isolation", () => {
     const res = await engine.request("/api/v1/ingest/traces", { apiKey: null });
     expect(res.status).toBe(401);
     await res.text();
+  });
+});
+
+// Deleting a project is the one destructive project operation, and the rows it has to clear are
+// only reachable by project id - so a miss is invisible through the API and only shows up as
+// storage that never goes away. These assert against the database file, not just the response.
+describe("project deletion", () => {
+  const projectsDb = () => new Database(path.join(engine.home, "agentx.db"), { readonly: true });
+
+  const createProject = async (name: string) => {
+    const created = await engine.json("/api/v1/projects", post({ name }, null));
+    expect(created.status).toBe(201);
+    return (created.body as { project: { _id: string; apiKey: string } }).project;
+  };
+
+  it("removes the project and every row scoped to it", async () => {
+    const doomed = await createProject("Doomed project");
+    const ingested = await engine.json(
+      "/api/v1/ingest/traces",
+      post({ name: "doomed-agent", input: "q", output: "a" }, doomed.apiKey)
+    );
+    expect(ingested.status).toBe(200);
+
+    const before = projectsDb();
+    const countIn = (db: InstanceType<typeof Database>, table: string) =>
+      (db.prepare(`select count(*) as n from ${table} where project_id = ?`).get(doomed._id) as { n: number }).n;
+    expect(countIn(before, "traces")).toBeGreaterThan(0);
+    // The engine seeds a baseline judge + metric-pack configs on create, so this is non-empty too.
+    expect(countIn(before, "evaluation_settings")).toBeGreaterThan(0);
+    before.close();
+
+    const deleted = await engine.request(`/api/v1/projects/${doomed._id}`, { method: "DELETE", apiKey: keyA });
+    expect(deleted.status).toBe(204);
+    await deleted.text();
+
+    const after = projectsDb();
+    for (const table of ["traces", "evaluation_settings", "monitor_online_evaluators", "agents"]) {
+      expect(countIn(after, table), `${table} kept rows for a deleted project`).toBe(0);
+    }
+    expect((after.prepare("select count(*) as n from projects where id = ?").get(doomed._id) as { n: number }).n).toBe(
+      0
+    );
+    after.close();
+  });
+
+  it("stops accepting the deleted project's API key", async () => {
+    const doomed = await createProject("Key revoked on delete");
+    expect((await engine.json("/api/v1/ingest/traces", { apiKey: doomed.apiKey })).status).toBe(200);
+
+    const deleted = await engine.request(`/api/v1/projects/${doomed._id}`, { method: "DELETE", apiKey: keyA });
+    expect(deleted.status).toBe(204);
+    await deleted.text();
+
+    const res = await engine.request("/api/v1/ingest/traces", { apiKey: doomed.apiKey });
+    expect(res.status).toBe(401);
+    await res.text();
+  });
+
+  it("refuses to delete the default project", async () => {
+    const list = await engine.json("/api/v1/projects", { apiKey: keyA });
+    const projects = (list.body as { projects: { _id: string; isDefault?: boolean }[] }).projects;
+    const fallback = projects.find(p => p.isDefault);
+    expect(fallback, "no default project to test against").toBeTruthy();
+
+    const res = await engine.json(`/api/v1/projects/${fallback!._id}`, { method: "DELETE", apiKey: keyA });
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toContain("default project");
+
+    const still = await engine.json("/api/v1/projects", { apiKey: keyA });
+    expect((still.body as { projects: { _id: string }[] }).projects.map(p => p._id)).toContain(fallback!._id);
+  });
+
+  it("404s an unknown project id", async () => {
+    const res = await engine.json("/api/v1/projects/not-a-real-project", { method: "DELETE", apiKey: keyA });
+    expect(res.status).toBe(404);
+  });
+
+  it("refuses an unauthenticated delete", async () => {
+    const doomed = await createProject("Needs a key to delete");
+    const res = await engine.request(`/api/v1/projects/${doomed._id}`, { method: "DELETE", apiKey: null });
+    expect(res.status).toBe(401);
+    await res.text();
+
+    const list = await engine.json("/api/v1/projects", { apiKey: keyA });
+    expect((list.body as { projects: { _id: string }[] }).projects.map(p => p._id)).toContain(doomed._id);
   });
 });


### PR DESCRIPTION
Projects can be created and switched between but never removed — the API had `GET` and `POST /api/v1/projects` and nothing else, so a mistyped project was permanent. This adds the delete route the dashboard needs.

## The cascade

A project's rows live across **29 tables** and are only ever reachable by project id. Deleting just the `projects` row would leave storage that nothing can read and nothing will ever collect.

Rather than hand-listing those tables — a list that silently rots the next time one is added — `deleteProject` derives them from the schema itself: every table with a `projectId` column. A table added later cascades without anyone remembering this function exists.

## Guards

Two deletions are refused outright rather than left to the caller:

- **the default project** — its key is what the startup log prints and the SDK docs reference
- **the last remaining project** — would leave no key that resolves at all

The second is defensive rather than routine; the default guard normally fires first. It stays reachable on an instance whose `is_default` was never set, which is a state `getDefaultProject` already contemplates by returning `null`.

Auth matches the existing project routes: session + org ownership in `AGENTX_AUTH=enabled` (a project outside your orgs 404s rather than 403s, so the route doesn't confirm it exists), a valid project key in disabled mode.

## Verification

Tests assert against the engine's **real SQLite file**, not just the API surface — the whole point is rows the API can no longer see.

- create a project, ingest a trace into it, delete it → `traces`, `evaluation_settings`, `monitor_online_evaluators`, `agents` all drop to zero rows for that id, and the `projects` row is gone
- the deleted project's API key stops authenticating (401)
- the default project is refused with 400
- an unknown id 404s
- an unauthenticated delete is rejected and removes nothing

The cascade assertion was checked **both ways**: with the table loop disabled it fails with `traces kept rows for a deleted project: expected 1 to be +0`, so it isn't vacuous.

- `yarn workspace @agentx/engine typecheck` — clean
- full engine suite — 41 files / 457 tests pass (2 postgres files skipped, opt-in)

## Follow-up

The dashboard UI for this lands separately in `AgentX-eval-front` — a delete action under Platform Settings with a confirmation warning. This PR is the endpoint it calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)