### PR TITLE
feat(trace): separate eval-run traffic from production monitoring

### DIFF
--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -95,6 +95,8 @@ export const traceListItemSchema = z
     toolCalls: z.unknown().optional(),
     sessionId: z.string().optional(),
     spanId: z.string().optional(),
+    // "eval-run" for traffic produced inside an offline evaluation; absent for production.
+    trafficSource: z.string().optional(),
     parentSpanId: z.string().optional(),
     startedAt: isoDate.optional(),
     source: z.literal("sdk"),

--- a/engine/src/core/monitor/cost.ts
+++ b/engine/src/core/monitor/cost.ts
@@ -2,6 +2,7 @@ import { and, eq, gte } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import { listPortabilityModels, estimateCostUSD, normalizeModelId } from "../evaluate/models.js";
 import type { MonitoringWindow } from "./events.js";
+import { EVAL_RUN_SOURCE } from "../trace/evalTraffic.js";
 
 // Overview's "Total LLM cost" chart (Braintrust-style stacked bar, but stacked by model rather
 // than token type - self-host doesn't track cache-read/cache-write tokens per trace today, and
@@ -24,7 +25,7 @@ function windowConfig(window: MonitoringWindow): { days: number; bucketHours: nu
   }
 }
 
-type CostTraceRow = { model: string | null; inputTokens: number | null; outputTokens: number | null; createdAt: Date };
+type CostTraceRow = { model: string | null; inputTokens: number | null; outputTokens: number | null; createdAt: Date; source: string | null };
 
 async function listCostTracesSince(db: Db, since: Date): Promise<CostTraceRow[]> {
   const cond = and(gte(db.schema.traces.createdAt, since), eq(db.schema.traces.projectId, db.projectId));
@@ -39,6 +40,7 @@ async function listCostTracesSince(db: Db, since: Date): Promise<CostTraceRow[]>
             inputTokens: db.schema.traces.inputTokens,
             outputTokens: db.schema.traces.outputTokens,
             createdAt: db.schema.traces.createdAt,
+            source: db.schema.traces.source,
           })
           .from(db.schema.traces)
           .where(cond)
@@ -49,11 +51,16 @@ async function listCostTracesSince(db: Db, since: Date): Promise<CostTraceRow[]>
             inputTokens: db.schema.traces.inputTokens,
             outputTokens: db.schema.traces.outputTokens,
             createdAt: db.schema.traces.createdAt,
+            source: db.schema.traces.source,
           })
           .from(db.schema.traces)
           .where(cond);
   return rows as CostTraceRow[];
 }
+
+// The reserved stack key for spend from eval-run traffic. Eval spend is real money, so the
+// chart INCLUDES it - split into its own segment - where the monitor KPIs exclude it entirely.
+export const EVAL_COST_KEY = "eval runs";
 
 export type CostTrendPoint = {
   label: string;
@@ -144,8 +151,12 @@ export async function getCostTrend(db: Db, window: MonitoringWindow): Promise<Co
       continue;
     }
     const bucket = buckets[index]!;
-    bucket[matchedId] = (bucket[matchedId] ?? 0) + cost;
-    totalsByModel[matchedId] = (totalsByModel[matchedId] ?? 0) + cost;
+    // Eval-run spend goes into its own segment rather than the model's: the question this chart
+    // answers is "what is production costing me, and what is evaluation costing me" - folding
+    // eval spend into gpt-4o-mini's bar would hide the second answer inside the first.
+    const key = row.source === EVAL_RUN_SOURCE ? EVAL_COST_KEY : matchedId;
+    bucket[key] = (bucket[key] ?? 0) + cost;
+    totalsByModel[key] = (totalsByModel[key] ?? 0) + cost;
     totalCost += cost;
   }
 

--- a/engine/src/core/monitor/events.ts
+++ b/engine/src/core/monitor/events.ts
@@ -3,6 +3,7 @@ import { and, eq, gte, isNull, lt } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import { getTraceRow } from "../trace/ingest.js";
 import { getAgentNamesById } from "./agents.js";
+import { productionTracesOnly } from "../trace/evalTraffic.js";
 
 // Matches AgentX-web-front's MonitoringWindow (src/types/agentMonitoring.ts).
 export type MonitoringWindow = "24h" | "7d" | "30d";
@@ -196,7 +197,8 @@ export async function listEventsSince(db: Db, since: Date): Promise<EventRow[]> 
 }
 
 async function listTraceLatenciesSince(db: Db, since: Date): Promise<number[]> {
-  const cond = and(gte(db.schema.traces.createdAt, since), eq(db.schema.traces.projectId, db.projectId));
+  // Production only: a nightly eval's latencies are not the fleet's P95.
+  const cond = and(gte(db.schema.traces.createdAt, since), eq(db.schema.traces.projectId, db.projectId), productionTracesOnly(db));
   const rows = (
     db.kind === "sqlite"
       ? db.db.select({ latencyMs: db.schema.traces.latencyMs }).from(db.schema.traces).where(cond).all()
@@ -458,7 +460,8 @@ export type MonitoringTopFailingResponse = {
 // MCP-registered tools are included like any other), where the signal path only flags the first
 // failed call of a trace and knows no denominator for a rate.
 async function listToolCallStatsSince(db: Db, since: Date): Promise<Map<string, { total: number; failures: number }>> {
-  const cond = and(gte(db.schema.traces.createdAt, since), eq(db.schema.traces.projectId, db.projectId));
+  // Production only - eval datasets deliberately include failing tool calls.
+  const cond = and(gte(db.schema.traces.createdAt, since), eq(db.schema.traces.projectId, db.projectId), productionTracesOnly(db));
   const rows = (
     db.kind === "sqlite"
       ? db.db.select({ toolCalls: db.schema.traces.toolCalls }).from(db.schema.traces).where(cond).all()

--- a/engine/src/core/monitor/metrics.ts
+++ b/engine/src/core/monitor/metrics.ts
@@ -1,6 +1,7 @@
 import { and, eq, gte } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import { listPortabilityModels, normalizeModelId, type PortabilityModel } from "../evaluate/models.js";
+import { productionTracesOnly } from "../trace/evalTraffic.js";
 
 // The Monitor metrics grid (claude.design Monitor.dc.html): one bucketed pass over the window's
 // trace rows powering every card - spans by kind, latency percentiles, tokens, priced cost,
@@ -159,7 +160,8 @@ export async function getMonitorMetrics(
   let rows: Row[];
   if (db.kind === "sqlite") {
     const t = db.schema.traces;
-    const cond = and(gte(t.createdAt, since), eq(t.projectId, db.projectId));
+    // Production only: the span/latency/token buckets describe live traffic, not eval harnesses.
+    const cond = and(gte(t.createdAt, since), eq(t.projectId, db.projectId), productionTracesOnly(db));
     rows = db.db
       .select({
         id: t.id,
@@ -181,7 +183,7 @@ export async function getMonitorMetrics(
       .all() as Row[];
   } else {
     const t = db.schema.traces;
-    const cond = and(gte(t.createdAt, since), eq(t.projectId, db.projectId));
+    const cond = and(gte(t.createdAt, since), eq(t.projectId, db.projectId), productionTracesOnly(db));
     rows = (await db.db
       .select({
         id: t.id,

--- a/engine/src/core/monitor/modelComparison.ts
+++ b/engine/src/core/monitor/modelComparison.ts
@@ -2,6 +2,7 @@ import { and, eq, gte } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import { listPortabilityModels, estimateCostUSD, normalizeModelId } from "../evaluate/models.js";
 import type { MonitoringWindow } from "./events.js";
+import { productionTracesOnly } from "../trace/evalTraffic.js";
 
 // Overview's "Model comparison" table - how each LLM actually performing in production stacks up
 // on quality, latency, cost, and volume, side by side. The production complement to the
@@ -47,7 +48,7 @@ type ComparisonEventRow = {
 // union), and the codebase's existing idiom for cross-dialect fetches is full rows + a cast (see
 // events.ts's listEventsSince). Volume is the same windowed set getKpis already pulls.
 async function listComparisonTracesSince(db: Db, since: Date): Promise<ComparisonTraceRow[]> {
-  const cond = and(gte(db.schema.traces.createdAt, since), eq(db.schema.traces.projectId, db.projectId));
+  const cond = and(gte(db.schema.traces.createdAt, since), eq(db.schema.traces.projectId, db.projectId), productionTracesOnly(db));
   // Every row, not just root spans - same reasoning as cost.ts's listCostTracesSince: an OTel
   // session's individual LLM-call spans each carry their own model/tokens, and filtering to roots
   // would undercount both spend and volume.

--- a/engine/src/core/monitor/sessions.ts
+++ b/engine/src/core/monitor/sessions.ts
@@ -4,6 +4,7 @@ import type { MonitoringWindow } from "./events.js";
 import { getAgentNamesById } from "./agents.js";
 import { listOnlineEvaluatorRows } from "./onlineEvaluators.js";
 import { SESSION_BASELINE_KEY } from "./builtinEvaluators.js";
+import { productionTracesOnly } from "../trace/evalTraffic.js";
 
 // The Sessions surface under Observe: one row per conversation (traces sharing a session_id),
 // the level Live Traces deliberately doesn't show (one row = one interaction there). Turn count
@@ -77,6 +78,8 @@ export async function listSessions(db: Db, window: MonitoringWindow): Promise<Se
   const cond = and(
     gte(db.schema.traces.createdAt, since),
     isNotNull(db.schema.traces.sessionId),
+    // Production only: an eval run's per-case sessions are not conversations anyone held.
+    productionTracesOnly(db),
     eq(db.schema.traces.projectId, db.projectId)
   );
   const rows = (

--- a/engine/src/core/trace/evalTraffic.ts
+++ b/engine/src/core/trace/evalTraffic.ts
@@ -1,0 +1,31 @@
+import { isNull, ne, or, type SQL } from "drizzle-orm";
+import type { Db } from "../../storage/db.js";
+
+// Offline evaluation runs produce real traces - that is what makes trajectory matching and
+// retrieval-context extraction work - but they are not production traffic, and a nightly
+// 200-case eval must not read as Monday's production health. The SDK stamps those traces
+// source = "eval-run" at ingest; this module is the one place that says what that means:
+//
+//   - monitor surfaces (KPIs, span metrics, sessions, model comparison, live-traces default
+//     view) EXCLUDE eval traffic, via productionTracesOnly below
+//   - cost INCLUDES it, split out, because eval judge/agent spend is real money and hiding it
+//     would be its own kind of lie
+//   - per-trace features (open a trace from a run result, trajectory, retrieval context) are
+//     untouched - they address traces by id, not by aggregation
+//
+// The vocabulary is deliberately one value. "playground" or "synthetic" can join later; until
+// something produces them, an enum of one is honest.
+export const EVAL_RUN_SOURCE = "eval-run";
+
+// Parse what a producer stated. Unknown words become null (production) rather than being stored
+// as a fact nobody defined - the same posture as normalizeSpanKind.
+export function normalizeTraceSource(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  return raw.trim().toLowerCase() === EVAL_RUN_SOURCE ? EVAL_RUN_SOURCE : null;
+}
+
+// The WHERE fragment every production-only aggregation shares. Null (everything before this
+// column existed, and all normal traffic) is production.
+export function productionTracesOnly(db: Db): SQL {
+  return or(isNull(db.schema.traces.source), ne(db.schema.traces.source, EVAL_RUN_SOURCE)) as SQL;
+}

--- a/engine/src/core/trace/ingest.ts
+++ b/engine/src/core/trace/ingest.ts
@@ -7,6 +7,7 @@ import { listPortabilityModels, estimateCostUSD } from "../evaluate/models.js";
 import { getClassificationForTrace } from "../monitor/topics.js";
 import { unixNanosToDate } from "../shared/unixNano.js";
 import { logger } from "../../log.js";
+import { EVAL_RUN_SOURCE, normalizeTraceSource, productionTracesOnly } from "./evalTraffic.js";
 
 // Mirrors the wire payload agentx.tracing.tracer.Tracer._send builds in the Python SDK
 // (agentx/tracing/tracer.py); see AgentX-Python for the exact field list this was checked
@@ -58,6 +59,10 @@ export const ingestTraceSchema = z.preprocess(foldCamelAliases, z.object({
   framework: z.string().optional(),
   model: z.string().optional(),
   tool_calls: z.array(z.record(z.unknown())).optional(),
+  // Where this trace came from. "eval-run" marks traffic produced inside an offline evaluation
+  // run (the SDK's execute() stamps it); the monitor surfaces exclude it. Unknown words store as
+  // null rather than as a category nobody defined.
+  source: z.string().optional(),
   metadata: z.record(z.unknown()).optional(),
   session_id: z.string().optional(),
   performance_summary: z.record(z.unknown()).optional(),
@@ -138,6 +143,7 @@ export async function ingestTrace(
     framework: payload.framework ?? null,
     model: payload.model ?? null,
     toolCalls: payload.tool_calls ?? null,
+    source: normalizeTraceSource(payload.source),
     metadata: payload.metadata ?? null,
     sessionId: payload.session_id ?? null,
     performanceSummary: payload.performance_summary ?? null,
@@ -205,6 +211,7 @@ export type TraceRow = {
   cacheReadTokens: number | null;
   cacheWriteTokens: number | null;
   spanId: string | null;
+  source: string | null;
   parentSpanId: string | null;
   startedAt: Date | null;
   createdAt: Date;
@@ -230,6 +237,8 @@ function toWire(row: TraceRow) {
     spanId: row.spanId ?? undefined,
     parentSpanId: row.parentSpanId ?? undefined,
     startedAt: row.startedAt ? row.startedAt.toISOString() : undefined,
+    // "eval-run" for traces produced inside an offline evaluation; absent for production.
+    trafficSource: row.source ?? undefined,
     source: "sdk" as const,
     createdAt: row.createdAt.toISOString(),
     inputTokens: row.inputTokens,
@@ -258,6 +267,7 @@ export function toTraceDetailWire(row: TraceRow) {
     spanId: row.spanId ?? undefined,
     parentSpanId: row.parentSpanId ?? undefined,
     startedAt: row.startedAt ? row.startedAt.toISOString() : undefined,
+    trafficSource: row.source ?? undefined,
     metadata: row.metadata ?? undefined,
     performanceSummary: row.performanceSummary ?? undefined,
     source: "sdk" as const,
@@ -302,7 +312,13 @@ export async function toTraceDetailWireWithCost(db: Db, row: TraceRow) {
 // evolving this GET response shape for the dashboard doesn't risk SDK compatibility.
 export async function listTracesPaginated(
   db: Db,
-  { limit = 50, cursor, framework, search }: { limit?: number; cursor?: string; framework?: string; search?: string }
+  {
+    limit = 50,
+    cursor,
+    framework,
+    search,
+    source,
+  }: { limit?: number; cursor?: string; framework?: string; search?: string; source?: "production" | "eval" | "all" }
 ) {
   const pageSize = Math.min(Math.max(limit, 1), 100);
 
@@ -322,6 +338,10 @@ export async function listTracesPaginated(
   // only changes what the top-level list itself enumerates.
   const conditions: SQL[] = [isNull(db.schema.traces.parentSpanId), eq(db.schema.traces.projectId, db.projectId)];
   if (framework) conditions.push(eq(db.schema.traces.framework, framework));
+  // "production" (the Live Traces default) hides eval-run traffic; "eval" shows only it; "all"
+  // (and absent, for SDK/API compatibility) filters nothing.
+  if (source === "production") conditions.push(productionTracesOnly(db));
+  if (source === "eval") conditions.push(eq(db.schema.traces.source, EVAL_RUN_SOURCE));
   // Database-side search (the dashboard's Live Traces box) - a LIKE across the columns a person
   // actually greps traffic by: agent name, input/output text, model, error, and the trace/session
   // ids (so a pasted id resolves). SQLite LIKE is already case-insensitive for ASCII; Postgres

--- a/engine/src/routes/ingest.ts
+++ b/engine/src/routes/ingest.ts
@@ -101,6 +101,15 @@ ingestRouter.post("/traces", async (req: Request, res: Response) => {
     return;
   }
 
+  // Eval-run traffic never triggers monitoring on its own: the run's evaluator already judges
+  // every case, so detection would double-count, online judges would double-bill, and topics
+  // would classify synthetic questions. This is server-side belt to the SDK's monitor=False
+  // suspenders - a caller that stamps source but forgets the flag is still safe. An EXPLICIT
+  // monitor=true wins: that is someone deliberately pointing checks at eval traffic.
+  if (parsed.data.source === "eval-run" && parsed.data.monitor !== true) {
+    return;
+  }
+
   // Checked in the background, after responding: no background job queue in self-host (see plan
   // task #110), this is the same in-process fire-and-forget shape, just no longer blocking the
   // response the caller is actually waiting on. A caller polling client.monitor.signals or
@@ -177,11 +186,14 @@ ingestRouter.post("/traces", async (req: Request, res: Response) => {
 // Cursor-paginated, matching src/data/queries/evaluate/useGetProductionTraces.ts's params/
 // response shape exactly, see core/trace/ingest.ts's listTracesPaginated.
 ingestRouter.get("/traces", async (req: Request, res: Response) => {
-  const { limit, cursor, framework, search } = req.query;
+  const { limit, cursor, framework, search, source } = req.query;
   const result = await listTracesPaginated(scopedDb(req), {
     limit: limit ? Number(limit) : undefined,
     cursor: typeof cursor === "string" ? cursor : undefined,
     framework: typeof framework === "string" ? framework : undefined,
+    // "production" | "eval" | "all"; absent = all, for SDK/API compatibility. The dashboard's
+    // Live Traces sends "production" by default.
+    source: source === "production" || source === "eval" || source === "all" ? source : undefined,
     search: typeof search === "string" ? search : undefined,
   });
   res.status(200).json(result);

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -378,6 +378,7 @@ function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean } {
       output_tokens INTEGER,
       cache_read_tokens INTEGER,
       cache_write_tokens INTEGER,
+      source TEXT,
       span_id TEXT,
       parent_span_id TEXT,
       started_at INTEGER,
@@ -1027,6 +1028,7 @@ function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean } {
     // project_id column, backfilled to one auto-created "Default" project by
     // backfillDefaultProjectSqlite below - see that function's comment for why portability_models/
     // app_settings are deliberately excluded from this list (they stay instance-wide).
+    ["traces", "ALTER TABLE traces ADD COLUMN source TEXT"],
     ["traces", "ALTER TABLE traces ADD COLUMN project_id TEXT"],
     ["agents", "ALTER TABLE agents ADD COLUMN project_id TEXT"],
     ["datasets", "ALTER TABLE datasets ADD COLUMN project_id TEXT"],
@@ -1553,6 +1555,7 @@ async function bootstrapPostgres(pool: Pool): Promise<{ freshInstall: boolean }>
       output_tokens INTEGER,
       cache_read_tokens INTEGER,
       cache_write_tokens INTEGER,
+      source TEXT,
       span_id TEXT,
       parent_span_id TEXT,
       started_at TIMESTAMP,

--- a/engine/src/storage/schema.pg.ts
+++ b/engine/src/storage/schema.pg.ts
@@ -42,6 +42,11 @@ export const traces = pgTable("traces", {
   cacheReadTokens: integer("cache_read_tokens"),
   cacheWriteTokens: integer("cache_write_tokens"),
   // See schema.sqlite.ts's traces.spanId/parentSpanId/startedAt for the full comment.
+  // Where this trace came from: null = production traffic; "eval-run" = produced inside an
+  // offline evaluation run (stamped by the SDK's execute()). The monitor surfaces exclude
+  // eval-run traffic so a nightly eval cannot skew production KPIs; cost keeps it, split out,
+  // because eval spend is real spend. See core/trace/evalTraffic.ts.
+  source: text("source"),
   spanId: text("span_id"),
   parentSpanId: text("parent_span_id"),
   startedAt: timestamp("started_at", { mode: "date" }),

--- a/engine/src/storage/schema.sqlite.ts
+++ b/engine/src/storage/schema.sqlite.ts
@@ -82,6 +82,11 @@ export const traces = sqliteTable("traces", {
   // concept. spanId/parentSpanId let a session's rows (sessionId = the OTel traceId) be assembled
   // into a tree; startedAt is the absolute span start (otherwise only the derived latencyMs
   // duration survives ingestion, never enough on its own for a waterfall's relative positioning).
+  // Where this trace came from: null = production traffic; "eval-run" = produced inside an
+  // offline evaluation run (stamped by the SDK's execute()). The monitor surfaces exclude
+  // eval-run traffic so a nightly eval cannot skew production KPIs; cost keeps it, split out,
+  // because eval spend is real spend. See core/trace/evalTraffic.ts.
+  source: text("source"),
   spanId: text("span_id"),
   parentSpanId: text("parent_span_id"),
   startedAt: integer("started_at", { mode: "timestamp_ms" }),

--- a/engine/src/test/evalTraffic.integration.test.ts
+++ b/engine/src/test/evalTraffic.integration.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startEngine, postJson, type TestEngine } from "./server.js";
+
+// Eval-run traffic separation. An offline evaluation produces real traces (that is what makes
+// trajectory matching and retrieval-context extraction work), but they are not production
+// traffic. Pinned here: source="eval-run" traces never trigger monitoring on their own, are
+// excluded from the KPIs/metrics/sessions the Overview page builds trust on, stay reachable by
+// id and by explicit filter, and their spend still shows in cost - split out, not hidden.
+
+let engine: TestEngine;
+let key: string;
+
+const api = (path: string, init?: Parameters<TestEngine["json"]>[1]) =>
+  engine.json(`/api/v1${path}`, { apiKey: key, ...(init ?? {}) });
+
+async function ingest(body: Record<string, unknown>): Promise<string> {
+  const res = await api("/ingest/traces", postJson(body));
+  expect(res.status).toBe(200);
+  return (res.body as { trace_id: string }).trace_id;
+}
+
+let prodId: string;
+let evalId: string;
+
+beforeAll(async () => {
+  engine = await startEngine();
+  const created = await engine.json("/api/v1/projects", { ...postJson({ name: "eval-traffic" }), apiKey: null });
+  key = (created.body as { project: { apiKey: string } }).project.apiKey;
+
+  prodId = await ingest({
+    name: "prod-agent", input: "where is my order?", output: "It shipped.",
+    latency_ms: 500, model: "gpt-4o-mini", input_tokens: 100, output_tokens: 20,
+    session_id: "prod-sess", span_id: "p1",
+  });
+  // The eval trace: enormous latency and a failed tool call, exactly the kind of row that would
+  // wreck production KPIs if it counted.
+  evalId = await ingest({
+    name: "eval-agent", input: "synthetic case", output: "",
+    latency_ms: 60000, model: "gpt-4o-mini", input_tokens: 5000, output_tokens: 1000,
+    session_id: "eval-sess", span_id: "e1", source: "eval-run",
+    tool_calls: [{ name: "lookup", success: false, output: "boom" }],
+  });
+  await new Promise(r => setTimeout(r, 1200));
+}, 90_000);
+
+afterAll(async () => {
+  await engine?.stop();
+});
+
+describe("eval traffic separation", () => {
+  it("stores the stated source and puts it on the wire", async () => {
+    const all = (await api("/ingest/traces?limit=50&source=all")).body as { traces: { _id: string; trafficSource?: string }[] };
+    const byId = new Map(all.traces.map(t => [t._id, t.trafficSource]));
+    expect(byId.get(prodId)).toBeUndefined();
+    expect(byId.get(evalId)).toBe("eval-run");
+  });
+
+  it("ignores a source word nobody defined rather than storing it", async () => {
+    const id = await ingest({ name: "odd", input: "x", output: "y", source: "vibes" });
+    const all = (await api("/ingest/traces?limit=50&source=all")).body as { traces: { _id: string; trafficSource?: string }[] };
+    expect(all.traces.find(t => t._id === id)?.trafficSource).toBeUndefined();
+  });
+
+  it("hides eval traffic from the production list, shows it under its own filter", async () => {
+    const prod = (await api("/ingest/traces?limit=50&source=production")).body as { traces: { _id: string }[] };
+    expect(prod.traces.some(t => t._id === prodId)).toBe(true);
+    expect(prod.traces.some(t => t._id === evalId)).toBe(false);
+
+    const evals = (await api("/ingest/traces?limit=50&source=eval")).body as { traces: { _id: string }[] };
+    expect(evals.traces.some(t => t._id === evalId)).toBe(true);
+    expect(evals.traces.some(t => t._id === prodId)).toBe(false);
+
+    // Absent = all, so existing SDK/API callers see exactly what they always saw.
+    const dflt = (await api("/ingest/traces?limit=50")).body as { traces: { _id: string }[] };
+    expect(dflt.traces.some(t => t._id === evalId)).toBe(true);
+  });
+
+  it("keeps the eval trace reachable by id - per-trace features are untouched", async () => {
+    const detail = await api(`/ingest/traces/${evalId}`);
+    expect(detail.status).toBe(200);
+  });
+
+  it("keeps the 60s eval latency out of the KPI P95", async () => {
+    const kpis = (await api("/agent-monitoring/kpis?window=24h")).body as { p95LatencyMs: number | null };
+    expect(kpis.p95LatencyMs).not.toBeNull();
+    expect(kpis.p95LatencyMs!).toBeLessThan(10_000);
+  });
+
+  it("keeps eval spans and tokens out of the metrics buckets", async () => {
+    const metrics = (await api("/agent-monitoring/metrics?window=24h")).body as {
+      totals: { tokensPrompt: number };
+    };
+    // The eval trace carried 5000 prompt tokens; production carried 100.
+    expect(metrics.totals.tokensPrompt).toBeLessThan(5000);
+  });
+
+  it("keeps the eval session out of the sessions list", async () => {
+    const sessions = (await api("/agent-monitoring/sessions?window=7d")).body as {
+      sessions: { sessionId: string }[];
+    };
+    const ids = sessions.sessions.map(s => s.sessionId);
+    expect(ids).toContain("prod-sess");
+    expect(ids).not.toContain("eval-sess");
+  });
+
+  it("never raises signals or tool-failure detections for eval traffic", async () => {
+    // The eval trace had an empty output AND a failed tool call - both built-in detections.
+    const signals = (await api("/agent-monitoring/signals?polarity=all")).body as { signals: { traceId?: string }[] };
+    expect(signals.signals.filter(s => s.traceId === evalId)).toHaveLength(0);
+  });
+
+  it("keeps eval spend in the cost trend, split into its own segment", async () => {
+    // Price gpt-4o-mini so both traces' spend is computable.
+    const models = (await api("/agent-monitoring/portability/models")).body as {
+      models: { id: string; label: string; provider: string }[];
+    };
+    const target = models.models.find(m => m.id.includes("gpt-4o-mini")) ?? models.models[0]!;
+    const priced = await api(`/agent-monitoring/portability/models/${target.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        provider: "openai",
+        label: target.label,
+        pricePerMInputTokens: 1,
+        pricePerMOutputTokens: 2,
+      }),
+    });
+    expect(priced.status).toBe(200);
+
+    const trend = (await api("/agent-monitoring/cost-trend?window=24h")).body as {
+      totalsByModel: Record<string, number>;
+      totalCost: number;
+    };
+    // The eval trace's spend (5000 in / 1000 out) lands in the reserved "eval runs" segment;
+    // the production trace's (100 in / 20 out) lands under the model. Neither is hidden.
+    expect(trend.totalsByModel["eval runs"]).toBeGreaterThan(0);
+    const modelKeys = Object.keys(trend.totalsByModel).filter(k => k !== "eval runs");
+    expect(modelKeys.length).toBeGreaterThan(0);
+    const modelTotal = modelKeys.reduce((a, k) => a + trend.totalsByModel[k]!, 0);
+    // Eval spend is the big one here, and it must NOT be inside the model's own segment.
+    expect(trend.totalsByModel["eval runs"]).toBeGreaterThan(modelTotal);
+    expect(trend.totalCost).toBeCloseTo(modelTotal + trend.totalsByModel["eval runs"]!, 10);
+  });
+});


### PR DESCRIPTION
Offline evaluation runs produce real traces - that is what makes trajectory matching and retrieval-context extraction work - but they were indistinguishable from production traffic. A nightly 200-case eval read as Monday's production health: its latencies in the P95, its deliberately-failing cases in the failure KPIs, its sessions in the Sessions list, its questions in Topics if the caller forgot monitor=False, and every online judge re-scoring what the run's own judge had already scored.

Traces now carry a source column ("eval-run"; null = production; unknown words store as null rather than as a category nobody defined, same posture as span kinds). core/trace/evalTraffic.ts is the one place that says what it means:

- eval traces never trigger monitoring at ingest (detection, online and custom evaluators, rules, topics) unless monitor=true is explicit - server-side belt to the SDK's stamping suspenders
- KPIs, span metrics, sessions and model comparison exclude eval traffic via one shared WHERE fragment
- the Live Traces list takes source=production|eval|all; absent = all, so existing SDK/API callers see exactly what they always saw
- cost KEEPS eval spend, split into a reserved "eval runs" segment - it is real money, and folding it into a model's own bar would hide "what is evaluation costing me" inside "what is production costing me"
- per-trace features are untouched: a trace opens by id from its run's results regardless of source

Verified end to end with the SDK half: an instrumented agent function inside execute(), no flags anywhere, left production KPIs at totalRuns=1/p95<1ms while its two traces appeared only under the eval filter. 9 new integration tests incl. the cost-split arithmetic.

<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
