### PR TITLE
feat: keep Default empty, put the tour in an Example project

### DIFF
--- a/engine/src/core/seed.ts
+++ b/engine/src/core/seed.ts
@@ -1,3 +1,4 @@
+import { eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type { Db } from "../storage/db.js";
 import { createDataset, listDatasets } from "./evaluate/datasets.js";
@@ -7,19 +8,60 @@ import { createAgent, listAgentsWire } from "./monitor/agents.js";
 import { updateProfile } from "./monitor/profiles.js";
 import { ingestTrace } from "./trace/ingest.js";
 import { runMonitorCheck } from "./monitor/detect.js";
+import { createProject, listProjectRows } from "./project/projects.js";
+import { ensureSessionBaselineJudge } from "./monitor/builtinEvaluators.js";
+import { ensureMetricPackConfigs } from "./evaluate/metricPack.js";
+import { withProjectId, type Db as DbType } from "../storage/db.js";
+import { logger } from "../log.js";
 
-// One-time starter content, not a permanent hardcoded fallback - same convention as db.ts's
-// seedPortabilityModelsIfEmpty: each piece only inserts when its own table is genuinely empty, so
-// a user who deletes an example never sees it silently reappear on the next restart, and a user
-// who already has real data of their own is never touched. Point of this file: a fresh install
-// isn't a blank slate with four empty tabs and no idea what to put in them - Datasets, Evaluator,
-// Online Evaluators, and Prompts each start with one clearly-labeled "Example: ..." entry showing
-// the shape real data takes.
+// The example content lives in its own project, not in Default.
+//
+// It used to go into Default, which meant the first project someone points their SDK at already
+// contained a fake agent, fake traces and a fake dataset. Their own first trace landed in a list
+// next to invented ones, and every count on every page was their data plus ours. Deleting it all
+// was the first thing anyone did.
+//
+// So: Default starts genuinely empty, and a second project named "Example" holds the tour. It is
+// created once, on a fresh install only - an existing install never sprouts a new project on
+// upgrade, and someone who deletes the Example project does not get it back on the next restart.
+export const EXAMPLE_PROJECT_NAME = "Example";
+const EXAMPLE_AGENT_NAME = "example-support-agent";
+
+export async function seedFreshInstall(db: Db, opts: { freshInstall: boolean }): Promise<void> {
+  if (!opts.freshInstall) {
+    return;
+  }
+  const projects = await listProjectRows(db);
+  if (projects.some(p => p.name === EXAMPLE_PROJECT_NAME)) {
+    return;
+  }
+  // Same organization as Default, so in auth mode the example is visible to the owner who just
+  // signed up rather than orphaned behind a membership check.
+  const defaultProject = projects.find(p => p.isDefault) ?? projects[0];
+  const example = await createProject(db, EXAMPLE_PROJECT_NAME, defaultProject?.organizationId ?? null);
+  const scoped = withProjectId(db as DbType, example._id);
+  // Best-effort in the same sense the previous seeding was: a fresh install must boot even if one
+  // piece of the tour cannot be written, and an engine that refuses to start because example data
+  // failed would be a worse bug than a missing example.
+  try {
+    await seedExampleDataIfEmpty(scoped);
+    await ensureSessionBaselineJudge(scoped);
+    await ensureMetricPackConfigs(scoped);
+  } catch (err) {
+    logger.warn({ err }, "Could not seed the Example project - continuing with an empty one");
+  }
+}
+
+// The content itself. Each piece still only inserts when its own table is genuinely empty, so
+// re-running against a project someone has edited never resurrects a deleted example.
 export async function seedExampleDataIfEmpty(db: Db): Promise<void> {
   await seedExampleEvaluatorConfig(db);
   await seedExampleDataset(db);
   await seedExamplePrompt(db);
   await seedExampleMonitorDataIfEmpty(db);
+  await seedExampleSessionIfEmpty(db);
+  await seedExampleTopicsIfEmpty(db);
+  await seedExampleRunIfEmpty(db);
 }
 
 // Datasets/Evaluator/Prompts above cover Evaluate; Governance's Agents/Observe/Monitor tabs had
@@ -35,7 +77,7 @@ async function seedExampleMonitorDataIfEmpty(db: Db): Promise<void> {
     return;
   }
 
-  const agent = await createAgent(db, "example-support-agent");
+  const agent = await createAgent(db, EXAMPLE_AGENT_NAME);
   await updateProfile(db, agent._id, { enabled: true, coverageMode: "all", sampleRate: 1 });
 
   // Three traces, each showing a different shape the product is actually about (not flat
@@ -289,4 +331,222 @@ async function seedExamplePrompt(db: Db): Promise<void> {
     description: "A starter prompt - safe to edit or delete once you've registered your own.",
     text: "You are a helpful, empathetic customer support agent. Always acknowledge the customer's concern first, ask clarifying questions when the request is ambiguous, and offer a concrete next step or solution.",
   });
+}
+
+// A real multi-turn conversation. Every other seeded trace is a single exchange with its own
+// session id, which leaves the Sessions view technically populated and practically useless -
+// nothing to expand, no turn ordering, no drift across a conversation to look at.
+async function seedExampleSessionIfEmpty(db: Db): Promise<void> {
+  const agents = await listAgentsWire(db);
+  const agent = agents.find(a => a.name === EXAMPLE_AGENT_NAME);
+  if (!agent) {
+    return;
+  }
+  const sessionId = nanoid();
+  const base = Date.now() - 6 * 60 * 1000;
+  const nano = (offsetMs: number) => String((base + offsetMs) * 1_000_000);
+
+  const turns: { input: string; output: string; latency: number }[] = [
+    {
+      input: "I was charged twice for order 7781.",
+      output:
+        "I can see two authorizations on order 7781 from the same card. The second one is a pending hold, not a completed charge - it should drop off within 3 business days. Would you like me to release it now instead?",
+      latency: 720,
+    },
+    {
+      input: "Yes, release it. How long until I see the money?",
+      output:
+        "Released. Your bank decides when it posts, which is usually 1-3 business days. You will get an email as soon as we send the release, and the reference number is on that email if your bank asks.",
+      latency: 640,
+    },
+    {
+      input: "And can you make sure it doesn't happen again next time I order?",
+      output:
+        "It happens when an order is retried after a network timeout. I have flagged the account so retries reuse the original authorization instead of opening a second one.",
+      latency: 810,
+    },
+  ];
+
+  for (const [i, turn] of turns.entries()) {
+    const { traceId } = await ingestTrace(db, {
+      name: agent.name,
+      agent_id: agent._id,
+      input: turn.input,
+      output: turn.output,
+      latency_ms: turn.latency,
+      model: "gpt-4o-mini",
+      input_tokens: 210 + i * 40,
+      output_tokens: 52 + i * 6,
+      session_id: sessionId,
+      span_id: nanoid(),
+      started_at_unix_nano: nano(i * 45_000),
+    });
+    await runMonitorCheck(
+      db,
+      { input: turn.input, output: turn.output, latencyMs: turn.latency },
+      { agentId: agent._id, traceId }
+    );
+  }
+}
+
+// Topics for the seeded traces. Classification is normally an LLM call, and this file's hard
+// constraint is that a fresh install boots with no API key configured and spends nothing - so
+// these rows are written directly rather than run through core/monitor/topics.ts.
+//
+// The consequence is deliberate and visible: no embedding column, so the Topics "Map" view stays
+// empty for them while the trend, top intents and issue breakdown - the parts that answer "what
+// are people asking about" - have something real to draw. Rows classified from actual traffic
+// later carry embeddings and appear on the map normally.
+async function seedExampleTopicsIfEmpty(db: Db): Promise<void> {
+  const existing =
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.monitorClassifications).limit(1).all()
+      : await db.db.select().from(db.schema.monitorClassifications).limit(1);
+  if (existing.length > 0) {
+    return;
+  }
+  const agents = await listAgentsWire(db);
+  const agent = agents.find(a => a.name === EXAMPLE_AGENT_NAME);
+  if (!agent) {
+    return;
+  }
+  const traces = await listRecentTraceRows(db, 40);
+  if (traces.length === 0) {
+    return;
+  }
+
+  // Mapped off what each seeded trace actually says, so the Topics page and the traces behind it
+  // agree with each other.
+  const classify = (input: string): { intent: string; sentiment: string; issueType: string } => {
+    const text = input.toLowerCase();
+    if (text.includes("charged twice") || text.includes("release it") || text.includes("happen again")) {
+      return { intent: "Billing dispute", sentiment: "negative", issueType: "Duplicate charge" };
+    }
+    if (text.includes("human agent")) {
+      return { intent: "Escalation request", sentiment: "negative", issueType: "Unresolved request" };
+    }
+    if (text.includes("return policy")) {
+      return { intent: "Returns policy", sentiment: "neutral", issueType: "None" };
+    }
+    return { intent: "Order status", sentiment: "neutral", issueType: "None" };
+  };
+
+  const rows = traces.map(trace => {
+    const { intent, sentiment, issueType } = classify(typeof trace.input === "string" ? trace.input : "");
+    return {
+      id: nanoid(),
+      traceId: trace.id,
+      agentId: agent._id,
+      intent,
+      sentiment,
+      issueType,
+      createdAt: trace.createdAt ?? new Date(),
+      projectId: db.projectId,
+      embedding: null,
+    };
+  });
+  if (db.kind === "sqlite") {
+    await db.db.insert(db.schema.monitorClassifications).values(rows);
+  } else {
+    await db.db.insert(db.schema.monitorClassifications).values(rows);
+  }
+}
+
+// Root traces only, newest first - the classification rows attach to what a person sees in
+// Observe, not to the child spans underneath them.
+async function listRecentTraceRows(db: Db, limit: number) {
+  type Row = { id: string; input: unknown; createdAt: Date | null; parentSpanId: string | null };
+  const rows = (
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.traces).where(eq(db.schema.traces.projectId, db.projectId)).all()
+      : await db.db.select().from(db.schema.traces).where(eq(db.schema.traces.projectId, db.projectId))
+  ) as Row[];
+  return rows.filter(r => !r.parentSpanId).slice(0, limit);
+}
+
+// One finished evaluation run, so Evaluate opens on a result instead of an empty list and the
+// run-comparison, gate and analysis surfaces have something to point at.
+//
+// The rows are written directly, with the same "only if empty" guard as everything else here.
+// The alternative - driving the real run path - would make a judge call per case at install time,
+// against whatever key happens to be configured, before anyone has asked for anything. A fresh
+// install must not spend money to draw a chart. These are fixture numbers in a project named
+// Example, on a dataset named "Example: ...", which is what they are allowed to be.
+async function seedExampleRunIfEmpty(db: Db): Promise<void> {
+  const existingRuns =
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.evaluationRuns).limit(1).all()
+      : await db.db.select().from(db.schema.evaluationRuns).limit(1);
+  if (existingRuns.length > 0) {
+    return;
+  }
+  const datasets = await listDatasets(db);
+  const dataset = datasets.find(d => d.name.startsWith("Example:"));
+  if (!dataset) {
+    return;
+  }
+
+  const runId = nanoid();
+  const createdAt = new Date(Date.now() - 45 * 60 * 1000);
+  const runRow = {
+    id: runId,
+    datasetId: dataset._id,
+    evaluationSettingsId: dataset._id,
+    evaluationSubject: { displayName: "example-support-agent", framework: "custom", runtime: "local" },
+    version: "example-v1",
+    runSource: "sdk",
+    sdkInfo: null,
+    smokeTestVariants: null,
+    status: "completed",
+    createdAt,
+    projectId: db.projectId,
+  };
+
+  const cases = [
+    {
+      query: "A customer says their order hasn't arrived after 2 weeks. How do you respond?",
+      output:
+        "I'm sorry your order is this late. Could you share the order number? I'll check where it is with the carrier, and if it cannot be located I'll send a replacement or refund it today, whichever you prefer.",
+      rating: 8.5,
+      justification:
+        "Apologizes, asks for the order number, and offers both remedies with a concrete timeframe - all of the acceptance criteria.",
+    },
+  ];
+
+  const resultRows = cases.map((c, index) => ({
+    id: nanoid(),
+    runId,
+    batchId: "example-batch",
+    idempotencyKey: `${runId}-${index}`,
+    caseId: null,
+    questionIndex: index,
+    runNumber: 1,
+    input: { query: c.query },
+    output: { text: c.output },
+    error: null,
+    traceId: null,
+    isSmokeTestVariant: false,
+    smokeTestVariantText: null,
+    latencyMs: 900 + index * 120,
+    inputTokens: 240,
+    outputTokens: 62,
+    vectorSimilarity: null,
+    jaccardSimilarity: null,
+    bleuScore: null,
+    rougeScore: null,
+    codeScorerResults: null,
+    rating: c.rating,
+    justification: c.justification,
+    status: "scored",
+    createdAt,
+    projectId: db.projectId,
+  }));
+
+  if (db.kind === "sqlite") {
+    await db.db.insert(db.schema.evaluationRuns).values(runRow);
+    await db.db.insert(db.schema.evaluationRunResults).values(resultRows);
+  } else {
+    await db.db.insert(db.schema.evaluationRuns).values(runRow);
+    await db.db.insert(db.schema.evaluationRunResults).values(resultRows);
+  }
 }

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -10,7 +10,7 @@ import { drizzle as drizzlePg, type NodePgDatabase } from "drizzle-orm/node-post
 import { Pool } from "pg";
 import * as sqliteSchema from "./schema.sqlite.js";
 import * as pgSchema from "./schema.pg.js";
-import { seedExampleDataIfEmpty } from "../core/seed.js";
+import { seedFreshInstall } from "../core/seed.js";
 import { getDefaultProject } from "../core/project/projects.js";
 import { logger } from "../log.js";
 
@@ -65,32 +65,31 @@ export async function initDb(): Promise<Db> {
   const url = process.env.AGENTX_DB_URL;
   if (url && url.startsWith("postgres")) {
     const pool = new Pool({ connectionString: url });
-    await bootstrapPostgres(pool);
+    const { freshInstall } = await bootstrapPostgres(pool);
     // "" is a deliberate never-matches-a-real-project sentinel - see the Db type's own comment.
     cached = { kind: "postgres", db: drizzlePg(pool, { schema: pgSchema }), schema: pgSchema, projectId: "" };
     closeHandle = () => pool.end();
     await seedPortabilityModelsIfEmpty(cached);
     await ensureRealWorldPortabilityModels(cached);
-    // seedExampleDataIfEmpty writes project-scoped rows (datasets, agents, traces, ...), so it
-    // needs a real projectId, not `cached`'s never-matches sentinel (see the Db type's own
-    // comment) - backfillDefaultProjectPostgres above already guarantees a default project
-    // exists by this point. The `?? cached` fallback is unreachable in practice, kept only so a
-    // violated invariant here degrades to today's existing (broken) behavior instead of a new,
-    // different crash.
-    const defaultProject = await getDefaultProject(cached);
-    await seedExampleDataIfEmpty(defaultProject ? withProjectId(cached, defaultProject.id) : cached);
+    // The example content goes into its own "Example" project, created here on a fresh install
+    // only - Default is left genuinely empty so the first trace someone sends is the first row
+    // they see. See core/seed.ts.
+    await seedFreshInstall(cached, { freshInstall });
     return cached;
   }
 
   const sqlitePath = url?.startsWith("sqlite:") ? url.slice("sqlite:".length) : defaultSqlitePath();
   fs.mkdirSync(path.dirname(sqlitePath), { recursive: true });
 
+  // Set by whichever sqlite driver branch runs below; both bootstrap the same schema.
+  let freshInstall = false;
+
   if (isBun) {
     const { Database: BunDatabase } = await import("bun:sqlite");
     const { drizzle: drizzleBun } = await import("drizzle-orm/bun-sqlite");
     const sqlite = new BunDatabase(sqlitePath);
     sqlite.exec("PRAGMA journal_mode = WAL;");
-    bootstrapSqlite(sqlite);
+    ({ freshInstall } = bootstrapSqlite(sqlite));
     cached = {
       kind: "sqlite",
       db: drizzleBun(sqlite, { schema: sqliteSchema }) as unknown as BetterSQLite3Database<typeof sqliteSchema>,
@@ -105,7 +104,7 @@ export async function initDb(): Promise<Db> {
     const { drizzle: drizzleSqlite } = await import("drizzle-orm/better-sqlite3");
     const sqlite = new BetterSqlite3(sqlitePath);
     sqlite.pragma("journal_mode = WAL");
-    bootstrapSqlite(sqlite);
+    ({ freshInstall } = bootstrapSqlite(sqlite));
     cached = { kind: "sqlite", db: drizzleSqlite(sqlite, { schema: sqliteSchema }), schema: sqliteSchema, projectId: "" };
     closeHandle = () => {
       sqlite.close();
@@ -113,9 +112,8 @@ export async function initDb(): Promise<Db> {
   }
   await seedPortabilityModelsIfEmpty(cached);
   await ensureRealWorldPortabilityModels(cached);
-  // See the postgres branch above for why this needs a real projectId, not `cached` directly.
-  const defaultProject = await getDefaultProject(cached);
-  await seedExampleDataIfEmpty(defaultProject ? withProjectId(cached, defaultProject.id) : cached);
+  // See the postgres branch above.
+  await seedFreshInstall(cached, { freshInstall });
   return cached;
 }
 
@@ -320,7 +318,7 @@ const SEEDED_SETTINGS_BACKFILL_NAMES = [
   .map(name => `'${name}'`)
   .join(", ");
 
-function bootstrapSqlite(sqlite: SqliteHandle): void {
+function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean } {
   // Checked BEFORE any DDL runs: `seeded` is backfilled by name exactly once, at the upgrade
   // that introduces the column (see the UPDATE after columnMigrations). Running it on every
   // boot could misclassify a user's scorer that happens to share a seed name.
@@ -1145,7 +1143,7 @@ function bootstrapSqlite(sqlite: SqliteHandle): void {
   migrateOnlineEvaluatorsToConfigsSqlite(sqlite);
   enforceJudgeScorerCardinalitySqlite(sqlite);
   backfillAgentsSqlite(sqlite);
-  backfillDefaultProjectSqlite(sqlite);
+  const { freshInstall } = backfillDefaultProjectSqlite(sqlite);
 
   // One-way Topics migration: the toggle moved from per-agent monitor_profiles.topics_enabled to
   // project-level projects.topics_enabled. Copy "any agent had it on" up to the project, then
@@ -1160,6 +1158,7 @@ function bootstrapSqlite(sqlite: SqliteHandle): void {
   `);
 
   ensureProjectScopedUniqueIndexes(statement => sqlite.exec(statement));
+  return { freshInstall };
 }
 
 // prompt_versions has had this index since it shipped; tool_schema_versions never got the
@@ -1499,7 +1498,7 @@ function backfillAgentsSqlite(sqlite: SqliteHandle): void {
 // INTEGER epoch, BOOLEAN instead of INTEGER 0/1, DOUBLE PRECISION instead of REAL) matching
 // schema.pg.ts. Replace with real drizzle-kit migrations once the schema stabilizes, see plan
 // task #107 (same note as bootstrapSqlite).
-async function bootstrapPostgres(pool: Pool): Promise<void> {
+async function bootstrapPostgres(pool: Pool): Promise<{ freshInstall: boolean }> {
   // See bootstrapSqlite: checked BEFORE any DDL so the one-shot `seeded` backfill below runs
   // only at the upgrade that introduces the column.
   const settingsSeededColumnPreexists =
@@ -2270,7 +2269,7 @@ async function bootstrapPostgres(pool: Pool): Promise<void> {
   await migrateOnlineEvaluatorsToConfigsPostgres(pool);
   await enforceJudgeScorerCardinalityPostgres(pool);
   await backfillAgentsPostgres(pool);
-  await backfillDefaultProjectPostgres(pool);
+  const { freshInstall } = await backfillDefaultProjectPostgres(pool);
 
   for (const statement of PROJECT_SCOPED_UNIQUE_INDEXES) {
     try {
@@ -2282,6 +2281,7 @@ async function bootstrapPostgres(pool: Pool): Promise<void> {
       );
     }
   }
+  return { freshInstall };
 }
 
 // Postgres mirror of migrateOnlineEvaluatorsToConfigsSqlite above - see that function's comment
@@ -2481,7 +2481,7 @@ function readExistingLocalApiKey(): string | null {
 // register a second project afterward. Safe to re-run: only creates a project if none exist yet
 // (an already-migrated install just reuses the existing Default project's id), and only backfills
 // rows still NULL.
-function backfillDefaultProjectSqlite(sqlite: SqliteHandle): void {
+function backfillDefaultProjectSqlite(sqlite: SqliteHandle): { freshInstall: boolean } {
   const existing = sqlite.prepare(`SELECT id FROM projects ORDER BY created_at ASC LIMIT 1`).all() as {
     id: string;
   }[];
@@ -2506,11 +2506,12 @@ function backfillDefaultProjectSqlite(sqlite: SqliteHandle): void {
   for (const table of PROJECT_SCOPED_TABLES) {
     sqlite.prepare(`UPDATE ${table} SET project_id = ? WHERE project_id IS NULL`).run(defaultProjectId);
   }
+  return { freshInstall: existing.length === 0 };
 }
 
 // Postgres mirror of backfillDefaultProjectSqlite above - see that function's comment for the
 // full rationale.
-async function backfillDefaultProjectPostgres(pool: Pool): Promise<void> {
+async function backfillDefaultProjectPostgres(pool: Pool): Promise<{ freshInstall: boolean }> {
   const { rows: existing } = await pool.query<{ id: string }>(`SELECT id FROM projects ORDER BY created_at ASC LIMIT 1`);
   let defaultProjectId: string;
   if (existing.length > 0) {
@@ -2533,4 +2534,5 @@ async function backfillDefaultProjectPostgres(pool: Pool): Promise<void> {
   for (const table of PROJECT_SCOPED_TABLES) {
     await pool.query(`UPDATE ${table} SET project_id = $1 WHERE project_id IS NULL`, [defaultProjectId]);
   }
+  return { freshInstall: existing.length === 0 };
 }

--- a/engine/src/test/exampleProject.integration.test.ts
+++ b/engine/src/test/exampleProject.integration.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startEngine, type TestEngine } from "./server.js";
+
+// A fresh install used to put the example agent, its traces and a starter dataset into Default -
+// the same project someone points their SDK at first. Their real first trace then arrived into a
+// list next to invented ones, and every count on every page was their data plus ours.
+//
+// Now Default is genuinely empty and the tour lives in its own "Example" project. Pinned here
+// because the failure is quiet in both directions: seed content leaking back into Default looks
+// like the product working, and an Example project that never gets created looks like an empty
+// install nobody can evaluate.
+
+let engine: TestEngine;
+let defaultKey: string;
+let exampleKey: string;
+
+type Project = { _id: string; name: string; apiKey: string; isDefault: boolean };
+
+const api = (path: string, key: string) => engine.json(`/api/v1${path}`, { apiKey: key });
+
+async function count(path: string, key: string, field: string): Promise<number> {
+  const res = await api(path, key);
+  const body = res.body as Record<string, unknown>;
+  const list = body[field];
+  return Array.isArray(list) ? list.length : 0;
+}
+
+beforeAll(async () => {
+  engine = await startEngine();
+  const projects = ((await engine.json("/api/v1/projects")).body as { projects: Project[] }).projects;
+  defaultKey = projects.find(p => p.isDefault)!.apiKey;
+  exampleKey = projects.find(p => p.name === "Example")?.apiKey ?? "";
+}, 90_000);
+
+afterAll(async () => {
+  await engine?.stop();
+});
+
+describe("fresh install layout", () => {
+  it("creates exactly two projects: an empty Default and an Example", async () => {
+    const projects = ((await engine.json("/api/v1/projects")).body as { projects: Project[] }).projects;
+    expect(projects.map(p => p.name).sort()).toEqual(["Default", "Example"]);
+    expect(projects.find(p => p.name === "Default")!.isDefault).toBe(true);
+    // The example is a normal project, not a second default.
+    expect(projects.find(p => p.name === "Example")!.isDefault).toBe(false);
+  });
+
+  it("leaves Default with no content of its own", async () => {
+    expect(await count("/agent-monitoring/agents", defaultKey, "agents")).toBe(0);
+    expect(await count("/custom-agent-evaluations/datasets", defaultKey, "datasets")).toBe(0);
+    expect(await count("/evaluate/prompts", defaultKey, "prompts")).toBe(0);
+    expect(await count("/agent-monitoring/signals?workspaceId=local&polarity=all", defaultKey, "signals")).toBe(0);
+    const runs = (await api("/custom-agent-evaluations/runs", defaultKey)).body as { runs?: unknown[] };
+    expect(runs.runs ?? []).toHaveLength(0);
+  });
+
+  it("still gives Default the built-in scorer catalog, which is product, not example data", async () => {
+    const scorers = (await api("/agent-monitoring/judge-scorers", defaultKey)).body as { judgeScorers?: unknown[] };
+    // The metric pack seeds per project - an empty project is not a project without scorers.
+    expect((scorers.judgeScorers ?? []).length).toBeGreaterThan(0);
+  });
+
+  it("puts the tour in Example: an agent with traces, a dataset, a prompt", async () => {
+    expect(exampleKey).toBeTruthy();
+    expect(await count("/agent-monitoring/agents", exampleKey, "agents")).toBe(1);
+    expect(await count("/custom-agent-evaluations/datasets", exampleKey, "datasets")).toBe(1);
+    expect(await count("/evaluate/prompts", exampleKey, "prompts")).toBe(1);
+  });
+
+  it("gives Example a multi-turn session, not only single-exchange traces", async () => {
+    const sessions = (await api("/agent-monitoring/sessions?window=7d", exampleKey)).body as {
+      sessions?: { turnCount?: number; traceCount?: number }[];
+    };
+    const list = sessions.sessions ?? [];
+    expect(list.length).toBeGreaterThan(0);
+    const longest = Math.max(...list.map(s => s.turnCount ?? s.traceCount ?? 0));
+    expect(longest).toBeGreaterThanOrEqual(3);
+  });
+
+  it("gives Example topics to show, without having spent a judge call to get them", async () => {
+    const topics = (await api("/agent-monitoring/topics?window=7d", exampleKey)).body as {
+      topIntents?: { intent: string }[];
+    };
+    expect((topics.topIntents ?? []).length).toBeGreaterThan(0);
+  });
+
+  it("gives Example a finished run, so Evaluate opens on a result", async () => {
+    const runs = (await api("/custom-agent-evaluations/runs", exampleKey)).body as {
+      runs?: { status: string; averageRating: number | null }[];
+    };
+    const list = runs.runs ?? [];
+    expect(list.length).toBeGreaterThan(0);
+    expect(list[0]!.status).toBe("completed");
+    expect(list[0]!.averageRating).toBeGreaterThan(0);
+  });
+
+  it("detection ran on the example traces, so Review is not empty either", async () => {
+    const signals = (await api("/agent-monitoring/signals?workspaceId=local&polarity=all", exampleKey)).body as {
+      signals?: unknown[];
+    };
+    expect((signals.signals ?? []).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
The starter content went into Default - the project whose key is printed at boot and pasted into the first SDK call anyone makes. Their real first trace then arrived into a list beside an invented agent's, every count on every page was their data plus ours, and the first job on a new install was deleting all of it.

Default is now genuinely empty. A second project, "Example", holds the tour: the agent and its traces, a three-turn session, topics, a dataset, a prompt, a grading config, and one finished evaluation.

It is created on a fresh install only. The bootstrap already knew whether it had just created the default project - that answer is what "fresh install" means, and it now travels out to the seeder instead of being discarded. An existing install does not sprout a new project on upgrade, and deleting the Example project does not bring it back on the next restart.

Two additions to the content, both within this file's standing rule that a fresh install boots with no API key and spends nothing:

The topics rows are written directly rather than classified, so the trend, top intents and issue breakdown have something real to draw. The cost is visible and deliberate: no embeddings, so those rows never appear on the Topics map, while rows classified from real traffic later do.

The evaluation is a fixture, written as rows rather than driven through the run path, which would have made a judge call per case at install time against whatever key happened to be configured. A fresh install must not spend money to draw a chart.

Verified on a real fresh boot: Default has zero agents, datasets, prompts, sessions, signals, runs and topics while still carrying the 13 built-in scorers, and Example has all of them.

<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
