### PR TITLE
chore: close the gaps between the conventions and what CI enforces

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Something behaves differently than documented
+labels: bug
+---
+
+**What happened, and what you expected instead**
+
+**Smallest reproduction you have**
+<!-- A curl call against a local engine, or an SDK snippet. -->
+
+**Environment**
+- Engine version or commit:
+- How it is running: released binary / Docker / `yarn dev` from source
+- Database: SQLite (default) or Postgres
+- `AGENTX_AUTH`: disabled (default) or enabled
+
+**Engine log around the failure**
+<!-- Each request logs one structured line with a reqId, echoed in the X-Request-Id response
+     header, so a failing browser call can be matched to its log line. Please scrub API keys. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/AgentX-ai/AgentX-trace-eval/security/advisories/new
+    about: Please report privately rather than as a public issue. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Propose a change before building it
+labels: enhancement
+---
+
+**The problem**
+<!-- What you were trying to do, and where the current behaviour stopped you. -->
+
+**What you would like instead**
+
+**Alternatives you considered**
+<!-- Including doing nothing. README's "Project status" lists what is deliberately out of scope
+     rather than merely unbuilt; worth a look first. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->
+
+## What this changes, and why
+
+<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->
+
+## How it was verified
+
+<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
+     case that would have failed before is. Say so plainly if something is unverified. -->
+
+## Checklist
+
+- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
+- [ ] `yarn workspace @agentx/engine test` passes
+- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
+      same commit
+- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
+      deleted from `routeBodyValidation.test.ts` if it had one
+- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
+      (pg), with existing ids left byte-identical
+- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# Four ecosystems, because this repo ships from four of them: the yarn workspace (engine +
+# packages/judge-core), the Go CLI, the workflows themselves, and the Dockerfile's base images.
+#
+# The github-actions entry is the one that is easy to forget and most worth having. Every workflow
+# here pins its actions to a full commit SHA rather than a moving tag, which is the right call for
+# supply-chain reasons and has exactly one cost: a pinned SHA never updates, so a security fix in
+# an action is invisible until someone re-reads the pin by hand. This turns that into a PR.
+#
+# Grouped and monthly on purpose. Ungrouped weekly dependency PRs are how a small project ends up
+# with a permanently red, permanently ignored PR queue; one batched PR per ecosystem per month is
+# a review a maintainer actually does.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    groups:
+      npm:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: gomod
+    directory: /cli
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,13 +108,44 @@ jobs:
           go-version-file: cli/go.mod
           cache: false
 
+      # gofmt is the whole formatting standard for Go, so "we all run gofmt" costs nothing to
+      # enforce and stops the first unformatted file from turning every later diff into noise.
+      # `gofmt -l` lists offenders and exits 0 either way, hence the explicit emptiness check.
+      - name: Format
+        working-directory: cli
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt-clean. Run: gofmt -w ." >&2
+            echo "$unformatted" >&2
+            gofmt -d .
+            exit 1
+          fi
+
       - name: Vet
         working-directory: cli
         run: go vet ./...
 
+      # -race, because the CLI's whole job is process supervision: cmd/server.go spawns the engine
+      # and juggles its stdio, signals, and shutdown across goroutines, which is exactly the shape
+      # of code where a data race hides behind a passing test. The suite runs in seconds, so the
+      # detector's overhead buys a real class of bug for no meaningful time.
       - name: Test
         working-directory: cli
-        run: go test ./...
+        run: go test -race ./...
+
+  shell:
+    name: shell scripts
+    # install.sh is piped straight into bash from a curl one-liner in the README, and build.sh and
+    # scripts/ are what a contributor runs to produce a real distribution. A quoting bug in any of
+    # them fails on someone else's machine, after the merge. shellcheck is preinstalled on the
+    # GitHub runner image, so this is a check with no install step and no new action to pin.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+
+      - name: Shellcheck
+        run: shellcheck install.sh build.sh scripts/*.sh
 
   binary:
     name: compiled binary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing
+
+Issues and PRs are welcome. For anything beyond a small fix, please open an issue first so the
+approach can be agreed before the work happens.
+
+The engine's own conventions, which are the substance of a review here, live in
+[engine/CONTRIBUTING.md](engine/CONTRIBUTING.md): wire casing, the `src/contract/wire.ts` response
+contract, body validation, per-dialect queries, migrations, sampling. Read that before touching
+`engine/`. This file covers the repo as a whole.
+
+## Getting set up
+
+```bash
+yarn install                              # one workspace install: engine/ + packages/judge-core/
+yarn workspace @agentx/judge-core build   # engine imports it through its exports map, so build first
+yarn workspace @agentx/engine dev         # tsx watch loop on http://localhost:4700
+```
+
+[README's "Building from source"](README.md#building-from-source) covers the dashboard bundle, the
+full distribution build, and the end-to-end smoke test.
+
+## What CI will run against your PR
+
+Run these before pushing. They are the same commands the workflow runs, so a local pass is a real
+prediction rather than a hopeful one.
+
+| Command | What it protects |
+| --- | --- |
+| `yarn typecheck` | strict TypeScript across both workspaces |
+| `yarn workspace @agentx/engine lint` | async discipline the compiler cannot see, see `engine/eslint.config.mjs` |
+| `yarn workspace @agentx/engine test` | the integration-first suite, on SQLite |
+| `yarn workspace @agentx/engine test:coverage` | the same suite behind the coverage floors |
+| `cd cli && gofmt -l . && go vet ./... && go test -race ./...` | the Go CLI |
+| `shellcheck install.sh build.sh scripts/*.sh` | the scripts users pipe into bash |
+
+CI additionally runs the engine suite a second time against a real Postgres service, and smoke
+tests the `bun build --compile` binary that releases actually ship. To reproduce the Postgres run
+locally, point `AGENTX_TEST_DB_URL` at a superuser connection string; the suites create and drop
+their own throwaway databases, and skip entirely when the variable is unset.
+
+## Tests
+
+Prefer extending an existing `engine/src/test/*.integration.test.ts` over mocking internals. Those
+suites boot the real engine as a subprocess (`src/test/server.ts`) and speak HTTP to it, because
+the failures worth catching are runtime ones: a rejection that kills the process, a migration that
+only runs against a fresh database, a query that is fine on SQLite and wrong on Postgres. None of
+those reproduce against a hand-assembled express app.
+
+Booting an engine costs seconds, so `engine/vitest.config.ts` sets a 60s default timeout. A case
+that boots more than once should still state its own budget explicitly.
+
+## Ratchets
+
+Two checks measure a number and refuse to let it get worse, rather than demanding the codebase
+already be perfect:
+
+- **Coverage**, in `engine/package.json`'s `test:coverage` and described in
+  `.github/workflows/test.yml`. Raise the floors when coverage rises. Never lower them to make a
+  PR pass.
+- **Route body validation**, in `engine/src/test/routeBodyValidation.test.ts`. It holds a frozen
+  list of mutating routes that still hand-roll their body checks. A new route not using
+  `validateBody(schema)` fails the build, and converting one fails it too until you delete the
+  entry. The list may shrink and never grow.
+
+If a ratchet blocks you, the fix is the code, not the threshold.
+
+## Style
+
+Match the file you are editing. The one convention worth stating outright, because it is
+unusual: comments here explain what the code cannot say for itself, which is the constraint, the
+bug a guard exists for, the contract being preserved, or the alternative that was tried and
+failed. A comment restating the line below it is noise. Also, no em-dashes in any output.
+
+## Security
+
+Please do not open a public issue for a vulnerability. See [SECURITY.md](SECURITY.md).
+
+## License
+
+By contributing you agree that your contributions are licensed under Apache-2.0, matching
+[LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -345,10 +345,17 @@ every feature above.
 
 ## Contributing
 
-Issues and PRs are welcome. There's no separate `CONTRIBUTING.md` yet - for anything beyond a
-small fix, please open an issue first to discuss the approach. Run `yarn install` at the repo root
-(a workspace install covering `engine/` and `packages/judge-core/` together), and see
-[Building from source](#building-from-source) for the dev loop and smoke test.
+Issues and PRs are welcome. For anything beyond a small fix, please open an issue first to discuss
+the approach. Run `yarn install` at the repo root (a workspace install covering `engine/` and
+`packages/judge-core/` together), and see [Building from source](#building-from-source) for the dev
+loop and smoke test.
+
+[CONTRIBUTING.md](CONTRIBUTING.md) lists the checks CI runs and how to reproduce each one locally.
+[engine/CONTRIBUTING.md](engine/CONTRIBUTING.md) has the engine's own conventions, which are the
+substance of a code review here: wire casing, the response contract, body validation, per-dialect
+queries, migrations.
+
+Vulnerabilities go to [SECURITY.md](SECURITY.md), privately, rather than to a public issue.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please report vulnerabilities privately, not as a public issue, so a fix can ship before the
+details are public.
+
+Use GitHub's private reporting on this repository: **Security** tab, then **Report a
+vulnerability**. That opens a draft advisory visible only to you and the maintainers.
+
+Useful in a report: what an attacker gains, the smallest reproduction you have (a curl call
+against a local engine is ideal), the version or commit, and whether `AGENTX_AUTH` was enabled.
+Expect an acknowledgement within a few working days. This is a small project, so please treat that
+as a best effort rather than a contractual SLA.
+
+Please do not run automated scanners against any hosted AgentX instance. Everything here is
+self-hostable, so test against your own.
+
+## Supported versions
+
+Fixes land on `main` and go out in the next release. There are no long-lived maintenance branches,
+so "upgrade to the latest release" is the supported path.
+
+## What the default deployment assumes
+
+Worth stating, because several reports would otherwise describe the documented design:
+
+- **No dashboard login by default.** The engine trusts anything that can reach its port, which
+  assumes one machine and one operator. `AGENTX_AUTH=enabled` turns on sign-in for shared
+  deployments. See README's "Dashboard authentication".
+- **Project API keys are stored in plaintext** in the engine's own database, and the dashboard
+  shows them. That is deliberate: the key is the project selector, an operator has to be able to
+  copy it into an SDK, and it is stored in the same database as the telemetry it protects. So
+  database read access is already total compromise, and hashing the key would not change that.
+  Keys carry 192 bits of entropy from `crypto.randomBytes`, and both credential and data-plane
+  request rates are capped by default (`engine/src/auth/rateLimit.ts`).
+- **LLM provider keys are write-only over the API.** They are stored so the engine can call
+  OpenAI and Anthropic on your behalf, and read back only in masked form.
+- **Code scorers execute code you supply**, in a subprocess, by design. They are an operator
+  feature, not a sandbox. Treat the ability to write a scorer as equivalent to shell access on the
+  engine host.
+- **Exposing the engine to the internet is your call to make deliberately.** Put it behind TLS and
+  `AGENTX_AUTH=enabled`, and set `AGENTX_TRUSTED_ORIGINS`.
+
+Reports that show a way *around* one of these boundaries are very much in scope. A bypass of
+project scoping is the one to look hardest at: every project-scoped query derives its tenancy from
+the resolved API key (`engine/src/auth/apiKey.ts`), and anything that reads one project's rows
+with another project's key is a serious bug.

--- a/engine/CONTRIBUTING.md
+++ b/engine/CONTRIBUTING.md
@@ -9,7 +9,9 @@ The checks CI enforces and the conventions it cannot.
   compiler can't check. Fire-and-forget calls must say `void`; a forgotten `await` fails CI.
 - `yarn test` - the integration-first suite. Tests boot the real engine (`src/test/server.ts`)
   and speak HTTP; prefer extending an existing `*.integration.test.ts` over mocking internals.
-  CI runs the suite twice: SQLite and a real Postgres service.
+  CI runs the suite twice: SQLite and a real Postgres service. Booting an engine costs seconds, so
+  `vitest.config.ts` sets the default timeout to 60s rather than vitest's 5s; a case that boots
+  more than once still states its own budget.
 
 ## Conventions the reviewers enforce
 
@@ -24,6 +26,9 @@ The checks CI enforces and the conventions it cannot.
 - **Body validation**: new/changed routes validate with `validateBody(schema)`
   (`src/routes/validateBody.ts`) - shape/range in the schema, cross-data checks in the handler.
   Never the silent `typeof`-skip pattern it replaced. Unknown keys strip; mistyped fields 400.
+  Enforced, not just reviewed: `src/test/routeBodyValidation.test.ts` freezes the list of routes
+  that still hand-roll their checks. A new mutating route without `validateBody` fails the build;
+  converting one fails it too until you delete its entry. The list shrinks, never grows.
 - **Per-dialect queries**: drizzle's union typing requires separate sqlite/pg select branches;
   duplicate the query per dialect rather than fighting the types with casts.
 - **Migrations**: additive DDL in the `columnMigrations` list (sqlite) / `IF NOT EXISTS` block

--- a/engine/src/test/metricPackV3.integration.test.ts
+++ b/engine/src/test/metricPackV3.integration.test.ts
@@ -50,7 +50,7 @@ describe("metric pack v3", () => {
     // The trimmed-in-2026-08 safety names must NOT come back under their old identities.
     expect(names).not.toContain("Safety: Toxicity");
     expect(names).not.toContain("Safety: Bias");
-  });
+  }, 90_000);
 
   it("upgrades a v2 install's seeded prompts exactly once, preserving operator edits", async () => {
     const first = await startEngine();

--- a/engine/src/test/routeBodyValidation.test.ts
+++ b/engine/src/test/routeBodyValidation.test.ts
@@ -1,0 +1,221 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// A ratchet for CONTRIBUTING.md's body-validation rule, in the same spirit as the coverage floors
+// in .github/workflows/test.yml: it does not demand the codebase already be clean, it demands the
+// debt only ever shrink.
+//
+// The rule ("new/changed routes validate with validateBody(schema) ... Never the silent
+// typeof-skip pattern it replaced") is real and load-bearing, because the pattern it replaced
+// fails silently: a mistyped field is IGNORED rather than rejected, so a caller believes a setting
+// was applied while nothing changed. That is the same class of bug as the placebo knobs the same
+// document bans. But the rule was reviewer-enforced only, and reviewer-enforced rules decay: at
+// the time this test was written 8 of 94 mutating routes used validateBody and the other 86 still
+// carried hand-rolled typeof checks. Nothing failed, because nothing was checking.
+//
+// So: the list below is the frozen inventory of that debt. Adding a mutating route without
+// validateBody fails this test, and converting one fails it too until the entry is deleted. The
+// list is allowed to shrink and never to grow.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const routesDir = path.resolve(here, "../routes");
+
+// Not debt: endpoints whose body is not JSON that a zod schema could describe. OTLP/HTTP takes
+// protobuf (routes/otlp.ts mounts express.raw for it) or an OTLP-shaped JSON envelope, and does
+// its own content-type gate and decode; there is no request-shaped schema to apply.
+const EXEMPT = new Set(["otlp.ts POST /v1/traces"]);
+
+// Frozen 2026-08. Delete an entry when its route moves to validateBody(); never add one.
+const KNOWN_UNVALIDATED = [
+  "agentMonitoringDashboard.ts PATCH /profiles/:agentId/approval-policy",
+  "agentMonitoringDashboard.ts PATCH /signals/:signalId",
+  "agentMonitoringDashboard.ts POST /agents",
+  "agentMonitoringDashboard.ts POST /custom-evaluators",
+  "agentMonitoringDashboard.ts POST /custom-evaluators/dry-run",
+  "agentMonitoringDashboard.ts POST /estimate",
+  "agentMonitoringDashboard.ts POST /judge-scorers",
+  "agentMonitoringDashboard.ts POST /judge-scorers/preview-score",
+  "agentMonitoringDashboard.ts POST /online-evaluators",
+  "agentMonitoringDashboard.ts POST /online-evaluators/:evaluatorId/tune",
+  "agentMonitoringDashboard.ts POST /online-evaluators/:evaluatorId/tune/publish",
+  "agentMonitoringDashboard.ts POST /online-evaluators/:evaluatorId/tune/validate",
+  "agentMonitoringDashboard.ts POST /patterns",
+  "agentMonitoringDashboard.ts POST /patterns/generate-regex",
+  "agentMonitoringDashboard.ts POST /portability/models",
+  "agentMonitoringDashboard.ts POST /portability/models/test-connection",
+  "agentMonitoringDashboard.ts POST /session-sweep/run",
+  "agentMonitoringDashboard.ts POST /sessions/:sessionId/coherence-check",
+  "agentMonitoringDashboard.ts POST /sessions/:sessionId/judge/:evaluatorId",
+  "agentMonitoringDashboard.ts POST /settings/api-key/regenerate",
+  "agentMonitoringDashboard.ts POST /signals/:signalId/create-evaluator",
+  "agentMonitoringDashboard.ts POST /signals/:signalId/feedback",
+  "agentMonitoringDashboard.ts POST /signals/:signalId/suggest-expected-results",
+  "agentMonitoringDashboard.ts POST /signals/:signalId/suggest-human-feedback",
+  "agentMonitoringDashboard.ts POST /traces/:traceId/portability",
+  "agentMonitoringDashboard.ts PUT /custom-evaluators/:evaluatorId",
+  "agentMonitoringDashboard.ts PUT /judge-scorers/:id",
+  "agentMonitoringDashboard.ts PUT /online-evaluators/:evaluatorId",
+  "agentMonitoringDashboard.ts PUT /patterns/:patternId",
+  "agentMonitoringDashboard.ts PUT /portability/models/:id",
+  "agentMonitoringDashboard.ts PUT /profiles/:agentId",
+  "agentMonitoringDashboard.ts PUT /settings/llm-keys",
+  "agents.ts POST /",
+  "apiV1.ts POST /projects",
+  "authOrg.ts POST /invitations/:id/accept",
+  "authOrg.ts POST /organizations/:orgId/invitations",
+  "evaluateDashboard.ts PATCH /playground/runs/:id",
+  "evaluateDashboard.ts PATCH /prompts/:id",
+  "evaluateDashboard.ts PATCH /tool-schemas/:id",
+  "evaluateDashboard.ts PATCH /tool-schemas/:id/test-endpoint",
+  "evaluateDashboard.ts POST /agent-connectors",
+  "evaluateDashboard.ts POST /agent-connectors/test-connection",
+  "evaluateDashboard.ts POST /analyze/:id",
+  "evaluateDashboard.ts POST /datasets/:datasetId/run-with-connector",
+  "evaluateDashboard.ts POST /datasets/:id/cases",
+  "evaluateDashboard.ts POST /datasets/case-preview",
+  "evaluateDashboard.ts POST /datasets/suggest-expected",
+  "evaluateDashboard.ts POST /evaluationSettings/create",
+  "evaluateDashboard.ts POST /evaluationSettings/create-standalone",
+  "evaluateDashboard.ts POST /improve/inbox/:id/dismiss",
+  "evaluateDashboard.ts POST /improve/inbox/:id/publish",
+  "evaluateDashboard.ts POST /improve/inbox/sweep/run",
+  "evaluateDashboard.ts POST /mcp/tools",
+  "evaluateDashboard.ts POST /playground/run",
+  "evaluateDashboard.ts POST /playground/runs",
+  "evaluateDashboard.ts POST /playground/simulate",
+  "evaluateDashboard.ts POST /prompts",
+  "evaluateDashboard.ts POST /prompts/:id/proposals/validate",
+  "evaluateDashboard.ts POST /prompts/:id/propose",
+  "evaluateDashboard.ts POST /prompts/:id/versions",
+  "evaluateDashboard.ts POST /synthesize-cases",
+  "evaluateDashboard.ts POST /tool-schemas",
+  "evaluateDashboard.ts POST /tool-schemas/:id/proposals/validate",
+  "evaluateDashboard.ts POST /tool-schemas/:id/propose",
+  "evaluateDashboard.ts POST /tool-schemas/:id/versions",
+  "evaluateDashboard.ts PUT /agent-connectors/:id",
+  "evaluateDashboard.ts PUT /evaluationSettings/:id",
+  "evaluations.ts POST /datasets",
+  "evaluations.ts POST /datasets/:id/cases",
+  "evaluations.ts POST /datasets/case-preview",
+  "evaluations.ts POST /datasets/suggest-expected",
+  "evaluations.ts POST /evaluation-settings",
+  "evaluations.ts POST /prompts",
+  "evaluations.ts POST /runs",
+  "evaluations.ts POST /runs/:runId/analyze",
+  "evaluations.ts POST /runs/:runId/finalize",
+  "evaluations.ts POST /runs/:runId/results",
+  "feedback.ts POST /",
+  "ingest.ts POST /traces",
+  "ingest.ts POST /traces/:traceId/evaluate",
+  "monitor.ts POST /online-evaluators",
+  "monitor.ts POST /patterns",
+  "monitor.ts PUT /online-evaluators/:id",
+  "monitor.ts PUT /profiles/:agentId",
+  "outcomes.ts POST /",
+];
+
+type Registration = { key: string; validated: boolean };
+
+// Every mutating registration in routes/ is written the same way: `<router>.post(<path>, ...
+// async (req: Request, res: Response) => {`, with any middleware between the path and the handler.
+// So "is this route validated" is exactly "does validateBody( appear before the handler opens".
+// Source scanning rather than introspecting a booted express app: express 4 exposes middleware
+// only through the undocumented router.stack internals that routes/asyncRouter.ts deliberately
+// refuses to touch, and a wrapped handler is anonymous there anyway.
+const HANDLER_START = /async \(\s*(_?req|_)/;
+
+// Bounded, so a registration with no handler of its own cannot silently borrow the NEXT route's
+// and be recorded under the wrong path. The widest real middleware chain in routes/ is a few
+// hundred characters; anything past this is a parse failure, not a long chain.
+const HANDLER_SEARCH_WINDOW = 1200;
+
+// A `router.post(...)` written inside a line comment is prose, not a route. Without this the
+// scanner would try to parse it and fail the suite over a code sample in a comment.
+function insideLineComment(src: string, index: number): boolean {
+  const lineStart = src.lastIndexOf("\n", index) + 1;
+  const commentAt = src.slice(lineStart, index).indexOf("//");
+  return commentAt !== -1;
+}
+
+function scan(file: string): Registration[] {
+  const src = fs.readFileSync(path.join(routesDir, file), "utf8");
+  const out: Registration[] = [];
+  const registration = /\b[A-Za-z_$][\w$]*\.(post|put|patch)\(\s*/g;
+  let match: RegExpExecArray | null;
+  while ((match = registration.exec(src))) {
+    if (insideLineComment(src, match.index)) {
+      continue;
+    }
+    const verb = match[1]?.toUpperCase();
+    const rest = src.slice(match.index + match[0].length);
+    const handlerAt = rest.slice(0, HANDLER_SEARCH_WINDOW).search(HANDLER_START);
+    const pathLiteral = /^\s*(`[^`]*`|"[^"]*"|'[^']*')/.exec(rest)?.[1];
+    // A registration the scanner cannot parse would silently drop out of the inventory, which is
+    // how a ratchet quietly stops ratcheting. Fail loudly rather than skipping it.
+    if (verb === undefined || handlerAt === -1 || pathLiteral === undefined) {
+      throw new Error(
+        `${file}: could not parse a route registration at offset ${match.index}. The scanner ` +
+          `expects <router>.post|put|patch(<literal path>, ...async (req, res) => ...). Teach it ` +
+          `the new form rather than letting the route escape the inventory.`
+      );
+    }
+    out.push({
+      key: `${file} ${verb} ${pathLiteral.slice(1, -1)}`,
+      validated: /validateBody\(/.test(rest.slice(0, handlerAt)),
+    });
+  }
+  return out;
+}
+
+function allRegistrations(): Registration[] {
+  return fs
+    .readdirSync(routesDir)
+    .filter(f => f.endsWith(".ts") && !f.endsWith(".test.ts"))
+    .sort()
+    .flatMap(scan);
+}
+
+describe("route body validation", () => {
+  it("finds the mutating routes at all, so a broken scanner cannot pass vacuously", () => {
+    const registrations = allRegistrations();
+    // Not an exact count: routes get added. A floor near the inventory this was frozen against is
+    // enough to catch a regex that stopped matching anything.
+    expect(registrations.length).toBeGreaterThanOrEqual(90);
+    expect(registrations.some(r => r.validated)).toBe(true);
+  });
+
+  it("adds no new route that skips validateBody", () => {
+    const unvalidated = allRegistrations()
+      .filter(r => !r.validated && !EXEMPT.has(r.key))
+      .map(r => r.key);
+    const known = new Set(KNOWN_UNVALIDATED);
+    const added = unvalidated.filter(key => !known.has(key));
+    expect(
+      added,
+      "These mutating routes read their body without validateBody(schema). CONTRIBUTING.md " +
+        "requires a zod schema on new and changed routes: shape and range in the schema, " +
+        "cross-data checks in the handler. Hand-rolled typeof checks ignore a mistyped field " +
+        "instead of rejecting it, so the caller is told nothing went wrong."
+    ).toEqual([]);
+  });
+
+  it("keeps the known-unvalidated list free of entries that are already fixed", () => {
+    const stillUnvalidated = new Set(
+      allRegistrations()
+        .filter(r => !r.validated)
+        .map(r => r.key)
+    );
+    const stale = KNOWN_UNVALIDATED.filter(key => !stillUnvalidated.has(key));
+    expect(
+      stale,
+      "These routes now validate their body, or no longer exist. Delete them from " +
+        "KNOWN_UNVALIDATED so the ratchet holds the ground you just gained."
+    ).toEqual([]);
+  });
+
+  it("lists the known-unvalidated routes exactly once each, in sorted order", () => {
+    expect(KNOWN_UNVALIDATED).toEqual([...new Set(KNOWN_UNVALIDATED)].sort());
+  });
+});

--- a/engine/vitest.config.ts
+++ b/engine/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+// Timeout floors, not per-test opinions. Almost every suite under src/test/ boots the REAL engine
+// (src/test/server.ts spawns `node --import tsx src/index.ts`, which runs migrations and seeds a
+// fresh database before the first request), so the work in a single `it` is seconds, not
+// milliseconds. Vitest's stock 5s testTimeout / 10s hookTimeout are sized for pure unit tests and
+// cannot cover that: the suite compensated by hand-writing `}, 90_000)` on ~110 individual cases,
+// which works right up until one is forgotten. One was - metricPackV3's first case booted an
+// engine under the 5s default and failed as a timeout, not an assertion. Under the coverage job
+// the margin is thinner still, since V8 instrumentation slows the spawned engine's boot (see
+// server.ts's own note about a harness artifact first seen exactly that way).
+//
+// Setting the defaults here makes the boot budget structural. Explicit per-test timeouts still
+// win, so the longer suites (multi-boot restart/upgrade cases at 120s-240s) keep their own
+// values; what changes is that omitting one now yields a sane budget instead of a flake.
+export default defineConfig({
+  test: {
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});


### PR DESCRIPTION
The engineering discipline here is already unusually strong: strict TS with
noUncheckedIndexedAccess, an integration-first suite that boots the real
engine, a wire contract enforced against live responses, a coverage ratchet,
SHA-pinned actions, a non-root multi-stage Dockerfile. What was missing was
enforcement on the parts left to reviewers, and reviewer-enforced rules decay.

Fixes a real flake, first. metricPackV3's first case boots an engine and was
the one integration case with no explicit timeout, so it ran under vitest's
5s default and failed as a timeout rather than an assertion. Reproduced
locally on a clean checkout.

- engine/vitest.config.ts: 60s default test and hook timeouts. The suite had
  been buying that budget by hand-writing `}, 90_000)` on ~110 cases, which
  works until one is forgotten. Explicit per-case timeouts still win, so the
  multi-boot suites keep their 120s-240s values; what changes is that omitting
  one now yields a sane budget instead of a flake.

- routeBodyValidation.test.ts: a ratchet for the body-validation convention,
  in the same spirit as the coverage floors. CONTRIBUTING requires
  validateBody(schema) on new and changed routes and bans the typeof-skip
  pattern it replaced, because that pattern IGNORES a mistyped field rather
  than rejecting it, so the caller believes a setting was applied while
  nothing changed. 8 of 94 mutating routes actually used it. The other 86 are
  frozen in a list that may shrink and never grow: a new route without
  validateBody fails the build, and converting one fails it until the entry is
  deleted. OTLP is exempt with a reason, being protobuf rather than schema-
  shaped JSON. Both failure directions verified by deliberately breaking them.

- CI: gofmt -l on the Go CLI (formatting is free to enforce and stops the
  first unformatted file from making every later diff noisy); go test -race,
  because the CLI supervises a spawned engine across goroutines, which is
  where a data race hides behind a passing test; and shellcheck on install.sh,
  build.sh and scripts/, which users pipe straight into bash. All three pass
  on the tree as it stands, so none of them arrives red.

- dependabot: monthly and grouped, so the queue stays reviewable. The
  github-actions ecosystem is the one that matters most here, since every
  workflow pins full commit SHAs, which is correct and means a security fix in
  an action is otherwise invisible until someone re-reads the pin by hand.

- Community health files the README already flagged as missing: a root
  CONTRIBUTING.md mapping each CI check to the local command that reproduces
  it, a SECURITY.md that documents the private reporting path and states the
  default deployment's assumptions plainly so they are not re-reported as
  findings, and PR/issue templates carrying the conventions to where they get
  read. engine/CONTRIBUTING.md now notes which of its rules are enforced.

Verified: yarn typecheck, engine lint, full engine suite under the coverage
ratchet (576 passed, 37 skipped, floors met), gofmt/vet/go test -race, and
shellcheck.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QoaBHGQsFUA7v9zbGSyVxZ