### PR TITLE
fix feedback tune scorer judge prompt

### DIFF
--- a/engine/src/core/evaluate/evaluationSettings.ts
+++ b/engine/src/core/evaluate/evaluationSettings.ts
@@ -243,6 +243,9 @@ export async function cloneEvaluationSettings(db: Db, id: string): Promise<strin
   const clone: EvaluationSettingsRow = {
     ...existing,
     id: nanoid(),
+    // A verbatim-name clone is indistinguishable from its source in every list UI, and "which
+    // of these identical rows did my edit land on?" is a support ticket. Label it.
+    name: `${existing.name} (copy)`,
     isDefault: false,
     // A clone always exists because of user activity (a legacy binding, a copy) - it is the
     // user's row even when the source was an engine-seeded template.

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -1361,6 +1361,9 @@ function judgeScorerCloneTargets(evaluators: JudgeScorerBindingRow[], datasetIds
 const JUDGE_SCORER_CLONE_COLUMNS =
   "name, description, number_of_requests, similarity_config, code_scorers, acceptance_criteria, " +
   "rejection_criteria, evaluation_criteria, judge_prompt, judge_model";
+// The SELECT half suffixes the name: a clone that keeps its source's exact name is
+// indistinguishable in every list UI ("which Production Quality Bar did I just edit?").
+const JUDGE_SCORER_CLONE_SELECT = JUDGE_SCORER_CLONE_COLUMNS.replace("name,", "name || ' (copy)',");
 
 function enforceJudgeScorerCardinalitySqlite(sqlite: SqliteHandle): void {
   const evaluators = sqlite
@@ -1381,7 +1384,7 @@ function enforceJudgeScorerCardinalitySqlite(sqlite: SqliteHandle): void {
     sqlite
       .prepare(
         `INSERT INTO evaluation_settings (id, ${JUDGE_SCORER_CLONE_COLUMNS}, is_default, status, created_at, project_id)
-         SELECT ?, ${JUDGE_SCORER_CLONE_COLUMNS}, 0, status, ?, project_id
+         SELECT ?, ${JUDGE_SCORER_CLONE_SELECT}, 0, status, ?, project_id
          FROM evaluation_settings WHERE id = (SELECT evaluation_settings_id FROM monitor_online_evaluators WHERE id = ?)`
       )
       .run(cloneId, now, evaluatorId);
@@ -2352,7 +2355,7 @@ async function enforceJudgeScorerCardinalityPostgres(pool: Pool): Promise<void> 
     const cloneId = nanoid();
     await pool.query(
       `INSERT INTO evaluation_settings (id, ${JUDGE_SCORER_CLONE_COLUMNS}, is_default, status, created_at, project_id)
-       SELECT $1, ${JUDGE_SCORER_CLONE_COLUMNS}, FALSE, status, NOW(), project_id
+       SELECT $1, ${JUDGE_SCORER_CLONE_SELECT}, FALSE, status, NOW(), project_id
        FROM evaluation_settings WHERE id = (SELECT evaluation_settings_id FROM monitor_online_evaluators WHERE id = $2)`,
       [cloneId, evaluatorId]
     );


### PR DESCRIPTION
<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
