### PR TITLE
P2 enterprise IT: bulk NDJSON export, append-only audit log, generic …

### DIFF
--- a/engine/src/auth/betterAuth.ts
+++ b/engine/src/auth/betterAuth.ts
@@ -3,7 +3,7 @@ import { nanoid } from "nanoid";
 import { eq, isNull } from "drizzle-orm";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { organization } from "better-auth/plugins";
+import { genericOAuth, organization } from "better-auth/plugins";
 import { mailerConfigured, sendMailInBackground } from "./mailer.js";
 
 // Verification is an explicit opt-in on top of a working mailer.
@@ -13,11 +13,42 @@ export function verificationRequired(): boolean {
 
 // Google/GitHub sign-in appear automatically when their credentials are configured - the
 // standard SaaS front door, entirely env-driven so the OSS default stays credential-free.
+// "oidc" is the generic enterprise SSO door (P2.3): one env trio covers Okta/Entra/Auth0/
+// Google Workspace/anything speaking OIDC discovery, without per-vendor engine work. SAML and
+// SCIM are deliberately NOT implied by this - they remain unimplemented and documented as such.
 export function enabledSocialProviders(): string[] {
   const providers: string[] = [];
   if (process.env.AGENTX_GOOGLE_CLIENT_ID && process.env.AGENTX_GOOGLE_CLIENT_SECRET) providers.push("google");
   if (process.env.AGENTX_GITHUB_CLIENT_ID && process.env.AGENTX_GITHUB_CLIENT_SECRET) providers.push("github");
+  if (oidcConfigured()) providers.push("oidc");
   return providers;
+}
+
+export function oidcConfigured(): boolean {
+  return Boolean(
+    process.env.AGENTX_OIDC_ISSUER && process.env.AGENTX_OIDC_CLIENT_ID && process.env.AGENTX_OIDC_CLIENT_SECRET
+  );
+}
+
+// What the SSO button says, e.g. "Okta" - purely cosmetic, defaults to the neutral "SSO".
+export function oidcDisplayName(): string {
+  return process.env.AGENTX_OIDC_NAME?.trim() || "SSO";
+}
+
+function genericOAuthConfigFromEnv() {
+  if (!oidcConfigured()) {
+    return [];
+  }
+  const issuer = process.env.AGENTX_OIDC_ISSUER!.replace(/\/$/, "");
+  return [
+    {
+      providerId: "oidc",
+      clientId: process.env.AGENTX_OIDC_CLIENT_ID!,
+      clientSecret: process.env.AGENTX_OIDC_CLIENT_SECRET!,
+      discoveryUrl: `${issuer}/.well-known/openid-configuration`,
+      scopes: ["openid", "profile", "email"],
+    },
+  ];
 }
 
 function socialProvidersFromEnv() {
@@ -214,6 +245,9 @@ function buildAuth(db: Db, opts: InitAuthOpts) {
           invitation: { modelName: "auth_invitation" },
         },
       }),
+      // Generic OIDC SSO (sign-in route: POST /auth/sign-in/oauth2 with providerId "oidc",
+      // callback: <public URL>/api/v1/auth/oauth2/callback/oidc). Inert without the env trio.
+      genericOAuth({ config: genericOAuthConfigFromEnv() }),
     ],
   });
 }

--- a/engine/src/core/audit/auditLog.ts
+++ b/engine/src/core/audit/auditLog.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from "node:crypto";
+import { and, desc, eq, gte, inArray, type SQL } from "drizzle-orm";
+import type { Db } from "../../storage/db.js";
+
+// The append-only audit trail (P2.2 of the enterprise improvement plan). Two functions, by
+// design: record and list. There is no update, no delete, and no route that reaches either -
+// immutability here is enforced by the absence of code, which is the strongest guarantee a
+// single-binary engine can make (an operator with database access can always do anything; the
+// audit trail's job is making the ENGINE incapable of quietly rewriting history).
+
+export type AuditActorType = "project-key" | "user" | "admin" | "anonymous";
+
+export type AuditEventInput = {
+  actor: string;
+  actorType: AuditActorType;
+  action: string;
+  method: string;
+  path: string;
+  status: number;
+  entityType?: string | null;
+  entityId?: string | null;
+  summary?: Record<string, unknown> | null;
+  ip?: string | null;
+  projectId?: string | null;
+};
+
+export type AuditEventRow = AuditEventInput & { id: string; createdAt: Date };
+
+// Fire-and-forget from the request tap: an audit insert failing must never fail the request it
+// describes (the mutation already happened), so errors are logged and swallowed here rather
+// than bubbled into response handling.
+export async function recordAuditEvent(db: Db, input: AuditEventInput): Promise<void> {
+  const row = {
+    id: randomUUID(),
+    createdAt: new Date(),
+    actor: input.actor,
+    actorType: input.actorType,
+    action: input.action,
+    method: input.method,
+    path: input.path,
+    status: input.status,
+    entityType: input.entityType ?? null,
+    entityId: input.entityId ?? null,
+    summary: input.summary ?? null,
+    ip: input.ip ?? null,
+    projectId: input.projectId ?? null,
+  };
+  try {
+    if (db.kind === "sqlite") {
+      db.db.insert(db.schema.auditEvents).values(row).run();
+    } else {
+      await db.db.insert(db.schema.auditEvents).values(row);
+    }
+  } catch (err) {
+    console.error("Audit event write failed (request unaffected):", err);
+  }
+}
+
+export type AuditListFilters = {
+  since?: Date;
+  action?: string;
+  actor?: string;
+  projectId?: string;
+  // Org-scoped reads (/auth-org/audit): restrict to the caller's own projects. An empty array
+  // matches nothing, by design - "no projects" must not mean "everything".
+  projectIds?: string[];
+  limit?: number;
+};
+
+export async function listAuditEvents(db: Db, filters: AuditListFilters = {}): Promise<AuditEventRow[]> {
+  // Same one-spot `any` narrowing as core/export/exportData.ts: the sqlite/pg table types
+  // don't unify, and the two schemas are kept parallel by auth/schemaParity.test.ts.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const t: any = db.schema.auditEvents;
+  const conds: SQL[] = [];
+  if (filters.since) {
+    conds.push(gte(t.createdAt, filters.since));
+  }
+  if (filters.action) {
+    conds.push(eq(t.action, filters.action));
+  }
+  if (filters.actor) {
+    conds.push(eq(t.actor, filters.actor));
+  }
+  if (filters.projectId) {
+    conds.push(eq(t.projectId, filters.projectId));
+  }
+  if (filters.projectIds) {
+    conds.push(inArray(t.projectId, filters.projectIds.length ? filters.projectIds : ["__none__"]));
+  }
+  const limit = Math.min(Math.max(filters.limit ?? 200, 1), 1000);
+  const where = conds.length ? and(...conds) : undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const q = (db.db as any).select().from(t).where(where).orderBy(desc(t.createdAt)).limit(limit);
+  const rows = db.kind === "sqlite" ? q.all() : await q;
+  return rows as AuditEventRow[];
+}

--- a/engine/src/core/export/exportData.ts
+++ b/engine/src/core/export/exportData.ts
@@ -1,0 +1,81 @@
+import { and, asc, count, eq, gt, gte, type SQL } from "drizzle-orm";
+import type { Db } from "../../storage/db.js";
+
+// Bulk data egress (P2.1 of the enterprise improvement plan): every project-scoped table an
+// operator needs to back up, migrate, or walk out the door with, streamed as NDJSON by
+// routes/exportData.ts. Config tables (patterns, evaluators) ride along with the data tables
+// because a usable backup is the data PLUS the scorer/judge config that produced it.
+//
+// The registry maps a stable wire name to its table and to the timestamp column an incremental
+// `?since=` filter applies to. Rows are keyset-paginated on `id` under the hood, so memory stays
+// flat regardless of table size and an interrupted export can be diffed against a re-run (ids
+// are stable). Instance-wide tables (portability models, app settings, auth_*) are deliberately
+// absent: they belong to the operator's own infrastructure backup, not a project's data export.
+export const EXPORT_ENTITIES = {
+  traces: { table: "traces", sinceColumn: "createdAt" },
+  signals: { table: "monitorSignals", sinceColumn: "lastSeenAt" },
+  "signal-feedback": { table: "monitorSignalFeedback", sinceColumn: "createdAt" },
+  events: { table: "monitorEvents", sinceColumn: "createdAt" },
+  classifications: { table: "monitorClassifications", sinceColumn: "createdAt" },
+  runs: { table: "evaluationRuns", sinceColumn: "createdAt" },
+  "run-results": { table: "evaluationRunResults", sinceColumn: "createdAt" },
+  "gate-results": { table: "gateResults", sinceColumn: "createdAt" },
+  datasets: { table: "datasets", sinceColumn: "createdAt" },
+  feedback: { table: "userFeedback", sinceColumn: "createdAt" },
+  outcomes: { table: "outcomeReports", sinceColumn: "reportedAt" },
+  "session-scores": { table: "sessionScores", sinceColumn: "createdAt" },
+  patterns: { table: "monitorPatterns", sinceColumn: "createdAt" },
+  "online-evaluators": { table: "monitorOnlineEvaluators", sinceColumn: "createdAt" },
+  "custom-evaluators": { table: "customEvaluators", sinceColumn: "createdAt" },
+} as const;
+
+export type ExportEntity = keyof typeof EXPORT_ENTITIES;
+
+export const EXPORT_BATCH = 500;
+
+export function isExportEntity(value: string): value is ExportEntity {
+  return value in EXPORT_ENTITIES;
+}
+
+// drizzle's sqlite and pg table types don't unify, so the registry lookup narrows through `any`
+// in this one spot; the two schemas are kept structurally parallel by auth/schemaParity.test.ts.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function entityTable(db: Db, entity: ExportEntity): any {
+  return (db.schema as Record<string, any>)[EXPORT_ENTITIES[entity].table];
+}
+
+function buildWhere(db: Db, entity: ExportEntity, since: Date | null, cursor: string | null): SQL | undefined {
+  const t = entityTable(db, entity);
+  const conds: SQL[] = [eq(t.projectId, db.projectId)];
+  if (since) {
+    conds.push(gte(t[EXPORT_ENTITIES[entity].sinceColumn], since));
+  }
+  if (cursor) {
+    conds.push(gt(t.id, cursor));
+  }
+  return and(...conds);
+}
+
+export async function countExportRows(db: Db, entity: ExportEntity, since: Date | null = null): Promise<number> {
+  const t = entityTable(db, entity);
+  const q = (db.db as any).select({ n: count() }).from(t).where(buildWhere(db, entity, since, null));
+  const rows: { n: number | string }[] = db.kind === "sqlite" ? q.all() : await q;
+  return Number(rows[0]?.n ?? 0);
+}
+
+export async function fetchExportBatch(
+  db: Db,
+  entity: ExportEntity,
+  since: Date | null,
+  cursor: string | null
+): Promise<Record<string, unknown>[]> {
+  const t = entityTable(db, entity);
+  const q = (db.db as any)
+    .select()
+    .from(t)
+    .where(buildWhere(db, entity, since, cursor))
+    .orderBy(asc(t.id))
+    .limit(EXPORT_BATCH);
+  return db.kind === "sqlite" ? q.all() : await q;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/engine/src/routes/admin.ts
+++ b/engine/src/routes/admin.ts
@@ -3,6 +3,7 @@ import { and, eq, gte, isNull, sql } from "drizzle-orm";
 import { asyncRouter } from "./asyncRouter.js";
 import { getDb } from "../storage/db.js";
 import { judgeCallsSince } from "../core/shared/usage.js";
+import { listAuditEvents } from "../core/audit/auditLog.js";
 
 // Operator surface for a multi-tenant deployment: who's on this instance and what are they
 // spending. Guarded by a static operator token (AGENTX_ADMIN_TOKEN, x-admin-token header) -
@@ -79,4 +80,25 @@ adminRouter.get("/overview", async (req: Request, res: Response) => {
       judgeCalls24h: judgeCalls.get(null) ?? 0,
     },
   });
+});
+
+// The instance-wide audit trail (core/audit/auditLog.ts) - the operator's compliance read.
+// Read-only by design: no update or delete route exists anywhere for audit_events, and this
+// router adds none. Filters: ?since=ISO, ?action=scorer.create, ?actor=..., ?limit= (max 1000).
+adminRouter.get("/audit", async (req: Request, res: Response) => {
+  let since: Date | undefined;
+  if (typeof req.query.since === "string" && req.query.since) {
+    since = new Date(req.query.since);
+    if (Number.isNaN(since.getTime())) {
+      res.status(400).json({ error: "since must be an ISO-8601 date" });
+      return;
+    }
+  }
+  const events = await listAuditEvents(getDb(), {
+    since,
+    action: typeof req.query.action === "string" ? req.query.action : undefined,
+    actor: typeof req.query.actor === "string" ? req.query.actor : undefined,
+    limit: typeof req.query.limit === "string" ? Number(req.query.limit) || undefined : undefined,
+  });
+  res.status(200).json({ events });
 });

--- a/engine/src/routes/apiV1.ts
+++ b/engine/src/routes/apiV1.ts
@@ -12,6 +12,8 @@ import { feedbackRouter } from "./feedback.js";
 import { agentMonitoringDashboardRouter } from "./agentMonitoringDashboard.js";
 import { evaluateDashboardRouter } from "./evaluateDashboard.js";
 import { otlpRouter } from "./otlp.js";
+import { exportRouter } from "./exportData.js";
+import { auditAuthTap, auditControlPlaneTap } from "./auditTap.js";
 import { getDb, withProjectId } from "../storage/db.js";
 import {
   createProject,
@@ -35,6 +37,8 @@ import {
   getSessionUser,
   getUserOrganizationIds,
   needsSetup,
+  oidcConfigured,
+  oidcDisplayName,
   verificationRequired,
 } from "../auth/betterAuth.js";
 import { mailerConfigured } from "../auth/mailer.js";
@@ -67,12 +71,17 @@ export function registerAuthRoutes(app: Express, credentialLimit: RequestHandler
             socialProviders: enabledSocialProviders(),
             emailEnabled: mailerConfigured(),
             verificationRequired: verificationRequired(),
+            // The generic OIDC provider's button label ("Okta", "Entra", ... - AGENTX_OIDC_NAME).
+            ...(oidcConfigured() ? { ssoLabel: oidcDisplayName() } : {}),
           }
         : {}),
     });
   }));
   if (authMode() === "enabled") {
-    app.all("/api/v1/auth/*", credentialLimit, toNodeHandler(getAuth()));
+    // auditAuthTap sits before better-auth's handler (and before express.json - better-auth
+    // reads the raw stream itself): sign-in/up/out attempts land in the audit trail with
+    // status and attempted email, nothing more (routes/auditTap.ts).
+    app.all("/api/v1/auth/*", credentialLimit, auditAuthTap, toNodeHandler(getAuth()));
   }
 }
 
@@ -83,6 +92,11 @@ export function registerApiV1(app: Express, deps: ApiV1Deps): void {
   });
   const { credentialLimit, dataPlaneLimit, apiKey } = deps;
   const router = Router();
+
+  // Control-plane audit trail (routes/auditTap.ts): observes every /api/v1 request and records
+  // config mutations + bulk egress into audit_events. Registered first so nothing below can
+  // dodge it; data-plane routes are excluded inside the tap, not here.
+  router.use(auditControlPlaneTap);
 
   router.get("/mcp-oauth/callback", credentialLimit, asyncHandler(async (req, res) => {
     const code = typeof req.query.code === "string" ? req.query.code : "";
@@ -211,6 +225,9 @@ export function registerApiV1(app: Express, deps: ApiV1Deps): void {
   router.use("/agent-monitoring", dataPlaneLimit, apiKey, agentMonitoringDashboardRouter);
   router.use("/evaluate", dataPlaneLimit, apiKey, evaluateDashboardRouter);
   router.use("/otel", dataPlaneLimit, apiKey, otlpRouter);
+  // Bulk NDJSON export for backup/migration (routes/exportData.ts) - data-plane like everything
+  // else keyed by x-api-key; the key alone scopes what leaves the box.
+  router.use("/export", dataPlaneLimit, apiKey, exportRouter);
 
   app.use("/api/v1", router);
 }

--- a/engine/src/routes/auditTap.ts
+++ b/engine/src/routes/auditTap.ts
@@ -1,0 +1,229 @@
+import type { NextFunction, Request, Response } from "express";
+import { getDb } from "../storage/db.js";
+import { recordAuditEvent, type AuditActorType } from "../core/audit/auditLog.js";
+import { resolveProjectByApiKey } from "../core/project/projects.js";
+import { authMode, getSessionUser } from "../auth/betterAuth.js";
+
+// The audit tap (P2.2): a response-finish observer that turns control-plane activity into
+// append-only audit_events rows (core/audit/auditLog.ts). Two deliberate boundaries:
+//
+//  - Data plane is NOT audited (/ingest, /otel, /monitor, /feedback, /outcomes, ...): a
+//    thousand traces a minute would bury the trail that matters. The one data-plane exception
+//    is bulk egress - GET /export/* is exactly what a security team wants in the log.
+//  - Values are NOT recorded: bodies carry scripts, keys, and passwords, so a mutation's
+//    summary keeps the field NAMES that were sent plus a human-recognizable `name`, never
+//    the values. The auth tap keeps only the attempted email (the identity claim itself).
+//
+// Recording is fire-and-forget on 'finish': an audit failure never fails the request.
+
+const DATA_PLANE_PREFIXES = [
+  "/ingest",
+  "/otel",
+  "/monitor",
+  "/custom-agent-evaluations",
+  "/feedback",
+  "/outcomes",
+  "/agents",
+];
+
+// Compute/preview POSTs that change no config - auditing them would be noise.
+const TRANSIENT_MARKERS = [
+  "/dry-run",
+  "/generate-regex",
+  "/coherence-check",
+  "/session-sweep",
+  "/suggest-",
+  "/estimate",
+  "/test-connection",
+  "/tune",
+  "/validate",
+  "/mcp-oauth",
+];
+
+const VERB: Record<string, string> = { POST: "create", PUT: "update", PATCH: "update", DELETE: "delete" };
+
+// Wire path segment -> audit noun. Falls back to the segment itself so new routes are audited
+// (generically) the day they land rather than silently skipped.
+const NOUN: Record<string, string> = {
+  "custom-evaluators": "scorer",
+  "online-evaluators": "judge",
+  patterns: "pattern",
+  profiles: "profile",
+  signals: "signal",
+  projects: "project",
+  "portability/models": "model-endpoint",
+};
+
+type Classified = { action: string; entityType: string | null; entityId: string | null };
+
+// Path is relative to the /api/v1 router mount (e.g. "/agent-monitoring/custom-evaluators/x1").
+export function classifyControlPlane(method: string, path: string): Classified | null {
+  if (method === "GET") {
+    if (path === "/export" || path.startsWith("/export/")) {
+      return { action: "export.read", entityType: "export", entityId: path.split("/")[2] ?? null };
+    }
+    return null;
+  }
+  if (!(method in VERB)) {
+    return null;
+  }
+  if (DATA_PLANE_PREFIXES.some(p => path === p || path.startsWith(`${p}/`))) {
+    return null;
+  }
+  if (TRANSIENT_MARKERS.some(m => path.includes(m))) {
+    return null;
+  }
+
+  // Named special cases first: the actions a compliance reviewer greps for by name.
+  if (path === "/settings/api-key/regenerate" || path.endsWith("/settings/api-key/regenerate")) {
+    return { action: "api-key.regenerate", entityType: "project", entityId: null };
+  }
+  if (path.endsWith("/settings/monitoring-defaults")) {
+    return { action: "settings.update", entityType: "settings", entityId: "monitoring-defaults" };
+  }
+  if (path.endsWith("/settings/llm-keys")) {
+    return { action: "llm-keys.update", entityType: "settings", entityId: "llm-keys" };
+  }
+
+  const segments = path.split("/").filter(Boolean);
+  if (segments.length === 0) {
+    return null;
+  }
+  // Drop router prefixes that carry no entity meaning of their own.
+  const scoped = segments[0] === "agent-monitoring" || segments[0] === "evaluate" || segments[0] === "auth-org"
+    ? segments.slice(1)
+    : segments;
+  if (scoped.length === 0) {
+    return null;
+  }
+  const two = scoped.slice(0, 2).join("/");
+  const nounKey = NOUN[two] ? two : scoped[0]!;
+  const noun = NOUN[nounKey] ?? nounKey;
+  const idIndex = nounKey.includes("/") ? 2 : 1;
+  const entityId = scoped.length > idIndex ? scoped[idIndex]! : null;
+  const verb = VERB[method]!;
+  return { action: `${noun}.${verb}`, entityType: noun, entityId };
+}
+
+function safeSummary(body: unknown): Record<string, unknown> | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return null;
+  }
+  const record = body as Record<string, unknown>;
+  const fields = Object.keys(record).slice(0, 30);
+  if (fields.length === 0) {
+    return null;
+  }
+  return {
+    fields,
+    ...(typeof record.name === "string" ? { name: record.name.slice(0, 200) } : {}),
+  };
+}
+
+async function resolveActor(req: Request): Promise<{ actor: string; actorType: AuditActorType }> {
+  const adminToken = process.env.AGENTX_ADMIN_TOKEN;
+  if (adminToken && req.header("x-admin-token") === adminToken) {
+    return { actor: "admin", actorType: "admin" };
+  }
+  if (req.projectId) {
+    return { actor: `project:${req.projectId}`, actorType: "project-key" };
+  }
+  // /projects handlers resolve the key themselves rather than through requireApiKey.
+  const key = req.header("x-api-key");
+  if (key) {
+    const project = await resolveProjectByApiKey(getDb(), key).catch(() => null);
+    if (project) {
+      return { actor: `project:${project.id}`, actorType: "project-key" };
+    }
+  }
+  if (authMode() === "enabled") {
+    const user = await getSessionUser(req).catch(() => null);
+    if (user?.email) {
+      return { actor: user.email, actorType: "user" };
+    }
+  }
+  return { actor: "anonymous", actorType: "anonymous" };
+}
+
+export function auditControlPlaneTap(req: Request, res: Response, next: NextFunction): void {
+  const classified = classifyControlPlane(req.method, req.path);
+  if (!classified) {
+    next();
+    return;
+  }
+  const summary = req.method === "GET" ? null : safeSummary(req.body);
+  res.on("finish", () => {
+    void (async () => {
+      const { actor, actorType } = await resolveActor(req);
+      await recordAuditEvent(getDb(), {
+        actor,
+        actorType,
+        action: classified.action,
+        method: req.method,
+        path: req.originalUrl.split("?")[0] ?? req.path,
+        status: res.statusCode,
+        entityType: classified.entityType,
+        entityId: classified.entityId,
+        summary,
+        ip: req.ip ?? null,
+        projectId: req.projectId ?? null,
+      });
+    })().catch(err => console.error("Audit tap failed (request unaffected):", err));
+  });
+  next();
+}
+
+// Auth events: mounted BEFORE better-auth's handler (and before express.json - better-auth
+// reads the raw stream itself), so the body is sniffed passively from 'data' events, capped,
+// and only the attempted email is kept. Failed and successful attempts both land, with status.
+const AUTH_ACTIONS: [RegExp, string][] = [
+  [/\/sign-in\b/, "auth.sign-in"],
+  [/\/sign-up\b/, "auth.sign-up"],
+  [/\/sign-out\b/, "auth.sign-out"],
+  [/\/forget-password\b/, "auth.forget-password"],
+  [/\/reset-password\b/, "auth.reset-password"],
+  [/\/callback\//, "auth.oauth-callback"],
+];
+
+export function auditAuthTap(req: Request, res: Response, next: NextFunction): void {
+  const match = AUTH_ACTIONS.find(([re]) => re.test(req.path));
+  if (!match || (req.method !== "POST" && !match[1].endsWith("oauth-callback"))) {
+    next();
+    return;
+  }
+  const action = match[1];
+  let sniffed = "";
+  if (req.method === "POST") {
+    req.on("data", chunk => {
+      if (sniffed.length < 8192) {
+        sniffed += String(chunk);
+      }
+    });
+  }
+  res.on("finish", () => {
+    void (async () => {
+      let email: string | null = null;
+      try {
+        const parsed = JSON.parse(sniffed || "{}");
+        if (typeof parsed.email === "string") {
+          email = parsed.email.slice(0, 200);
+        }
+      } catch {
+        // body wasn't JSON (or was truncated) - the event still records without an email
+      }
+      await recordAuditEvent(getDb(), {
+        actor: email ?? "anonymous",
+        // A successful attempt with an email IS that user acting; anything else stays anonymous
+        // (failed attempts are the rows a security review reads most closely).
+        actorType: email && res.statusCode < 400 ? "user" : "anonymous",
+        action,
+        method: req.method,
+        path: req.originalUrl.split("?")[0] ?? req.path,
+        status: res.statusCode,
+        summary: email ? { email } : null,
+        ip: req.ip ?? null,
+      });
+    })().catch(err => console.error("Auth audit tap failed (request unaffected):", err));
+  });
+  next();
+}

--- a/engine/src/routes/authOrg.ts
+++ b/engine/src/routes/authOrg.ts
@@ -311,3 +311,40 @@ authOrgRouter.delete("/organizations/:orgId/members/:memberId", async (req: Requ
   }
   res.status(200).json({ ok: true });
 });
+
+// Org-scoped audit read: members see the trail for their own organizations' projects (plus, for
+// owners/admins, nothing more - instance-wide reads stay behind the operator's admin token, a
+// different trust domain). Same read-only posture as GET /admin/audit: audit_events has no
+// mutation surface anywhere.
+authOrgRouter.get("/audit", async (req: Request, res: Response) => {
+  const user = await requireUser(req, res);
+  if (!user) return;
+  const db = getDb();
+  const memberships = await membershipsOf(db, user.id);
+  const orgIds = memberships.map(m => m.organizationId);
+  const projectRows = (
+    orgIds.length === 0
+      ? []
+      : db.kind === "sqlite"
+        ? db.db.select({ id: db.schema.projects.id }).from(db.schema.projects)
+            .where(inArray(db.schema.projects.organizationId, orgIds)).all()
+        : await db.db.select({ id: db.schema.projects.id }).from(db.schema.projects)
+            .where(inArray(db.schema.projects.organizationId, orgIds))
+  ) as { id: string }[];
+  let since: Date | undefined;
+  if (typeof req.query.since === "string" && req.query.since) {
+    since = new Date(req.query.since);
+    if (Number.isNaN(since.getTime())) {
+      res.status(400).json({ error: "since must be an ISO-8601 date" });
+      return;
+    }
+  }
+  const { listAuditEvents } = await import("../core/audit/auditLog.js");
+  const events = await listAuditEvents(db, {
+    since,
+    projectIds: projectRows.map(p => p.id),
+    action: typeof req.query.action === "string" ? req.query.action : undefined,
+    limit: typeof req.query.limit === "string" ? Number(req.query.limit) || undefined : undefined,
+  });
+  res.status(200).json({ events });
+});

--- a/engine/src/routes/exportData.ts
+++ b/engine/src/routes/exportData.ts
@@ -1,0 +1,66 @@
+import type { Request, Response } from "express";
+import { asyncRouter } from "./asyncRouter.js";
+import { scopedDb } from "../auth/apiKey.js";
+import {
+  EXPORT_BATCH,
+  EXPORT_ENTITIES,
+  countExportRows,
+  fetchExportBatch,
+  isExportEntity,
+  type ExportEntity,
+} from "../core/export/exportData.js";
+
+// Bulk export (P2.1): GET /export lists what's exportable with live row counts; GET
+// /export/:entity streams the rows as NDJSON (one JSON object per line, exactly the stored
+// shape - timestamps serialize as ISO-8601). `?since=` takes any ISO date for incremental
+// pulls. Project-scoped like every data-plane route: the API key IS the project selection, so
+// an export can never cross a tenant boundary. Restore is documented in the self-host backup
+// runbook: replay (traces re-POST through /ingest) or database-level (pg_dump / SQLite file
+// copy) - there is deliberately no blind row-level import endpoint that could corrupt
+// engine-owned invariants (dedupe, id uniqueness, derived agent rows).
+export const exportRouter = asyncRouter();
+
+exportRouter.get("/", async (req: Request, res: Response) => {
+  const db = scopedDb(req);
+  const entities = [];
+  for (const entity of Object.keys(EXPORT_ENTITIES) as ExportEntity[]) {
+    entities.push({ entity, rows: await countExportRows(db, entity), path: `/api/v1/export/${entity}` });
+  }
+  res.status(200).json({ generatedAt: new Date().toISOString(), format: "ndjson", entities });
+});
+
+exportRouter.get("/:entity", async (req: Request, res: Response) => {
+  const entity = req.params.entity ?? "";
+  if (!isExportEntity(entity)) {
+    res.status(404).json({ error: `Unknown export entity "${entity}"`, entities: Object.keys(EXPORT_ENTITIES) });
+    return;
+  }
+  let since: Date | null = null;
+  if (typeof req.query.since === "string" && req.query.since) {
+    since = new Date(req.query.since);
+    if (Number.isNaN(since.getTime())) {
+      res.status(400).json({ error: "since must be an ISO-8601 date" });
+      return;
+    }
+  }
+  const db = scopedDb(req);
+  res.status(200);
+  res.setHeader("content-type", "application/x-ndjson; charset=utf-8");
+  res.setHeader("content-disposition", `attachment; filename="${entity}.ndjson"`);
+
+  let cursor: string | null = null;
+  for (;;) {
+    const batch = await fetchExportBatch(db, entity, since, cursor);
+    for (const row of batch) {
+      // Respect socket backpressure so a huge table never balloons the response buffer.
+      if (!res.write(`${JSON.stringify(row)}\n`)) {
+        await new Promise<void>(resolve => res.once("drain", () => resolve()));
+      }
+    }
+    if (batch.length < EXPORT_BATCH) {
+      break;
+    }
+    cursor = String(batch[batch.length - 1]!.id);
+  }
+  res.end();
+});

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -697,6 +697,23 @@ function bootstrapSqlite(sqlite: SqliteHandle): void {
       expires_at INTEGER NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS audit_events (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL,
+      actor TEXT NOT NULL,
+      actor_type TEXT NOT NULL,
+      action TEXT NOT NULL,
+      method TEXT NOT NULL,
+      path TEXT NOT NULL,
+      status INTEGER NOT NULL,
+      entity_type TEXT,
+      entity_id TEXT,
+      summary TEXT,
+      ip TEXT,
+      project_id TEXT
+    );
+    CREATE INDEX IF NOT EXISTS audit_events_created_at ON audit_events (created_at);
+
     CREATE TABLE IF NOT EXISTS tool_schemas (
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
@@ -1662,6 +1679,23 @@ async function bootstrapPostgres(pool: Pool): Promise<void> {
       holder TEXT NOT NULL,
       expires_at TIMESTAMP NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS audit_events (
+      id TEXT PRIMARY KEY,
+      created_at TIMESTAMPTZ NOT NULL,
+      actor TEXT NOT NULL,
+      actor_type TEXT NOT NULL,
+      action TEXT NOT NULL,
+      method TEXT NOT NULL,
+      path TEXT NOT NULL,
+      status INTEGER NOT NULL,
+      entity_type TEXT,
+      entity_id TEXT,
+      summary JSONB,
+      ip TEXT,
+      project_id TEXT
+    );
+    CREATE INDEX IF NOT EXISTS audit_events_created_at ON audit_events (created_at);
 
     CREATE TABLE IF NOT EXISTS tool_schemas (
       id TEXT PRIMARY KEY,

--- a/engine/src/storage/schema.pg.ts
+++ b/engine/src/storage/schema.pg.ts
@@ -419,6 +419,23 @@ export const gateResults = pgTable("gate_results", {
 });
 
 // See schema.sqlite.ts's sweepLeases for the full comment.
+// Append-only audit trail - see schema.sqlite.ts's auditEvents comment for the contract.
+export const auditEvents = pgTable("audit_events", {
+  id: text("id").primaryKey(),
+  createdAt: timestamp("created_at", { mode: "date" }).notNull(),
+  actor: text("actor").notNull(),
+  actorType: text("actor_type").notNull(),
+  action: text("action").notNull(),
+  method: text("method").notNull(),
+  path: text("path").notNull(),
+  status: integer("status").notNull(),
+  entityType: text("entity_type"),
+  entityId: text("entity_id"),
+  summary: jsonb("summary"),
+  ip: text("ip"),
+  projectId: text("project_id"),
+});
+
 export const sweepLeases = pgTable("sweep_leases", {
   name: text("name").primaryKey(),
   holder: text("holder").notNull(),

--- a/engine/src/storage/schema.sqlite.ts
+++ b/engine/src/storage/schema.sqlite.ts
@@ -645,6 +645,32 @@ export const usageEvents = sqliteTable("usage_events", {
 // One row per background sweep name (core/shared/sweepLease.ts): the multi-replica guard that
 // keeps N engine replicas sharing one database from each running the same sweep every tick.
 // Global on purpose - no project_id, a sweep iterates every project itself.
+// Append-only audit trail (core/audit/auditLog.ts): who changed what, when, from where. Written
+// by the control-plane tap in routes/auditTap.ts (config mutations, auth events, data egress);
+// readable via GET /admin/audit (operator token) and the org-scoped /auth-org/audit. Immutable
+// by construction - the code base contains INSERT and SELECT for this table and nothing else.
+export const auditEvents = sqliteTable("audit_events", {
+  id: text("id").primaryKey(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  // "project:<id>" (API-key caller), a user email (session caller), "admin" (operator token),
+  // or "anonymous" (unauthenticated attempt - failed sign-ins land here).
+  actor: text("actor").notNull(),
+  actorType: text("actor_type").notNull(),
+  // Stable dotted verb, e.g. "scorer.create", "project.delete", "auth.sign-in", "export.read" -
+  // derived from method+path by the tap so dashboards can group without parsing URLs.
+  action: text("action").notNull(),
+  method: text("method").notNull(),
+  path: text("path").notNull(),
+  status: integer("status").notNull(),
+  entityType: text("entity_type"),
+  entityId: text("entity_id"),
+  // Deliberately values-free except a human-recognizable `name`: bodies carry secrets (scripts,
+  // keys, passwords), so the tap records which fields changed, never what they changed to.
+  summary: text("summary", { mode: "json" }),
+  ip: text("ip"),
+  projectId: text("project_id"),
+});
+
 export const sweepLeases = sqliteTable("sweep_leases", {
   name: text("name").primaryKey(),
   holder: text("holder").notNull(),

--- a/engine/src/test/audit.integration.test.ts
+++ b/engine/src/test/audit.integration.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startEngine, postJson, type TestEngine } from "./server.js";
+
+// P2.2 append-only audit log. The acceptance from DEVELOPMENT_PLAN.md, verbatim: creating and
+// deleting a scorer, a sign-in, and an API-key regeneration each produce one row; and the trail
+// is immutable because no mutation surface exists (asserted here as PUT/DELETE returning 404).
+// Also pinned: the data plane stays OUT of the trail (ingest must not flood it), bulk egress
+// (GET /export/*) goes IN, and reads require the operator token.
+
+const ADMIN_TOKEN = "audit-test-operator-token";
+
+type AuditEvent = {
+  actor: string;
+  actorType: string;
+  action: string;
+  status: number;
+  entityType: string | null;
+  entityId: string | null;
+  summary: { fields?: string[]; name?: string } | null;
+  path: string;
+};
+
+let engine: TestEngine;
+let key: string;
+
+const audit = async (query = ""): Promise<AuditEvent[]> => {
+  const res = await engine.request(`/api/v1/admin/audit${query}`, {
+    apiKey: null,
+    headers: { "x-admin-token": ADMIN_TOKEN },
+  });
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { events: AuditEvent[] }).events;
+};
+
+beforeAll(async () => {
+  engine = await startEngine({ AGENTX_ADMIN_TOKEN: ADMIN_TOKEN });
+  key = engine.apiKey;
+}, 90_000);
+
+afterAll(async () => {
+  await engine?.stop();
+});
+
+describe("what lands in the trail", () => {
+  it("records scorer create and delete as one row each, with actor and safe summary", async () => {
+    const created = await engine.json("/api/v1/agent-monitoring/custom-evaluators", {
+      ...postJson({
+        name: "Audit probe scorer",
+        kind: "code",
+        language: "python",
+        sampleRate: 1,
+        alertBelow: 0.5,
+        script: "async def handler(input, output, expected, metadata, trace):\n    return 1.0\n",
+      }),
+      apiKey: key,
+    });
+    expect(created.status).toBe(201);
+    const scorerId = (created.body as { evaluator: { _id: string } }).evaluator._id;
+
+    const deleted = await engine.json(`/api/v1/agent-monitoring/custom-evaluators/${scorerId}`, {
+      method: "DELETE",
+      apiKey: key,
+    });
+    expect([200, 204]).toContain(deleted.status);
+
+    const events = await audit();
+    const creates = events.filter(e => e.action === "scorer.create");
+    const deletes = events.filter(e => e.action === "scorer.delete");
+    expect(creates.length).toBe(1);
+    expect(deletes.length).toBe(1);
+    expect(deletes[0]!.entityId).toBe(scorerId);
+    expect(creates[0]!.actor).toMatch(/^project:/);
+    expect(creates[0]!.actorType).toBe("project-key");
+    // Field names and the display name are recorded; the script's content must NOT be.
+    expect(creates[0]!.summary?.fields).toContain("script");
+    expect(creates[0]!.summary?.name).toBe("Audit probe scorer");
+    expect(JSON.stringify(creates[0]!.summary)).not.toContain("handler");
+  });
+
+  it("records an API-key regeneration", async () => {
+    const res = await engine.json("/api/v1/agent-monitoring/settings/api-key/regenerate", {
+      method: "POST",
+      apiKey: key,
+    });
+    expect(res.status).toBe(200);
+    key = (res.body as { apiKey: string }).apiKey;
+    expect(key).toBeTruthy();
+
+    const events = await audit("?action=api-key.regenerate");
+    expect(events.length).toBe(1);
+    expect(events[0]!.status).toBe(200);
+  });
+
+  it("records settings changes and bulk-export reads, but never data-plane ingest", async () => {
+    await engine.json("/api/v1/agent-monitoring/settings/monitoring-defaults", {
+      method: "PUT",
+      ...postJson({ enabledBuiltinPatterns: ["pii-in-response"] }),
+      apiKey: key,
+      headers: { "content-type": "application/json" },
+    });
+    for (let i = 0; i < 5; i++) {
+      const ingested = await engine.json("/api/v1/ingest/traces", {
+        ...postJson({ name: "audit-noise", input: "q", output: "a" }),
+        apiKey: key,
+      });
+      expect(ingested.status).toBe(200);
+    }
+    await engine.request("/api/v1/export/traces", { apiKey: key });
+
+    const events = await audit();
+    expect(events.filter(e => e.action === "settings.update").length).toBeGreaterThanOrEqual(1);
+    expect(events.filter(e => e.action === "export.read" && e.entityId === "traces").length).toBe(1);
+    expect(events.filter(e => e.path.includes("/ingest/")).length).toBe(0);
+  });
+});
+
+describe("who can read it, and that nobody can rewrite it", () => {
+  it("requires the operator token", async () => {
+    expect((await engine.json("/api/v1/admin/audit", { apiKey: null })).status).toBe(401);
+    const wrongToken = await engine.request("/api/v1/admin/audit", {
+      apiKey: null,
+      headers: { "x-admin-token": "wrong" },
+    });
+    expect(wrongToken.status).toBe(401);
+  });
+
+  it("has no mutation surface: PUT and DELETE do not exist", async () => {
+    for (const method of ["PUT", "DELETE", "PATCH", "POST"]) {
+      const res = await engine.request("/api/v1/admin/audit", {
+        method,
+        apiKey: null,
+        headers: { "x-admin-token": ADMIN_TOKEN },
+      });
+      expect(res.status).toBe(404);
+    }
+  });
+});
+
+describe("auth events (enabled mode)", () => {
+  it("records sign-up and sign-in attempts with the attempted email, and failures too", async () => {
+    const authEngine = await startEngine({ AGENTX_AUTH: "enabled", AGENTX_ADMIN_TOKEN: ADMIN_TOKEN });
+    try {
+      const signUp = await authEngine.request("/api/v1/auth/sign-up/email", {
+        ...postJson({ email: "owner@example.com", password: "correct-horse-battery", name: "Owner" }),
+        apiKey: null,
+      });
+      expect(signUp.status).toBeLessThan(300);
+      const badSignIn = await authEngine.request("/api/v1/auth/sign-in/email", {
+        ...postJson({ email: "owner@example.com", password: "wrong-password" }),
+        apiKey: null,
+      });
+      expect(badSignIn.status).toBeGreaterThanOrEqual(400);
+
+      const res = await authEngine.request("/api/v1/admin/audit", {
+        apiKey: null,
+        headers: { "x-admin-token": ADMIN_TOKEN },
+      });
+      const events = ((await res.json()) as { events: AuditEvent[] }).events;
+      const signUps = events.filter(e => e.action === "auth.sign-up");
+      const signIns = events.filter(e => e.action === "auth.sign-in");
+      expect(signUps.length).toBe(1);
+      expect(signUps[0]!.actor).toBe("owner@example.com");
+      expect(signUps[0]!.actorType).toBe("user");
+      expect(signIns.length).toBe(1);
+      expect(signIns[0]!.status).toBeGreaterThanOrEqual(400);
+      expect(signIns[0]!.actorType).toBe("anonymous");
+      // The password must never appear anywhere in the trail.
+      expect(JSON.stringify(events)).not.toContain("correct-horse-battery");
+      expect(JSON.stringify(events)).not.toContain("wrong-password");
+    } finally {
+      await authEngine.stop();
+    }
+  }, 90_000);
+});

--- a/engine/src/test/exportData.integration.test.ts
+++ b/engine/src/test/exportData.integration.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startEngine, postJson, type TestEngine } from "./server.js";
+
+// P2.1 bulk export: the buyer's "can I get my data OUT" question. The contract under test:
+// every registered entity streams project-scoped NDJSON, `since` filters incrementally, another
+// project's key never sees the rows, and an exported traces file can be REPLAYED through
+// /ingest into a fresh project with matching counts (the documented restore path).
+
+let engine: TestEngine;
+let keyA: string;
+let keyB: string;
+
+const ndjson = async (path: string, apiKey: string): Promise<Record<string, unknown>[]> => {
+  const res = await engine.request(path, { apiKey });
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-type")).toContain("application/x-ndjson");
+  const text = await res.text();
+  return text
+    .split("\n")
+    .filter(line => line.trim())
+    .map(line => JSON.parse(line));
+};
+
+beforeAll(async () => {
+  engine = await startEngine();
+  keyA = engine.apiKey;
+  const created = await engine.json("/api/v1/projects", { ...postJson({ name: "Export bystander" }), apiKey: null });
+  keyB = (created.body as { project: { apiKey: string } }).project.apiKey;
+
+  // Seed a small, mixed dataset in project A: traces (with session/spans), feedback, an outcome.
+  for (let i = 0; i < 7; i++) {
+    const ingested = await engine.json("/api/v1/ingest/traces", {
+      ...postJson({
+        name: "export-agent",
+        input: { q: `question-${i}` },
+        output: `answer-${i}`,
+        session_id: "export-session",
+        span_id: `export-span-${i}`,
+        metadata: { batch: "export-test" },
+      }),
+      apiKey: keyA,
+    });
+    expect(ingested.status).toBe(200);
+    const traceId = (ingested.body as { trace_id: string }).trace_id;
+    if (i === 0) {
+      const fb = await engine.json("/api/v1/feedback", {
+        ...postJson({ traceId, rating: "down", comment: "wrong answer", endUserId: "u-1" }),
+        apiKey: keyA,
+      });
+      expect([200, 201]).toContain(fb.status);
+      const oc = await engine.json("/api/v1/outcomes", {
+        ...postJson({ traceId, outcome: "confirmed_bad", isNegative: true, reportedBy: "test" }),
+        apiKey: keyA,
+      });
+      expect([200, 201]).toContain(oc.status);
+    }
+  }
+}, 90_000);
+
+afterAll(async () => {
+  await engine?.stop();
+});
+
+describe("export manifest", () => {
+  it("lists every entity with live row counts", async () => {
+    const res = await engine.json("/api/v1/export", { apiKey: keyA });
+    expect(res.status).toBe(200);
+    const body = res.body as { format: string; entities: { entity: string; rows: number }[] };
+    expect(body.format).toBe("ndjson");
+    const byName = Object.fromEntries(body.entities.map(e => [e.entity, e.rows]));
+    // 7 ingested + the fresh project's seed traces; at least our 7 exist.
+    expect(byName.traces).toBeGreaterThanOrEqual(7);
+    expect(byName.feedback).toBeGreaterThanOrEqual(1);
+    expect(byName.outcomes).toBeGreaterThanOrEqual(1);
+    expect(Object.keys(byName)).toContain("signals");
+    expect(Object.keys(byName)).toContain("custom-evaluators");
+  });
+
+  it("401s without a key and 404s an unknown entity", async () => {
+    expect((await engine.json("/api/v1/export", { apiKey: null })).status).toBe(401);
+    const bad = await engine.json("/api/v1/export/nonsense", { apiKey: keyA });
+    expect(bad.status).toBe(404);
+    expect((bad.body as { entities: string[] }).entities).toContain("traces");
+  });
+});
+
+describe("NDJSON streaming", () => {
+  it("streams full stored rows, project-scoped", async () => {
+    const rowsA = await ndjson("/api/v1/export/traces", keyA);
+    const ours = rowsA.filter(r => r.name === "export-agent");
+    expect(ours.length).toBe(7);
+    // Full stored shape, not a summary: json fields and timestamps survive.
+    expect(ours[0]).toHaveProperty("id");
+    expect(ours[0]).toHaveProperty("createdAt");
+    expect(ours.some(r => JSON.stringify(r.metadata).includes("export-test"))).toBe(true);
+
+    // Project B's key must not see project A's rows.
+    const rowsB = await ndjson("/api/v1/export/traces", keyB);
+    expect(rowsB.filter(r => r.name === "export-agent").length).toBe(0);
+  });
+
+  it("filters incrementally with ?since=", async () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const rows = await ndjson(`/api/v1/export/traces?since=${encodeURIComponent(future)}`, keyA);
+    expect(rows.length).toBe(0);
+    const bad = await engine.json("/api/v1/export/traces?since=not-a-date", { apiKey: keyA });
+    expect(bad.status).toBe(400);
+  });
+
+  it("exports feedback and outcomes rows with their content intact", async () => {
+    const feedback = await ndjson("/api/v1/export/feedback", keyA);
+    expect(feedback.some(r => r.comment === "wrong answer")).toBe(true);
+    const outcomes = await ndjson("/api/v1/export/outcomes", keyA);
+    expect(outcomes.some(r => r.outcome === "confirmed_bad")).toBe(true);
+  });
+});
+
+describe("round trip (the documented replay restore)", () => {
+  it("replays an exported traces file into a fresh project with matching counts", async () => {
+    const exported = (await ndjson("/api/v1/export/traces", keyA)).filter(r => r.name === "export-agent");
+    expect(exported.length).toBe(7);
+
+    const created = await engine.json("/api/v1/projects", { ...postJson({ name: "Export restore target" }), apiKey: null });
+    const keyC = (created.body as { project: { apiKey: string } }).project.apiKey;
+
+    for (const row of exported) {
+      const replayed = await engine.json("/api/v1/ingest/traces", {
+        ...postJson({
+          name: row.name,
+          input: row.input,
+          output: row.output,
+          ...(row.error ? { error: row.error } : {}),
+          ...(row.latencyMs != null ? { latency_ms: row.latencyMs } : {}),
+          ...(row.sessionId ? { session_id: row.sessionId } : {}),
+          ...(row.spanId ? { span_id: row.spanId } : {}),
+          ...(row.metadata ? { metadata: row.metadata } : {}),
+        }),
+        apiKey: keyC,
+      });
+      expect(replayed.status).toBe(200);
+    }
+
+    const restored = (await ndjson("/api/v1/export/traces", keyC)).filter(r => r.name === "export-agent");
+    expect(restored.length).toBe(exported.length);
+    expect(new Set(restored.map(r => JSON.stringify(r.output)))).toEqual(
+      new Set(exported.map(r => JSON.stringify(r.output)))
+    );
+  });
+});

--- a/engine/src/test/oidc.integration.test.ts
+++ b/engine/src/test/oidc.integration.test.ts
@@ -1,0 +1,104 @@
+import http from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startEngine, postJson, type TestEngine } from "./server.js";
+
+// P2.3 generic OIDC SSO: the env trio (AGENTX_OIDC_ISSUER/CLIENT_ID/CLIENT_SECRET) must light
+// up an "oidc" provider end-to-end against a stub issuer: /auth/config advertises it (with the
+// AGENTX_OIDC_NAME button label), and POST /auth/sign-in/oauth2 performs real OIDC discovery
+// against the issuer and returns an authorization URL pointing at it. The full round trip
+// (IdP login -> callback -> session) is verified against a real IdP per release, per the plan;
+// what CI pins is that the engine's half of the handshake is genuinely wired, not advertised.
+
+let issuer: http.Server;
+let issuerUrl: string;
+let discoveryHits = 0;
+
+beforeAll(async () => {
+  issuer = http.createServer((req, res) => {
+    if (req.url?.startsWith("/.well-known/openid-configuration")) {
+      discoveryHits += 1;
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          issuer: issuerUrl,
+          authorization_endpoint: `${issuerUrl}/authorize`,
+          token_endpoint: `${issuerUrl}/token`,
+          userinfo_endpoint: `${issuerUrl}/userinfo`,
+          jwks_uri: `${issuerUrl}/jwks`,
+          response_types_supported: ["code"],
+          subject_types_supported: ["public"],
+          id_token_signing_alg_values_supported: ["RS256"],
+        })
+      );
+      return;
+    }
+    res.statusCode = 404;
+    res.end("{}");
+  });
+  await new Promise<void>(resolve => issuer.listen(0, "127.0.0.1", resolve));
+  const address = issuer.address();
+  issuerUrl = `http://127.0.0.1:${typeof address === "object" && address ? address.port : 0}`;
+}, 30_000);
+
+afterAll(async () => {
+  await new Promise<void>(resolve => issuer.close(() => resolve()));
+});
+
+describe("with the env trio set", () => {
+  let engine: TestEngine;
+
+  beforeAll(async () => {
+    engine = await startEngine({
+      AGENTX_AUTH: "enabled",
+      AGENTX_OIDC_ISSUER: issuerUrl,
+      AGENTX_OIDC_CLIENT_ID: "agentx-test-client",
+      AGENTX_OIDC_CLIENT_SECRET: "agentx-test-secret",
+      AGENTX_OIDC_NAME: "Okta",
+    });
+  }, 90_000);
+
+  afterAll(async () => {
+    await engine?.stop();
+  });
+
+  it("advertises the oidc provider and its label on /auth/config", async () => {
+    const res = await engine.json("/api/v1/auth/config", { apiKey: null });
+    expect(res.status).toBe(200);
+    const body = res.body as { socialProviders: string[]; ssoLabel: string };
+    expect(body.socialProviders).toContain("oidc");
+    expect(body.ssoLabel).toBe("Okta");
+  });
+
+  it("performs discovery against the issuer and returns its authorization URL", async () => {
+    const res = await engine.json("/api/v1/auth/sign-in/oauth2", {
+      ...postJson({ providerId: "oidc", callbackURL: "http://localhost:3000" }),
+      apiKey: null,
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { url: string };
+    expect(body.url).toContain(`${issuerUrl}/authorize`);
+    expect(body.url).toContain("client_id=agentx-test-client");
+    expect(body.url).toContain("scope=");
+    expect(discoveryHits).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("without the env trio", () => {
+  it("advertises nothing and the oauth2 sign-in route rejects the unknown provider", async () => {
+    const engine = await startEngine({ AGENTX_AUTH: "enabled" });
+    try {
+      const cfg = await engine.json("/api/v1/auth/config", { apiKey: null });
+      const body = cfg.body as { socialProviders: string[]; ssoLabel?: string };
+      expect(body.socialProviders).not.toContain("oidc");
+      expect(body.ssoLabel).toBeUndefined();
+
+      const res = await engine.json("/api/v1/auth/sign-in/oauth2", {
+        ...postJson({ providerId: "oidc", callbackURL: "http://localhost:3000" }),
+        apiKey: null,
+      });
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await engine.stop();
+    }
+  }, 90_000);
+});


### PR DESCRIPTION
…OIDC SSO

- GET /export manifest + GET /export/:entity streaming NDJSON (15 project-scoped entities, keyset-paginated, ?since= incremental); no import endpoint by design, restore is replay or db-level per the backup runbook
- audit_events (both dialects) + response-finish tap: control-plane mutations, auth attempts (attempted email only, sniffed pre-body-parser), export reads; values-free summaries; reads via GET /admin/audit (operator token) and org-scoped /auth-org/audit; immutable - no mutation surface exists
- generic OIDC via AGENTX_OIDC_ISSUER/CLIENT_ID/CLIENT_SECRET (+ AGENTX_OIDC_NAME label); /auth/config advertises oidc + ssoLabel; SAML/SCIM stay unsupported
- 15 new integration tests (export round-trip replay, audit acceptance incl. auth-mode sign-in rows, OIDC vs a stub issuer); full suite 483 passed