### PR TITLE
chore: bump pg ^8.23.0 and typescript ^6.0.3

### DIFF
--- a/engine/package.json
+++ b/engine/package.json
@@ -29,7 +29,7 @@
     "nanoid": "^5.0.7",
     "nodemailer": "^9.0.5",
     "openai": "^7.5.0",
-    "pg": "^8.12.0",
+    "pg": "^8.23.0",
     "pino": "^10.3.1",
     "protobufjs": "^8.7.1",
     "re2js": "^2.8.6",
@@ -47,7 +47,7 @@
     "c8": "^12.0.0",
     "eslint": "^10.9.1",
     "tsx": "^4.19.0",
-    "typescript": "^5.5.4",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.68.0",
     "vitest": "^4.0.5"
   }

--- a/engine/src/test/cloudOps.integration.test.ts
+++ b/engine/src/test/cloudOps.integration.test.ts
@@ -52,7 +52,7 @@ beforeAll(async () => {
     AGENTX_MULTI_TENANT: "true",
     AGENTX_ADMIN_TOKEN: ADMIN_TOKEN,
     AGENTX_EMAIL_DEBUG_DIR: mailDir,
-    AGENTX_QUOTA_TRACES_PER_DAY: "6",
+    AGENTX_QUOTA_TRACES_PER_DAY: "12",
     AGENTX_QUOTA_JUDGE_CALLS_PER_DAY: "1",
   });
   carolCookie = await signUp("carol@tenant.test", "Carol");
@@ -92,19 +92,21 @@ describe("mailer", () => {
 
 describe("quotas", () => {
   it("caps daily root-trace ingest per project, children ride free", async () => {
-    // The tenant's seeded example project starts with 3 starter traces, but their createdAt is
-    // backdated ~10 minutes (seed.ts stamps startedAt for a believable timeline, and ingest
-    // uses startedAt as createdAt) - so in the first minutes after LOCAL midnight they fall
-    // outside the quota's dayStart() window and don't count. Compute today's usage instead of
-    // assuming 3, so this test doesn't fail between 00:00 and 00:10.
+    // The tenant's project is seeded with example traces whose count has grown before and will
+    // again (it broke this test at 6 seeded roots against a quota of 6). So: never assume the
+    // seed size. Compute today's usage from the trace list (seeded rows are backdated a few
+    // minutes, so right after local midnight some fall outside the quota's dayStart() window),
+    // and assert the quota leaves headroom - if seeding ever meets or exceeds the quota again,
+    // this line names the real problem instead of the loop below silently doing nothing.
+    const QUOTA = 12;
     const midnight = new Date();
     midnight.setHours(0, 0, 0, 0);
     const listed = await engine.json("/api/v1/ingest/traces?limit=100", { apiKey: carolKey });
     const usedToday = (bodyOf(listed).traces as { createdAt: string }[]).filter(
       t => new Date(t.createdAt) >= midnight
     ).length;
-    const room = 6 - usedToday;
-    expect(room).toBeGreaterThan(0);
+    const room = QUOTA - usedToday;
+    expect(room, `seeding uses ${usedToday} of the ${QUOTA}/day test quota - raise the quota env above`).toBeGreaterThan(0);
     for (let i = 0; i < room; i++) {
       const ok = await engine.json("/api/v1/ingest/traces", {
         ...json({ name: "quota-agent", input: `q${i}`, output: "a" }),

--- a/packages/judge-core/package.json
+++ b/packages/judge-core/package.json
@@ -18,7 +18,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json --emitDeclarationOnly --declarationDir dist",
     "dev": "tsup --watch",
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p ."
@@ -32,7 +32,7 @@
     "@types/node": "^22.5.0",
     "openai": "^7.5.0",
     "tsup": "^8.5.0",
-    "typescript": "^5.5.4",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.5"
   }
 }

--- a/packages/judge-core/tsconfig.build.json
+++ b/packages/judge-core/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/judge-core/tsconfig.json
+++ b/packages/judge-core/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ES2020"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/packages/judge-core/tsup.config.ts
+++ b/packages/judge-core/tsup.config.ts
@@ -6,7 +6,6 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm", "cjs"],
-  dts: true,
   sourcemap: true,
   clean: true,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2702,10 +2702,15 @@ pg-pool@^3.14.0:
   resolved "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz"
   integrity sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==
 
-pg-protocol@*, pg-protocol@^1.15.0:
+pg-protocol@*:
   version "1.15.0"
   resolved "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz"
   integrity sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==
+
+pg-protocol@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.16.0.tgz#cffb008826561ee9770a8a15dc21f269d731b305"
+  integrity sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==
 
 pg-types@2.2.0, pg-types@^2.2.0:
   version "2.2.0"
@@ -2718,14 +2723,14 @@ pg-types@2.2.0, pg-types@^2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8.12.0:
-  version "8.22.0"
-  resolved "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz"
-  integrity sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==
+pg@^8.23.0:
+  version "8.23.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.23.0.tgz#5c2026d32bd0cb4fbd9196bac1ecf5ae66607180"
+  integrity sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==
   dependencies:
     pg-connection-string "^2.14.0"
     pg-pool "^3.14.0"
-    pg-protocol "^1.15.0"
+    pg-protocol "^1.16.0"
     pg-types "2.2.0"
     pgpass "1.0.5"
   optionalDependencies:
@@ -3487,10 +3492,10 @@ typescript-eslint@^8.68.0:
     "@typescript-eslint/typescript-estree" "8.68.0"
     "@typescript-eslint/utils" "8.68.0"
 
-typescript@^5.5.4:
-  version "5.9.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 ufo@^1.6.3:
   version "1.6.4"


### PR DESCRIPTION
pg 8.12 -> 8.23 is minor-line and behaved like it: the full suite ran against a real Postgres 16 with AGENTX_TEST_DB_URL set, which un-skipped all 37 dialect/parity tests - 621/621 green - and a live engine booted on AGENTX_DB_URL served the eval samples end to end.

typescript 5.5 -> 6.0 is a real major and surfaced two toolchain truths, both fixed here rather than papered over:

- judge-core's tsconfig never declared "types": ["node"]. TS <= 5.5 auto-included the hoisted @types and hid it; 6.0 does not, and every console call was suddenly undeclared. The dependency was always real - now it is stated.
- tsup's dts step drives the TypeScript compiler API through a bundled rollup-plugin-dts, which lags TS majors (it broke on 6 and cannot work on 7's native compiler at all). Declarations now come from tsc itself (--emitDeclarationOnly, tests excluded via tsconfig.build); tsup keeps doing what esbuild is good at, the dual-format JS. The exports map already pointed at dist/index.d.ts, so consumers see no change.

TypeScript 7.0 was tried first: the engine typechecks clean under the native compiler, but the ecosystem it builds with does not follow yet, so 6.0.3 is the honest "latest that keeps every tool working".

Also fixes the failing cloudOps quota test, which was not flaky but deterministic: the Example-project seeding grew to 6 root traces per tenant, exactly consuming the test's 6/day quota, leaving zero headroom. Quota env raised to 12 and the test now names the real problem ("seeding uses N of the quota") if seeding ever catches up again, instead of a bare 0 > 0 failure.

<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
