### PR TITLE
fix(evaluate): two report-quality bugs the eval deep-dive suite caught

### DIFF
--- a/engine/src/routes/evaluations.ts
+++ b/engine/src/routes/evaluations.ts
@@ -12,8 +12,7 @@ import {
   computeRunGate,
   recordGateResult,
   computeLiveStatistics,
-  MAX_BATCH_SIZE,
-} from "../core/evaluate/runs.js";
+  MAX_BATCH_SIZE, getRunResults, type RunResultRow,} from "../core/evaluate/runs.js";
 import { createPrompt, getPromptForSdk, listPromptsForSdk } from "../core/evaluate/prompts.js";
 import { runEvaluationAnalysis, getEvaluationAnalysisStatus, getEvaluationAnalysisRow } from "../core/evaluate/analysis.js";
 import { handleCasePreview, handleSuggestExpected, handleAddCase } from "./curationHandlers.js";
@@ -224,12 +223,25 @@ evaluationsRouter.get("/runs/:runId/report", async (req: Request, res: Response)
     res.status(404).json({ error: "No analysis found for this run. POST /runs/:runId/analyze first." });
     return;
   }
+  // A report that cannot point at its failures is a summary. The hosted platform sends
+  // lowScoringCases; this route silently omitted it, so the SDK's Report.low_scoring_cases was
+  // [] forever on self-host. Derived from the run's own rows: rating at or below the middle.
+  const results = await getRunResults(db, runId);
+  const lowScoringCases = results
+    .filter((r: RunResultRow) => r.rating != null && (r.rating as number) <= 5)
+    .map((r: RunResultRow) => ({
+      query: r.input?.query ?? null,
+      response: r.output?.text ?? null,
+      rating: r.rating,
+      justification: r.justification ?? null,
+    }));
   res.status(200).json({
     ...(row.analysis ?? {}),
     runId,
     datasetId: run.datasetId,
     status: row.status,
     statistics: row.statistics ?? null,
+    lowScoringCases,
   });
 });
 

--- a/packages/judge-core/src/index.ts
+++ b/packages/judge-core/src/index.ts
@@ -244,7 +244,9 @@ export const DEFAULT_JUDGE_PROMPT = `You are an expert AI evaluator. Score the a
 **Expected Results (reference answer - ground truth for facts):**
 {expected}
 
-Rate 0-10 (0 = fails the criteria completely, 5 = partially meets them, 10 = fully meets them) with a concise justification written in the language the query itself is written in (if unclear, English).
+Rate 0-10 (0 = fails the criteria completely, 5 = partially meets them, 10 = fully meets them) with a concise justification.
+
+**LANGUAGE:** Write the justification in the language the User Query itself is written in - an English query gets an English justification. If the query's language is unclear or mixed, write in English.
 
 Rules:
 - The evaluation criteria are the rubric. Score how well the response meets them; the Expected Results tell you which facts are true - never fact-check, dispute, or second-guess them with outside knowledge.


### PR DESCRIPTION
Both were found by writing assertions against a live engine rather than reading code, and both are the quiet kind.

1. The default (reference-guided) judge prompt could answer in the wrong language. The metric-pack prompts got an explicit bold LANGUAGE block when this bug first surfaced; the default prompt got only a soft inline clause, and gpt-5.6-luna ignored it - an English query about return policy came back with "La respuesta contradice directamente...". The default prompt now carries the same LANGUAGE block as its reference-free sibling. Verified live: same case, English justification.

2. GET /runs/:id/report never populated lowScoringCases. The SDK models the field (the hosted platform sends it), so on self-host Report.low_scoring_cases was [] forever - a run with a 0-rated row produced a report that could not point at its own failure. The route now derives it from the run's rows (rating <= 5, with query, response, rating and justification). Verified live: the fluent-but-wrong answer is flagged.

judge-core's dist/ is gitignored (rebuilt at install); the src change is the source of truth.

Evidence and the suite that caught both:
sample-scripts/eval_deep_dive (01-06, all green on a fresh engine).

Note: cloudOps.integration.test.ts "caps daily root-trace ingest" fails on clean main as well (verified via stash) - pre-existing, not touched here.

<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
