### PR TITLE
feat: two grading modes - criteria-anchored judging on both surfaces

### DIFF
--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -172,6 +172,8 @@ export const judgeScorerSchema = z
         judgePrompt: z.string().optional(),
         judgeModel: z.string().optional(),
         toolContext: z.enum(["none", "simple", "detailed"]),
+        // Reference-centric rubric: offline-only, online enable is a 409.
+        requiresExpected: z.boolean(),
       })
       .strict(),
     offline: z

--- a/engine/src/core/evaluate/evaluationSettings.ts
+++ b/engine/src/core/evaluate/evaluationSettings.ts
@@ -42,6 +42,10 @@ export type CreateEvaluationSettingsInput = {
   // How much tool context the judge sees: "none" | "simple" | "detailed" (see the schema
   // column). Defaults to "simple", the historical behavior.
   toolContext?: JudgeToolContext;
+  // Reference-centric rubric: meaningless without a case's expected_results (RAG: Contextual
+  // Recall, or a custom "matches the reference" prompt). Online enable is refused and offline
+  // runs skip reference-less items. Default false.
+  requiresExpected?: boolean;
   // Set ONLY by the engine's seed paths (Example judge, RAG metric packs): marks quick-start
   // template rows so the dashboard can tell a clean account from one the user built in. Not
   // accepted from any write surface, never inherited by clones, immutable after create.
@@ -66,6 +70,7 @@ export type EvaluationSettingsRow = {
   isDefault: boolean;
   status: string;
   toolContext: string;
+  requiresExpected: boolean;
   seeded: boolean;
   createdAt: Date;
 };
@@ -86,6 +91,7 @@ function toWire(row: EvaluationSettingsRow) {
     isDefault: row.isDefault,
     status: row.status,
     toolContext: normalizeToolContext(row.toolContext),
+    requiresExpected: row.requiresExpected ?? false,
     seeded: row.seeded ?? false,
     createdAt: row.createdAt,
   };
@@ -126,6 +132,7 @@ export async function createEvaluationSettings(db: Db, input: CreateEvaluationSe
     isDefault: input.isDefault ?? false,
     status: input.status ?? "published",
     toolContext: normalizeToolContext(input.toolContext),
+    requiresExpected: input.requiresExpected ?? false,
     seeded: input.seeded ?? false,
     createdAt: new Date(),
   };
@@ -202,6 +209,7 @@ export async function patchEvaluationSettings(db: Db, id: string, patch: Partial
     isDefault: patch.isDefault ?? existing.isDefault,
     status: patch.status ?? existing.status,
     toolContext: patch.toolContext !== undefined ? normalizeToolContext(patch.toolContext) : existing.toolContext,
+    requiresExpected: patch.requiresExpected ?? existing.requiresExpected,
   };
   const patchCond = and(eq(db.schema.evaluationSettings.id, id), eq(db.schema.evaluationSettings.projectId, db.projectId));
   if (db.kind === "sqlite") {

--- a/engine/src/core/evaluate/metricPack.ts
+++ b/engine/src/core/evaluate/metricPack.ts
@@ -21,6 +21,8 @@ type PackConfig = {
   rejectionCriteria: string;
   evaluationCriteria: string;
   judgePrompt?: string;
+  // Reference-centric rubric (offline-only) - see evaluationSettings.requiresExpected.
+  requiresExpected?: boolean;
 };
 
 const METRIC_PACK: PackConfig[] = [
@@ -97,6 +99,7 @@ For each chunk, decide whether it is relevant to the query, then rate how well t
   },
   {
     name: "RAG: Contextual Recall",
+    requiresExpected: true,
     // v2 - offline-focused: {expected} comes from the dataset case's reference answer.
     description:
       "Does the retrieved context cover everything the EXPECTED answer needs? Offline metric (needs a reference answer) - a low score means retrieval is missing source material.",
@@ -137,6 +140,7 @@ export async function ensureMetricPackConfigs(db: Db): Promise<number> {
       rejectionCriteria: config.rejectionCriteria,
       evaluationCriteria: config.evaluationCriteria,
       judgePrompt: config.judgePrompt,
+      requiresExpected: config.requiresExpected ?? false,
       seeded: true,
     });
     created++;

--- a/engine/src/core/evaluate/runs.ts
+++ b/engine/src/core/evaluate/runs.ts
@@ -70,6 +70,9 @@ type ResolvedRunConfig = {
   // The judge's tool-context level (settings-only - datasets have no such column):
   // "none" | "simple" (default, the historical trajectory behavior) | "detailed".
   toolContext: string;
+  // Reference-centric rubric (RAG: Contextual Recall etc.): items without expectedResults are
+  // skipped with an explicit reason instead of judging an empty reference.
+  requiresExpected: boolean;
   similarityConfig: SimilarityConfig;
   codeScorers: CodeScorerConfig[];
   questions: Array<{
@@ -112,6 +115,7 @@ export async function resolveRunConfig(
     judgePrompt: (settings?.judgePrompt ?? "").trim() || DEFAULT_JUDGE_PROMPT,
     judgeModel: settings?.judgeModel ?? DEFAULT_JUDGE_MODEL,
     toolContext: settings?.toolContext ?? "simple",
+    requiresExpected: settings?.requiresExpected ?? false,
     similarityConfig: (source?.similarityConfig as SimilarityConfig | null) ?? {},
     codeScorers: ((source?.codeScorers as CodeScorerConfig[] | null) ?? []).filter(s => s.enabled),
     questions,
@@ -319,27 +323,38 @@ async function scoreOneResult(db: Db, config: ResolvedRunConfig, item: Submitted
     !resultContext && item.traceId ? await getTraceRetrievalContext(db, item.traceId).catch(() => null) : null;
   const retrievalContext = resultContext ?? traceContext ?? mainQ?.retrievalContext;
 
+  // Two grading modes: a reference-centric rubric has nothing to grade without this item's
+  // expected results - skip the judge call (rating null, explicit reason) rather than let it
+  // score an empty reference. Similarity/code scorers still run; they have their own inputs.
+  const judgePromise: Promise<{ rating: number | null; justification: string; judgeError: Error | null }> =
+    config.requiresExpected && !expected
+      ? Promise.resolve({
+          rating: null,
+          justification:
+            "Skipped: this scorer needs a reference answer (requiresExpected) and the case has no expected results.",
+          judgeError: null,
+        })
+      : scoreAgainstCriteria(config, {
+          input: item.input?.query || "",
+          output: actual || "",
+          expected,
+          judgeGuideline: mainQ?.judgeGuideline,
+          // For {context}-referencing judge prompts (the RAG metric pack) - dynamic per-result
+          // context first, then linked-trace retrievals, then the case's pinned chunks.
+          context: retrievalContext,
+          // "none" strips the trajectory too - conversation + expected results only.
+          trajectory: config.toolContext !== "none" ? (trajectory ?? undefined) : undefined,
+          toolDefinitions: itemToolDefinitions ?? undefined,
+        }).then(
+          result => ({ ...result, judgeError: null as Error | null }),
+          (err: unknown) => ({
+            rating: null,
+            justification: "",
+            judgeError: err instanceof Error ? err : new Error(String(err)),
+          })
+        );
   const [judged, vectorSimilarity, jaccardSimilarity, bleuScore, rougeScore, codeScorerResults] = await Promise.all([
-    // Resolved, never rejected - the same isolation the code scorers below already have.
-    scoreAgainstCriteria(config, {
-      input: item.input?.query || "",
-      output: actual || "",
-      expected,
-      judgeGuideline: mainQ?.judgeGuideline,
-      // For {context}-referencing judge prompts (the RAG metric pack) - dynamic per-result
-      // context first, then linked-trace retrievals, then the case's pinned chunks.
-      context: retrievalContext,
-      // "none" strips the trajectory too - conversation + expected results only.
-      trajectory: config.toolContext !== "none" ? (trajectory ?? undefined) : undefined,
-      toolDefinitions: itemToolDefinitions ?? undefined,
-    }).then(
-      result => ({ ...result, judgeError: null as Error | null }),
-      (err: unknown) => ({
-        rating: null,
-        justification: "",
-        judgeError: err instanceof Error ? err : new Error(String(err)),
-      })
-    ),
+    judgePromise,
     config.similarityConfig.vectorSimilarity?.enabled
       ? computeVectorSimilarity(expected, actual, config.similarityConfig.vectorSimilarity.model)
       : Promise.resolve(null),

--- a/engine/src/core/monitor/judgeScorers.ts
+++ b/engine/src/core/monitor/judgeScorers.ts
@@ -44,6 +44,8 @@ export type JudgeScorerJudgeInput = {
   // "detailed" (simple + definitions for the tools actually used + a one-line unused-tools
   // mention). See evaluation_settings.toolContext.
   toolContext?: string;
+  // Reference-centric rubric: offline-only. Enabling online scoring on such a scorer is a 409.
+  requiresExpected?: boolean;
 };
 
 export type JudgeScorerOfflineInput = {
@@ -119,6 +121,9 @@ export function toJudgeScorerWire(settings: EvaluationSettingsRow, evaluator: On
       judgePrompt: settings.judgePrompt ?? undefined,
       judgeModel: settings.judgeModel ?? undefined,
       toolContext: normalizeToolContext(settings.toolContext),
+      // Reference-centric rubric: offline-only (online enable is refused, reference-less
+      // offline items are skipped) - the "two grading modes" exception flag.
+      requiresExpected: settings.requiresExpected ?? false,
     },
     offline: {
       numberOfRequests: settings.numberOfRequests,
@@ -203,6 +208,7 @@ export async function createJudgeScorer(db: Db, input: CreateJudgeScorerInput) {
     judgePrompt: input.judge?.judgePrompt,
     judgeModel: input.judge?.judgeModel,
     toolContext: input.judge?.toolContext !== undefined ? normalizeToolContext(input.judge.toolContext) : undefined,
+    requiresExpected: input.judge?.requiresExpected,
     isDefault: input.offline?.isDefault,
     status: input.offline?.status,
   });
@@ -252,6 +258,7 @@ export async function updateJudgeScorer(db: Db, id: string, patch: UpdateJudgeSc
       if (patch.judge[key] !== undefined) settingsPatch[key] = patch.judge[key];
     }
     if (patch.judge.toolContext !== undefined) settingsPatch.toolContext = normalizeToolContext(patch.judge.toolContext);
+    if (patch.judge.requiresExpected !== undefined) settingsPatch.requiresExpected = patch.judge.requiresExpected;
   }
   if (patch.offline) {
     if (patch.offline.numberOfRequests !== undefined) settingsPatch.numberOfRequests = patch.offline.numberOfRequests;

--- a/engine/src/core/monitor/onlineEvaluators.ts
+++ b/engine/src/core/monitor/onlineEvaluators.ts
@@ -86,6 +86,21 @@ function toWire(row: OnlineEvaluatorRow) {
 // "name is required" validation error.
 export class InvalidEvaluationSettingsIdError extends Error {}
 
+// Two grading modes: a reference-centric rubric (requiresExpected - e.g. RAG: Contextual Recall)
+// has nothing to grade on live traffic, where no trace carries expected results. Enabling it
+// online would produce confident-looking scores of nothing, so the engine refuses loudly (409)
+// on BOTH surfaces (this legacy one and judgeScorers.ts's unified one route through here).
+export class ReferenceCentricScorerError extends Error {}
+
+async function assertScorableOnline(db: Db, evaluationSettingsId: string): Promise<void> {
+  const row = await getEvaluationSettingsRow(db, evaluationSettingsId);
+  if (row?.requiresExpected) {
+    throw new ReferenceCentricScorerError(
+      `"${row.name}" needs a reference answer (requiresExpected) - it can only grade offline dataset runs, not live traffic. Disable requiresExpected or keep live scoring off.`
+    );
+  }
+}
+
 async function assertEvaluationSettingsExists(db: Db, evaluationSettingsId: string): Promise<void> {
   const row = await getEvaluationSettingsRow(db, evaluationSettingsId);
   if (!row) {
@@ -130,6 +145,9 @@ async function resolveBindableSettingsId(db: Db, evaluationSettingsId: string, s
 
 export async function createOnlineEvaluator(db: Db, input: CreateOnlineEvaluatorInput) {
   const evaluationSettingsId = await resolveBindableSettingsId(db, input.evaluationSettingsId);
+  if (input.enabled !== false) {
+    await assertScorableOnline(db, evaluationSettingsId);
+  }
   const row: OnlineEvaluatorRow = {
     id: nanoid(),
     projectId: db.projectId,
@@ -214,6 +232,11 @@ export async function updateOnlineEvaluator(db: Db, id: string, input: UpdateOnl
     scope: input_.scope !== undefined ? (input_.scope === "session" ? "session" : "trace") : existing.scope,
     idleSeconds: input_.idleSeconds ?? existing.idleSeconds,
   };
+  // Gate on the POST-patch state: an update that flips enabled on (or repoints the binding)
+  // for a reference-centric rubric is the same mistake as creating it enabled.
+  if (updated.enabled && updated.evaluationSettingsId) {
+    await assertScorableOnline(db, updated.evaluationSettingsId);
+  }
   const setValues = {
     name: updated.name,
     evaluationSettingsId: updated.evaluationSettingsId,

--- a/engine/src/routes/agentMonitoringDashboard.ts
+++ b/engine/src/routes/agentMonitoringDashboard.ts
@@ -52,6 +52,7 @@ import {
   listOnlineEvaluatorsWire,
   getOnlineEvaluatorRow,
   InvalidEvaluationSettingsIdError,
+  ReferenceCentricScorerError,
 } from "../core/monitor/onlineEvaluators.js";
 import {
   BuiltinJudgeScorerError,
@@ -503,6 +504,10 @@ agentMonitoringDashboardRouter.post("/online-evaluators", async (req: Request, r
       res.status(400).json({ error: err.message });
       return;
     }
+    if (err instanceof ReferenceCentricScorerError) {
+      res.status(409).json({ error: err.message });
+      return;
+    }
     throw err;
   }
 });
@@ -534,6 +539,10 @@ agentMonitoringDashboardRouter.put("/online-evaluators/:evaluatorId", async (req
   } catch (err) {
     if (err instanceof InvalidEvaluationSettingsIdError) {
       res.status(400).json({ error: err.message });
+      return;
+    }
+    if (err instanceof ReferenceCentricScorerError) {
+      res.status(409).json({ error: err.message });
       return;
     }
     throw err;
@@ -618,14 +627,22 @@ agentMonitoringDashboardRouter.post("/judge-scorers", async (req: Request, res: 
   const online = parsed.online
     ? { ...parsed.online, agentIds: await resolveAgentIds(scopedDb(req), parsed.online.agentIds) }
     : parsed.online;
-  const judgeScorer = await createJudgeScorer(scopedDb(req), {
-    name: body.name.trim(),
-    description: typeof body.description === "string" ? body.description : undefined,
-    judge: body.judge && typeof body.judge === "object" ? body.judge : undefined,
-    offline: body.offline && typeof body.offline === "object" ? body.offline : undefined,
-    online,
-  });
-  res.status(201).json({ judgeScorer });
+  try {
+    const judgeScorer = await createJudgeScorer(scopedDb(req), {
+      name: body.name.trim(),
+      description: typeof body.description === "string" ? body.description : undefined,
+      judge: body.judge && typeof body.judge === "object" ? body.judge : undefined,
+      offline: body.offline && typeof body.offline === "object" ? body.offline : undefined,
+      online,
+    });
+    res.status(201).json({ judgeScorer });
+  } catch (err) {
+    if (err instanceof ReferenceCentricScorerError) {
+      res.status(409).json({ error: err.message });
+      return;
+    }
+    throw err;
+  }
 });
 
 agentMonitoringDashboardRouter.put("/judge-scorers/:id", async (req: Request, res: Response) => {
@@ -652,7 +669,7 @@ agentMonitoringDashboardRouter.put("/judge-scorers/:id", async (req: Request, re
     }
     res.status(200).json({ judgeScorer });
   } catch (err) {
-    if (err instanceof BuiltinJudgeScorerError) {
+    if (err instanceof BuiltinJudgeScorerError || err instanceof ReferenceCentricScorerError) {
       res.status(409).json({ error: err.message });
       return;
     }
@@ -669,7 +686,7 @@ agentMonitoringDashboardRouter.delete("/judge-scorers/:id", async (req: Request,
     }
     res.status(204).send();
   } catch (err) {
-    if (err instanceof BuiltinJudgeScorerError) {
+    if (err instanceof BuiltinJudgeScorerError || err instanceof ReferenceCentricScorerError) {
       res.status(409).json({ error: err.message });
       return;
     }

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -1040,6 +1040,8 @@ function bootstrapSqlite(sqlite: SqliteHandle): void {
     // Sampling simplification: Topics gets its own rate; the legacy coverage_mode/sample_rate
     // pair stays writable but unread (see schema.sqlite.ts's projects.coverageMode block).
     ["projects", "ALTER TABLE projects ADD COLUMN topics_sample_rate REAL NOT NULL DEFAULT 1"],
+    // Two grading modes: reference-centric rubrics are offline-only (see schema comment).
+    ["evaluation_settings", "ALTER TABLE evaluation_settings ADD COLUMN requires_expected INTEGER NOT NULL DEFAULT 0"],
     ["app_settings", "ALTER TABLE app_settings ADD COLUMN auth_secret TEXT"],
     ["app_settings", "ALTER TABLE app_settings ADD COLUMN metric_pack_seeded_at INTEGER"],
     ["app_settings", "ALTER TABLE app_settings ADD COLUMN metric_pack_version INTEGER"],
@@ -1073,6 +1075,10 @@ function bootstrapSqlite(sqlite: SqliteHandle): void {
   if (!topicsSampleRateColumnPreexists) {
     sqlite.exec(`UPDATE projects SET topics_sample_rate = sample_rate WHERE coverage_mode = 'sampled'`);
   }
+
+  // Safe to run every boot: only seeded metric-pack rows are touched, and the flag is what the
+  // seed would have written (a user clearing it on a CLONE is unaffected - clones aren't seeded).
+  sqlite.exec(`UPDATE evaluation_settings SET requires_expected = 1 WHERE seeded = 1 AND name = 'RAG: Contextual Recall'`);
 
   ensureTraceSpanIdUnique(statement => sqlite.exec(statement));
   ensureVersionUnique(statement => sqlite.exec(statement));
@@ -2096,6 +2102,7 @@ async function bootstrapPostgres(pool: Pool): Promise<void> {
     ALTER TABLE outcome_reports ADD COLUMN IF NOT EXISTS is_negative BOOLEAN NOT NULL DEFAULT false;
     ALTER TABLE projects ADD COLUMN IF NOT EXISTS topics_enabled BOOLEAN NOT NULL DEFAULT false;
     ALTER TABLE projects ADD COLUMN IF NOT EXISTS topics_sample_rate DOUBLE PRECISION NOT NULL DEFAULT 1;
+    ALTER TABLE evaluation_settings ADD COLUMN IF NOT EXISTS requires_expected BOOLEAN NOT NULL DEFAULT false;
     ALTER TABLE projects ADD COLUMN IF NOT EXISTS coherence_sweep_enabled BOOLEAN NOT NULL DEFAULT true;
     ALTER TABLE projects ADD COLUMN IF NOT EXISTS disabled_builtin_patterns JSONB;
     ALTER TABLE projects ADD COLUMN IF NOT EXISTS enabled_builtin_patterns JSONB;
@@ -2140,6 +2147,9 @@ async function bootstrapPostgres(pool: Pool): Promise<void> {
   if (!topicsSampleRateColumnPreexists) {
     await pool.query(`UPDATE projects SET topics_sample_rate = sample_rate WHERE coverage_mode = 'sampled'`);
   }
+
+  // See bootstrapSqlite's identical seeded-Recall backfill comment.
+  await pool.query(`UPDATE evaluation_settings SET requires_expected = true WHERE seeded = true AND name = 'RAG: Contextual Recall'`);
 
   await migrateOnlineEvaluatorsToConfigsPostgres(pool);
   await enforceJudgeScorerCardinalityPostgres(pool);

--- a/engine/src/storage/schema.pg.ts
+++ b/engine/src/storage/schema.pg.ts
@@ -92,6 +92,7 @@ export const evaluationSettings = pgTable("evaluation_settings", {
   isDefault: boolean("is_default").notNull().default(false),
   status: text("status").notNull().default("published"),
   toolContext: text("tool_context").notNull().default("simple"),
+  requiresExpected: boolean("requires_expected").notNull().default(false),
   // Engine-seeded template rows (Example judge, RAG metric packs) - see schema.sqlite.ts.
   seeded: boolean("seeded").notNull().default(false),
   createdAt: timestamp("created_at", { mode: "date" }).notNull(),

--- a/engine/src/storage/schema.sqlite.ts
+++ b/engine/src/storage/schema.sqlite.ts
@@ -162,6 +162,10 @@ export const evaluationSettings = sqliteTable("evaluation_settings", {
   // metadata.tools first with the registry as a by-name fallback, plus a one-line mention of
   // advertised-but-unused tools).
   toolContext: text("tool_context").notNull().default("simple"),
+  // Reference-centric rubric: the judge's task is meaningless without a dataset case's
+  // expected_results (e.g. RAG: Contextual Recall). Gates online enable (409) and skips
+  // reference-less items in offline runs - see the "two grading modes" docs section.
+  requiresExpected: integer("requires_expected", { mode: "boolean" }).notNull().default(false),
   // True for rows the engine itself seeded (the Example judge, the RAG metric packs): quick-start
   // templates, not the user's own scorers. The dashboard's first-run starter state keys on it -
   // never inherited by clones, never settable through the write surfaces.

--- a/engine/src/test/judgeScorers.integration.test.ts
+++ b/engine/src/test/judgeScorers.integration.test.ts
@@ -463,3 +463,39 @@ describe("judge preview endpoints (Try it on a real trace/session)", () => {
     expect(body.dailyTraces).toBeGreaterThanOrEqual(0);
   });
 });
+
+describe("two grading modes: reference-centric rubrics are offline-only", () => {
+  it("seeded RAG: Contextual Recall carries requiresExpected and refuses online enable", async () => {
+    const list = await api("/agent-monitoring/judge-scorers");
+    const scorers = (list.body as { judgeScorers: { _id: string; name: string; judge: { requiresExpected: boolean } }[] })
+      .judgeScorers;
+    const recall = scorers.find(s => s.name === "RAG: Contextual Recall");
+    expect(recall?.judge.requiresExpected).toBe(true);
+    // Faithfulness stays dual-surface.
+    expect(scorers.find(s => s.name === "RAG: Faithfulness")?.judge.requiresExpected).toBe(false);
+    const enable = await api(`/agent-monitoring/judge-scorers/${recall!._id}`, {
+      method: "PUT",
+      body: JSON.stringify({ online: { enabled: true } }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(enable.status).toBe(409);
+    expect((enable.body as { error: string }).error).toContain("reference answer");
+  });
+
+  it("creating a scorer with requiresExpected + enabled online is a 409; offline-only create works", async () => {
+    const refused = await api("/agent-monitoring/judge-scorers", postJson({
+      name: "exact-match judge",
+      judge: { acceptanceCriteria: "Matches the reference", requiresExpected: true },
+      online: { enabled: true, sampleRate: 0.1 },
+    }));
+    expect(refused.status).toBe(409);
+    const ok = await api("/agent-monitoring/judge-scorers", postJson({
+      name: "exact-match judge",
+      judge: { acceptanceCriteria: "Matches the reference", requiresExpected: true },
+    }));
+    expect(ok.status).toBe(201);
+    const wire = (ok.body as { judgeScorer: { judge: { requiresExpected: boolean }; online: null } }).judgeScorer;
+    expect(wire.judge.requiresExpected).toBe(true);
+    expect(wire.online).toBeNull();
+  });
+});

--- a/packages/judge-core/src/index.ts
+++ b/packages/judge-core/src/index.ts
@@ -223,24 +223,33 @@ export const REFERENCE_FREE_EXPECTED_PLACEHOLDER =
 
 // Deliberately compact (simplified 2026-08 from a ~30-line rulebook at Robin's request): the
 // JSON response shape is enforced by callJudgeJson's schema, not by prose, so the prompt only
-// needs the scoring semantics. Every rule below preserves the intent of the long version:
-// expected-results-as-ground-truth, exact-fact strictness, no style credit, tools optional.
-export const DEFAULT_JUDGE_PROMPT = `You are an expert AI evaluator. Score the agent response against the expected results.
+// needs the scoring semantics.
+//
+// Criteria-anchored, reference-guided (2026-08, "two grading modes" alignment): a scorer is one
+// rubric serving BOTH surfaces - offline dataset runs (which always carry expected_results) and
+// online live scoring (which never does). The old default made Expected Results THE rubric, so
+// the same scorer answered a different question on each surface ("matches the reference?" vs.
+// the reference-free sibling's "meets the criteria?") and the two score streams weren't
+// comparable. Now both modes anchor on the evaluation criteria - the constant across surfaces -
+// and a reference answer, when present, adds factual strictness on top (the industry
+// "reference-guided grading" pattern) instead of replacing the rubric. Exact-fact strictness,
+// no style credit, and tools-optional all survive from the long version.
+export const DEFAULT_JUDGE_PROMPT = `You are an expert AI evaluator. Score the agent response against the evaluation criteria provided with this request. A reference answer ("Expected Results") is also provided: treat it as ground truth for factual claims.
 
 **User Query:** {input}
 
 **Agent Response:**
 {output}
 
-**Expected Results:**
+**Expected Results (reference answer - ground truth for facts):**
 {expected}
 
-Rate 0-10 (0 = completely wrong, 5 = partially correct, 10 = perfect) with a concise justification, written in the same language as the query.
+Rate 0-10 (0 = fails the criteria completely, 5 = partially meets them, 10 = fully meets them) with a concise justification, written in the same language as the query.
 
 Rules:
-- The Expected Results are ground truth by definition. Score only how well the response agrees with them - never fact-check, dispute, or second-guess them with outside knowledge.
-- Specific facts (dates, numbers, names) must match exactly; a wrong core fact scores low (0-3) no matter how detailed or well-written the response is, and extra context never compensates.
-- Completeness counts: the response should cover every aspect of the Expected Results, stay on topic, and be clear.
+- The evaluation criteria are the rubric. Score how well the response meets them; the Expected Results tell you which facts are true - never fact-check, dispute, or second-guess them with outside knowledge.
+- Specific facts (dates, numbers, names) that contradict the Expected Results score low (0-3) no matter how detailed or well-written the response is, and extra context never compensates.
+- Completeness counts: the response should cover what the criteria and the Expected Results call for, stay on topic, and be clear.
 - Tools are optional unless the test explicitly requires them; references listed in the trace count as retrieval context, so do not penalize a missing explicit tool call.`;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Every dataset case carries expected_results; no live trace ever does - so the same judge scorer was answering a different question on each surface (offline: "matches the reference?", online: "meets the criteria?") and the two score streams weren't comparable.

- Default judge prompt (judge-core, shared with hosted) rebalanced to the industry reference-guided pattern: the evaluation criteria are the rubric on BOTH surfaces; the reference answer, when present, adds factual strictness (contradicting facts score low) instead of replacing the rubric. Exact-fact strictness, no style credit, and tools-optional all survive.
- New requiresExpected flag on judge configs for the genuinely reference-centric minority (seeded true on RAG: Contextual Recall, boot backfill for existing installs): enabling online scoring is a 409 on both the unified and legacy surfaces, and offline runs skip reference-less items with an explicit reason instead of judging an empty reference. Wire contract updated; integration tests pin the seeded flag, both 409 paths, and the offline-only create.