### PR TITLE
Runs carry _id alongside runId, like every sibling resource

### DIFF
--- a/engine/src/core/evaluate/runs.ts
+++ b/engine/src/core/evaluate/runs.ts
@@ -718,6 +718,11 @@ export async function getRun(db: Db, runId: string) {
   }));
 
   return {
+    // Every other /custom-agent-evaluations resource keys on _id (datasets.ts,
+    // evaluationSettings.ts, ...); runs historically keyed on runId, which the
+    // Python SDK's models alias and therefore must keep. Carry both, equal, so
+    // a consumer iterating mixed resources can read _id everywhere.
+    _id: run.id,
     runId: run.id,
     datasetId: run.datasetId,
     evaluationSettingsId: run.evaluationSettingsId,
@@ -1234,7 +1239,7 @@ export async function listRuns(db: Db, limit = 50) {
   return Promise.all(
     rows.slice(0, limit).map(async row => {
       const summary = await getRun(db, row.id);
-      return summary ?? { runId: row.id, datasetId: row.datasetId, status: row.status, resultCount: 0, averageRating: null };
+      return summary ?? { _id: row.id, runId: row.id, datasetId: row.datasetId, status: row.status, resultCount: 0, averageRating: null };
     })
   );
 }

--- a/engine/src/test/dialect.integration.test.ts
+++ b/engine/src/test/dialect.integration.test.ts
@@ -377,15 +377,30 @@ describe.skipIf(!postgresAvailable)("Postgres-specific behaviour", () => {
   }, 60_000);
 
   it("counts every simultaneous detection into one signal, losing none", async () => {
-    // Detection runs in detached post-ingest work, so a burst of failing traces all reach
+    // Detection runs in detached post-ingest work, so a burst of flagged traces all reach
     // upsertSignal having seen no existing signal row. Before this was made atomic, one insert
     // violated monitor_signals_pattern_key_agent_id and that trace's detection was dropped with
     // only a log line, while the survivors each wrote back a count they had read a moment
     // earlier - twelve detections were reported as five.
+    //
+    // The scorers redesign retired this test's original trigger: trace errors are operational
+    // KPI events now, not signals ("no signals" by design), and the remaining built-in scorers
+    // are opt-in via enabledBuiltinPatterns - nothing runs until enabled. The atomicity this
+    // test guards is unchanged, so it now opts a live scorer in and bursts through that.
+    const enable = await engine.request("/api/v1/agent-monitoring/settings/monitoring-defaults", {
+      method: "PUT",
+      body: JSON.stringify({ enabledBuiltinPatterns: ["pii-in-response"] }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(enable.status, JSON.stringify(enable.body)).toBe(200);
+
     const count = 12;
     await Promise.all(
       Array.from({ length: count }, (_, i) =>
-        engine.json("/api/v1/ingest/traces", post({ name: "pg-signal-agent", span_id: `pg-sig-${i}`, input: "q", output: "", error: "Boom" }))
+        engine.json(
+          "/api/v1/ingest/traces",
+          post({ name: "pg-signal-agent", span_id: `pg-sig-${i}`, input: "q", output: "reach me at pg-burst@example.com" })
+        )
       )
     );
 
@@ -394,7 +409,7 @@ describe.skipIf(!postgresAvailable)("Postgres-specific behaviour", () => {
     while (Date.now() < deadline) {
       const res = await engine.json("/api/v1/agent-monitoring/signals?limit=100&polarity=all");
       rows = ((res.body as { signals?: { patternKey?: string; occurrenceCount?: number }[] }).signals ?? []).filter(
-        s => s.patternKey === "agent-trace-error"
+        s => s.patternKey === "pii-in-response"
       );
       if (rows[0] && (rows[0].occurrenceCount ?? 0) >= count) break;
       await new Promise(r => setTimeout(r, 250));

--- a/engine/src/test/evaluate.integration.test.ts
+++ b/engine/src/test/evaluate.integration.test.ts
@@ -162,6 +162,27 @@ describe("evaluation run loop", () => {
     }
   });
 
+  it("carries _id alongside runId, like every sibling resource", async () => {
+    // datasets and evaluation-settings rows key on _id; runs historically keyed on runId
+    // (which the Python SDK aliases, so it stays). Both must be present and equal, on the
+    // single-run read and on every list row - a consumer iterating mixed resources reads
+    // _id everywhere without special-casing runs.
+    const one = await engine.json(`/api/v1/custom-agent-evaluations/runs/${runId}`);
+    expect(one.status).toBe(200);
+    const single = one.body as { _id?: string; runId?: string };
+    expect(single._id, "single run carries _id").toBe(runId);
+    expect(single.runId, "runId stays for the SDK").toBe(runId);
+
+    const list = await engine.json("/api/v1/custom-agent-evaluations/runs");
+    expect(list.status).toBe(200);
+    const rows = (list.body as { runs?: { _id?: string; runId?: string }[] }).runs ?? [];
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row._id, "list row carries _id").toBeTypeOf("string");
+      expect(row.runId, "list row keeps runId").toBe(row._id);
+    }
+  });
+
   it("finalizes the run", async () => {
     const finalized = await engine.json(`/api/v1/custom-agent-evaluations/runs/${runId}/finalize`, { method: "POST" });
     expect(finalized.status, JSON.stringify(finalized.body)).toBe(200);


### PR DESCRIPTION
Every other `/custom-agent-evaluations` resource keys its rows on `_id` — `datasets.ts`, `evaluationSettings.ts`, `agentConnectors.ts`, `playgroundRuns.ts` all map `_id: row.id`. Runs alone keyed on `runId`.

`runId` is load-bearing — agentx-python's models alias it (`run_id: str = Field(alias="runId")`, three models) — so this is **additive**: `getRun()` returns both, equal, and `listRuns()`'s fallback row does the same. A consumer iterating mixed resources now reads `_id` everywhere without special-casing runs; nothing that reads `runId` changes.

**Provenance:** found by the run-eval skill's live link check ([AgentX-Eval-Skill#29](https://github.com/AgentX-ai/AgentX-Eval-Skill/pull/29)) — its first FAIL was exactly this, because every other endpoint had taught it to expect `_id`.

**Tests:** new integration case asserts both fields on the single-run read and on every list row. Verified it fires: with the fix stashed it fails with `expected undefined to be 'o2h7…'`. Full engine suite 493 passed / 37 skipped, three consecutive clean runs (one unrelated flake in an initial run did not reproduce, including on unmodified main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)