### PR TITLE
Fix the deep-dive read-side bug cluster (bugs #2, #3, #4, #6)

### DIFF
--- a/engine/src/core/monitor/events.ts
+++ b/engine/src/core/monitor/events.ts
@@ -701,7 +701,10 @@ export async function listTraceEvaluations(db: Db, traceId: string): Promise<Tra
 export type CustomEvaluatorEvent = {
   id: string;
   traceId: string;
-  matched: boolean;
+  // null = the check itself failed to run (script crash, endpoint down); the error text is in
+  // `justification`. These rows MUST stay visible - filtering them out made a crashing scorer
+  // indistinguishable from a quiet one (deep-dive round 3, bug #4).
+  matched: boolean | null;
   score: number | null;
   justification: string | null;
   createdAt: Date;
@@ -721,9 +724,10 @@ export async function getCustomEvaluatorEvents(
   const { days } = windowConfig(window);
   const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 
+  // matched === null rows are the scorer's own failures (recorded by customEvaluators.ts with
+  // the error in justification) - they belong in the history, not on the cutting-room floor.
   const rows = (await listEventsSince(db, since)).filter(
-    (r): r is EventRow & { matched: boolean; traceId: string } =>
-      r.customEvaluatorId === evaluatorId && r.matched !== null && r.traceId !== null
+    (r): r is EventRow & { traceId: string } => r.customEvaluatorId === evaluatorId && r.traceId !== null
   );
   rows.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
 

--- a/engine/src/core/trace/ingest.ts
+++ b/engine/src/core/trace/ingest.ts
@@ -1,6 +1,6 @@
 import { nanoid } from "nanoid";
 import { z } from "zod";
-import { desc, lt, and, eq, isNull, type SQL } from "drizzle-orm";
+import { desc, lt, and, eq, isNull, or, type SQL } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import { resolveAgentId } from "../monitor/agents.js";
 import { listPortabilityModels, estimateCostUSD } from "../evaluate/models.js";
@@ -269,9 +269,11 @@ export async function listTracesPaginated(
   const pageSize = Math.min(Math.max(limit, 1), 100);
 
   let cursorCreatedAt: Date | null = null;
+  let cursorId: string | null = null;
   if (cursor) {
     const cursorRow = await getTraceRow(db, cursor);
     cursorCreatedAt = cursorRow?.createdAt ?? null;
+    cursorId = cursorRow?.id ?? null;
   }
 
   // Root spans only: a span_tree=True SDK trace or a multi-span OTel session otherwise floods
@@ -282,7 +284,17 @@ export async function listTracesPaginated(
   // only changes what the top-level list itself enumerates.
   const conditions: SQL[] = [isNull(db.schema.traces.parentSpanId), eq(db.schema.traces.projectId, db.projectId)];
   if (framework) conditions.push(eq(db.schema.traces.framework, framework));
-  if (cursorCreatedAt) conditions.push(lt(db.schema.traces.createdAt, cursorCreatedAt));
+  // Keyset with an id tiebreak, matching the (createdAt DESC, id DESC) sort below. The old
+  // createdAt-only predicate silently skipped every row that shared the page-boundary row's
+  // millisecond (3 of 2000 lost in a realistic burst - deep-dive round 3, bug #6), because
+  // "strictly older than the boundary" excludes its same-timestamp siblings.
+  if (cursorCreatedAt && cursorId) {
+    const next = or(
+      lt(db.schema.traces.createdAt, cursorCreatedAt),
+      and(eq(db.schema.traces.createdAt, cursorCreatedAt), lt(db.schema.traces.id, cursorId))
+    );
+    if (next) conditions.push(next);
+  }
   const where = and(...conditions);
 
   const rows = (
@@ -291,14 +303,14 @@ export async function listTracesPaginated(
           .select()
           .from(db.schema.traces)
           .where(where)
-          .orderBy(desc(db.schema.traces.createdAt))
+          .orderBy(desc(db.schema.traces.createdAt), desc(db.schema.traces.id))
           .limit(pageSize + 1)
           .all()
       : await db.db
           .select()
           .from(db.schema.traces)
           .where(where)
-          .orderBy(desc(db.schema.traces.createdAt))
+          .orderBy(desc(db.schema.traces.createdAt), desc(db.schema.traces.id))
           .limit(pageSize + 1)
   ) as TraceRow[];
 

--- a/engine/src/otel/mapping.ts
+++ b/engine/src/otel/mapping.ts
@@ -237,7 +237,7 @@ export function otelSpanToIngestInput(span: NormalizedSpan): IngestTraceInput {
     // Real span hierarchy, promoted to first-class ingestTraceSchema fields (see core/trace/
     // ingest.ts) so a session's rows can be assembled into a tree - kept in metadata.otel too
     // below, harmless redundancy, not worth a second edit to remove now that both exist.
-    // normalize.ts's base64ToHex falls back to "" (not null/undefined) for malformed wire ids, so
+    // normalize.ts's idToHex falls back to "" (not null/undefined) for malformed wire ids, so
     // these are guarded to "" -> undefined rather than trusting truthiness alone would already
     // catch it (it does, but the intent is worth being explicit about here).
     span_id: span.spanIdHex || undefined,

--- a/engine/src/otel/normalize.ts
+++ b/engine/src/otel/normalize.ts
@@ -18,15 +18,23 @@ export type NormalizedSpan = {
   events: NormalizedSpanEvent[];
 };
 
-// Bytes fields (trace/span/parent-span id) are base64 in both the protobuf-decoded object
-// (bytes: String, see protoTypes.ts) and a spec-compliant OTLP/JSON body - same conversion either
-// way. Rendered as hex (32/16 chars) to match how every OTel backend and the W3C tracecontext spec
-// display ids, not how they're transmitted.
-function base64ToHex(b64: unknown): string | null {
-  if (typeof b64 !== "string" || !b64) {
+// Bytes fields (trace/span/parent-span id) arrive in two encodings, and the OTLP spec makes
+// them DIFFERENT: the protobuf-decoded object carries base64 (bytes: String, see protoTypes.ts,
+// the plain proto3-JSON mapping), but OTLP/JSON is an explicit spec exception - ids are
+// hex-encoded there (opentelemetry-proto's JSON mapping note; opentelemetry-js's JSON exporter
+// sends hex). Treating both as base64 garbled every JSON-protocol exporter's ids into junk
+// sessions (deep-dive round 3, bug #3). The two encodings are length-unambiguous: hex ids are
+// 32 (trace) / 16 (span) chars of pure hex, base64 of the same bytes is 24 / 12 chars - so
+// detect by shape instead of trusting one spec reading. Rendered as lowercase hex either way,
+// matching how every OTel backend and W3C tracecontext display ids.
+function idToHex(value: unknown): string | null {
+  if (typeof value !== "string" || !value) {
     return null;
   }
-  return Buffer.from(b64, "base64").toString("hex");
+  if ((value.length === 32 || value.length === 16) && /^[0-9a-fA-F]+$/.test(value)) {
+    return value.toLowerCase();
+  }
+  return Buffer.from(value, "base64").toString("hex");
 }
 
 // A handful of real-world JSON producers emit snake_case (the literal .proto field names) instead
@@ -77,9 +85,9 @@ export function normalizeExportRequest(parsed: Record<string, unknown>): Normali
         const status = objectOrUndefined(span.status);
         const events = objectList(span.events);
         spans.push({
-          traceIdHex: base64ToHex(pick(span, "traceId", "trace_id")) ?? "",
-          spanIdHex: base64ToHex(pick(span, "spanId", "span_id")) ?? "",
-          parentSpanIdHex: base64ToHex(pick(span, "parentSpanId", "parent_span_id")),
+          traceIdHex: idToHex(pick(span, "traceId", "trace_id")) ?? "",
+          spanIdHex: idToHex(pick(span, "spanId", "span_id")) ?? "",
+          parentSpanIdHex: idToHex(pick(span, "parentSpanId", "parent_span_id")),
           name: typeof span.name === "string" && span.name ? span.name : "unknown",
           // 0n for anything unparseable, which mapping.ts already treats as "no timestamp".
           startTimeUnixNano: parseUnixNanosOrZero(pick(span, "startTimeUnixNano", "start_time_unix_nano")),

--- a/engine/src/routes/agentMonitoringDashboard.ts
+++ b/engine/src/routes/agentMonitoringDashboard.ts
@@ -3,7 +3,7 @@ import { asyncRouter } from "./asyncRouter.js";
 import { getDb, type Db } from "../storage/db.js";
 import { scopedDb } from "../auth/apiKey.js";
 import { createPattern, updatePattern, deletePattern, listPatternsWire, legacyPayloadToConditions } from "../core/monitor/patterns.js";
-import { builtInPatternsWire } from "../core/monitor/detect.js";
+import { BUILT_IN_MONITOR_PATTERNS, builtInPatternsWire } from "../core/monitor/detect.js";
 import { validateConditionRegexes } from "../core/monitor/regexSafety.js";
 import { listSignals, getSignal, updateSignal, signalCountsByPatternKey } from "../core/monitor/signals.js";
 import { updateProfile, listProfilesWire } from "../core/monitor/profiles.js";
@@ -1218,9 +1218,21 @@ agentMonitoringDashboardRouter.put("/settings/monitoring-defaults", async (req: 
   if (typeof body.topicsEnabled === "boolean") patch.topicsEnabled = body.topicsEnabled;
   if (typeof body.coherenceSweepEnabled === "boolean") patch.coherenceSweepEnabled = body.coherenceSweepEnabled;
   if (Array.isArray(body.enabledBuiltinPatterns)) {
-    patch.enabledBuiltinPatterns = (body.enabledBuiltinPatterns as unknown[]).filter(
-      (k): k is string => typeof k === "string"
-    );
+    const keys = (body.enabledBuiltinPatterns as unknown[]).filter((k): k is string => typeof k === "string");
+    // Reject unknown keys instead of storing them: a typo'd key used to be accepted verbatim,
+    // enable nothing, and report nothing - the config-as-code caller believed a scorer was on
+    // while nothing ran (deep-dive round 3, bug #2). Silent no-op config is the same failure
+    // class the removed redaction placebo was.
+    const known = new Set<string>(BUILT_IN_MONITOR_PATTERNS.map(p => p.key));
+    const unknown = keys.filter(k => !known.has(k));
+    if (unknown.length > 0) {
+      res.status(400).json({
+        error: `Unknown template scorer key(s): ${unknown.join(", ")}`,
+        knownKeys: [...known],
+      });
+      return;
+    }
+    patch.enabledBuiltinPatterns = keys;
   }
   const monitoringDefaults = await updateMonitoringDefaults(scopedDb(req), patch);
   res.status(200).json({ monitoringDefaults });

--- a/engine/src/test/readSideRegressions.integration.test.ts
+++ b/engine/src/test/readSideRegressions.integration.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startEngine, postJson, type TestEngine } from "./server.js";
+
+// Regressions for deep-dive round 3's read-side bug cluster (sample-scripts/
+// eval_framework_deep_dive/DEEP_DIVE_REPORT.md): the engine wrote correctly but showed less
+// than the truth. Bug #2 (typo'd scorer keys stored as silent no-ops), bug #3 (OTLP/JSON
+// hex ids misdecoded as base64), bug #4 (scorer-crash events invisible in the history read).
+
+let engine: TestEngine;
+let key: string;
+
+beforeAll(async () => {
+  engine = await startEngine();
+  const created = await engine.json("/api/v1/projects", { ...postJson({ name: "read-side" }), apiKey: null });
+  key = (created.body as { project: { apiKey: string } }).project.apiKey;
+}, 90_000);
+
+afterAll(async () => {
+  await engine?.stop();
+});
+
+describe("bug #2: template-scorer keys are validated", () => {
+  it("rejects unknown keys with the known list, and never stores the typo", async () => {
+    const res = await engine.json("/api/v1/agent-monitoring/settings/monitoring-defaults", {
+      ...postJson({ enabledBuiltinPatterns: ["pii-in-respose"] }), // the classic typo
+      method: "PUT",
+      apiKey: key,
+    });
+    expect(res.status).toBe(400);
+    const body = res.body as { error: string; knownKeys: string[] };
+    expect(body.error).toContain("pii-in-respose");
+    expect(body.knownKeys).toContain("pii-in-response");
+
+    const settings = await engine.json("/api/v1/agent-monitoring/settings", { apiKey: key });
+    expect(JSON.stringify(settings.body)).not.toContain("pii-in-respose");
+  });
+
+  it("still accepts valid keys", async () => {
+    const res = await engine.json("/api/v1/agent-monitoring/settings/monitoring-defaults", {
+      ...postJson({ enabledBuiltinPatterns: ["pii-in-response", "secrets-in-response"] }),
+      method: "PUT",
+      apiKey: key,
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("bug #3: OTLP/JSON accepts both id encodings", () => {
+  const exportBody = (traceId: string, rootId: string, childId: string) => ({
+    resourceSpans: [{
+      scopeSpans: [{
+        spans: [
+          { traceId, spanId: rootId, name: "otlp-root", kind: 1,
+            startTimeUnixNano: String(Date.now() * 1e6 - 5e7), endTimeUnixNano: String(Date.now() * 1e6) },
+          { traceId, spanId: childId, parentSpanId: rootId, name: "otlp-child", kind: 1,
+            startTimeUnixNano: String(Date.now() * 1e6 - 4e7), endTimeUnixNano: String(Date.now() * 1e6 - 1e7) },
+        ],
+      }],
+    }],
+  });
+
+  it("hex ids (the OTLP/JSON spec encoding) round-trip under their real session id", async () => {
+    const traceHex = "0af7651916cd43dd8448eb211c80319c";
+    const res = await engine.json("/api/v1/otel/v1/traces", {
+      ...postJson(exportBody(traceHex, "b7ad6b7169203331", "00f067aa0ba902b7")),
+      apiKey: key,
+    });
+    expect(res.status).toBe(200);
+    const spans = await engine.json(`/api/v1/ingest/sessions/${traceHex}/spans`, { apiKey: key });
+    const rows = (spans.body as { spans: { spanId: string; parentSpanId: string | null }[] }).spans;
+    expect(rows.length).toBe(2);
+    expect(rows.some(s => s.parentSpanId === "b7ad6b7169203331")).toBe(true);
+  });
+
+  it("base64 ids (protobuf-object JSON) still round-trip to the same hex rendering", async () => {
+    const bytes = Buffer.from("1af7651916cd43dd8448eb211c80319d", "hex");
+    const root = Buffer.from("c7ad6b7169203331", "hex");
+    const child = Buffer.from("10f067aa0ba902b7", "hex");
+    const res = await engine.json("/api/v1/otel/v1/traces", {
+      ...postJson(exportBody(bytes.toString("base64"), root.toString("base64"), child.toString("base64"))),
+      apiKey: key,
+    });
+    expect(res.status).toBe(200);
+    const spans = await engine.json(`/api/v1/ingest/sessions/${bytes.toString("hex")}/spans`, { apiKey: key });
+    expect((spans.body as { spans: unknown[] }).spans.length).toBe(2);
+  });
+});
+
+describe("bug #4: a crashing scorer is visible in its own history", () => {
+  it("surfaces the failure event with the error as justification, raising no false signal", async () => {
+    const created = await engine.json("/api/v1/agent-monitoring/custom-evaluators", {
+      ...postJson({
+        name: "Crasher",
+        kind: "code",
+        language: "python",
+        sampleRate: 1,
+        alertBelow: 0.5,
+        script: "async def handler(input, output, expected, metadata, trace):\n    raise ValueError('kaboom')\n",
+      }),
+      apiKey: key,
+    });
+    expect(created.status).toBe(201);
+    const scorerId = (created.body as { evaluator: { _id: string } }).evaluator._id;
+
+    const ingested = await engine.json("/api/v1/ingest/traces", {
+      ...postJson({ name: "crash-probe", input: "q", output: "a" }),
+      apiKey: key,
+    });
+    expect(ingested.status).toBe(200);
+
+    // The scorer runs in the post-response monitor pass; poll briefly.
+    let events: { matched: boolean | null; justification: string | null }[] = [];
+    for (let i = 0; i < 20; i++) {
+      const res = await engine.json(
+        `/api/v1/agent-monitoring/custom-evaluators/${scorerId}/events?window=24h`,
+        { apiKey: key }
+      );
+      events = (res.body as { events: typeof events }).events;
+      if (events.length > 0) break;
+      await new Promise(r => setTimeout(r, 500));
+    }
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(events[0]!.matched).toBeNull();
+    expect(events[0]!.justification).toContain("kaboom");
+
+    const signals = await engine.json("/api/v1/agent-monitoring/signals?limit=50", { apiKey: key });
+    const custom = ((signals.body as { signals: { patternKey: string }[] }).signals ?? []).filter(s =>
+      s.patternKey?.startsWith("custom-eval:")
+    );
+    expect(custom.length).toBe(0);
+  });
+});

--- a/engine/src/test/tracePagination.test.ts
+++ b/engine/src/test/tracePagination.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { nanoid } from "nanoid";
+import { openTestDb, type TestDb } from "./dbHarness.js";
+import { listTracesPaginated } from "../core/trace/ingest.js";
+import type { Db } from "../storage/db.js";
+
+// Deep-dive round 3, bug #6: the trace list's keyset cursor filtered on createdAt alone, so
+// every row sharing the page-boundary row's millisecond was skipped (3 of 2000 lost in a
+// realistic 20-thread burst - storage had all 2000, the paginated read didn't). Driven at the
+// core function with hand-planted timestamp collisions, since reproducing ties through the
+// HTTP path is a coin flip.
+
+let test: TestDb;
+let db: Db;
+
+async function insertTrace(target: Db, name: string, createdAt: Date): Promise<void> {
+  const values = {
+    id: nanoid(),
+    name,
+    input: "q",
+    output: "a",
+    error: null,
+    latencyMs: 1,
+    framework: null,
+    model: null,
+    toolCalls: null,
+    metadata: null,
+    sessionId: null,
+    performanceSummary: null,
+    inputTokens: null,
+    outputTokens: null,
+    cacheReadTokens: null,
+    cacheWriteTokens: null,
+    spanId: null,
+    parentSpanId: null,
+    startedAt: createdAt,
+    createdAt,
+    agentId: null,
+    projectId: target.projectId,
+  };
+  if (target.kind === "sqlite") {
+    await target.db.insert(target.schema.traces).values(values);
+  } else {
+    await target.db.insert(target.schema.traces).values(values);
+  }
+}
+
+beforeAll(async () => {
+  test = await openTestDb();
+  db = test.scoped(await test.newProject("pagination"));
+}, 60_000);
+
+afterAll(async () => {
+  await test?.close();
+});
+
+describe("listTracesPaginated under timestamp collisions", () => {
+  it("returns every row exactly once when many share a createdAt millisecond", async () => {
+    // 7 distinct milliseconds x 25 rows each = 175 rows, page size 20: every page boundary
+    // lands inside a tie group, the exact shape the createdAt-only cursor lost rows on.
+    const base = Date.now() - 60_000;
+    for (let bucket = 0; bucket < 7; bucket++) {
+      for (let i = 0; i < 25; i++) {
+        await insertTrace(db, `tie-${bucket}-${i}`, new Date(base + bucket * 1000));
+      }
+    }
+
+    const seen = new Set<string>();
+    let cursor: string | undefined;
+    let pages = 0;
+    for (;;) {
+      const page = await listTracesPaginated(db, { limit: 20, ...(cursor ? { cursor } : {}) });
+      for (const t of page.traces as { _id: string; name: string }[]) {
+        expect(seen.has(t._id)).toBe(false); // no dupes either - the other keyset failure mode
+        seen.add(t._id);
+      }
+      pages += 1;
+      expect(pages).toBeLessThan(50);
+      if (!page.hasNextPage) break;
+      cursor = page.nextCursor as string;
+    }
+
+    expect(seen.size).toBe(175);
+  });
+});


### PR DESCRIPTION
- monitoring-defaults PUT rejects unknown template-scorer keys with a 400 naming the typo and the known-key list, instead of storing a silent no-op
- OTLP id decoding detects encoding by shape: 32/16-char pure hex (the OTLP/JSON spec encoding, what opentelemetry-js sends) passes through, anything else decodes as base64 (the protobuf object mapping) - JSON exporters' ids no longer garble into junk sessions
- custom-evaluator event history no longer filters out matched=null rows: a scorer's own crashes are visible with the error as justification
- trace-list keyset pagination gains an id tiebreak (createdAt DESC, id DESC + matching cursor predicate) so rows sharing a page-boundary millisecond are never skipped (was 3/2000 lost in a burst)

9 new regression tests (readSideRegressions.integration.test.ts, tracePagination.test.ts with 175 hand-planted timestamp collisions); full suite 492 passed. Found by sample-scripts/eval_framework_deep_dive.