### PR TITLE
fix judge tuning UI and human review flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,22 +107,22 @@ needed. Pin a specific dashboard build instead with
 
 Set these in the environment before starting `agentx-server`:
 
-| Variable | Default | Purpose |
-| --- | --- | --- |
-| `OPENAI_API_KEY` | - | Powers judge scoring / model calls for OpenAI models. Can also be set live from the dashboard's Platform Settings (takes precedence over the env var). |
-| `ANTHROPIC_API_KEY` | - | Same, for Anthropic models. |
-| `GEMINI_API_KEY` | - | Same, for Gemini models. |
-| `AGENTX_DB_URL` | (local SQLite) | Set to a `postgres://...` URL to use Postgres instead of the default SQLite file. |
-| `AGENTX_HOME` | `~/.agentx` | Where the local SQLite database and config live. |
-| `PORT` | `4700` | Port the engine listens on. |
-| `AGENTX_OTEL_MONITOR` | `true` | Set to `false` to stop running Monitor against OTel-ingested spans. |
-| `AGENTX_MONITOR_CHILD_SPANS` | `false` | Set to `true` to also run Monitor against child spans of a traced call, not just top-level ones. |
-| `AGENTX_IMPROVEMENT_SWEEP` | `true` | Set to `false` to disable the background sweep that auto-generates and validates improvement proposals when failure evidence crosses a threshold (the Improvement Inbox). `POST /evaluate/improve/inbox/sweep/run` still triggers one manually. |
-| `AGENTX_SESSION_SWEEP` | `true` | Set to `false` to disable the background sweep that judges idle multi-turn sessions (session-scoped Online Evaluators). `POST /agent-monitoring/session-sweep/run` still triggers one manually. |
-| `AGENTX_AUTH` | `disabled` | Set to `enabled` to require dashboard sign-in (see "Dashboard authentication" below). The default keeps the zero-setup local posture. |
-| `AGENTX_AUTH_SECRET` | (auto-generated) | Session-signing secret for `AGENTX_AUTH=enabled`. Generated and persisted on first enabled boot if unset; set explicitly when running multiple replicas. |
-| `AGENTX_PUBLIC_URL` | - | The externally reachable base URL when running behind a proxy/domain with auth enabled (used for auth callbacks/cookies). |
-| `AGENTX_TRUSTED_ORIGINS` | - | Comma-separated extra origins allowed to make authenticated browser requests (e.g. a dev dashboard on another port). |
+| Variable                     | Default          | Purpose                                                                                                                                                                                                                                         |
+| ---------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OPENAI_API_KEY`             | -                | Powers judge scoring / model calls for OpenAI models. Can also be set live from the dashboard's Platform Settings (takes precedence over the env var).                                                                                          |
+| `ANTHROPIC_API_KEY`          | -                | Same, for Anthropic models.                                                                                                                                                                                                                     |
+| `GEMINI_API_KEY`             | -                | Same, for Gemini models.                                                                                                                                                                                                                        |
+| `AGENTX_DB_URL`              | (local SQLite)   | Set to a `postgres://...` URL to use Postgres instead of the default SQLite file.                                                                                                                                                               |
+| `AGENTX_HOME`                | `~/.agentx`      | Where the local SQLite database and config live.                                                                                                                                                                                                |
+| `PORT`                       | `4700`           | Port the engine listens on.                                                                                                                                                                                                                     |
+| `AGENTX_OTEL_MONITOR`        | `true`           | Set to `false` to stop running Monitor against OTel-ingested spans.                                                                                                                                                                             |
+| `AGENTX_MONITOR_CHILD_SPANS` | `false`          | Set to `true` to also run Monitor against child spans of a traced call, not just top-level ones.                                                                                                                                                |
+| `AGENTX_IMPROVEMENT_SWEEP`   | `true`           | Set to `false` to disable the background sweep that auto-generates and validates improvement proposals when failure evidence crosses a threshold (the Improvement Inbox). `POST /evaluate/improve/inbox/sweep/run` still triggers one manually. |
+| `AGENTX_SESSION_SWEEP`       | `true`           | Set to `false` to disable the background sweep that judges idle multi-turn sessions (session-scoped Online Evaluators). `POST /agent-monitoring/session-sweep/run` still triggers one manually.                                                 |
+| `AGENTX_AUTH`                | `disabled`       | Set to `enabled` to require dashboard sign-in (see "Dashboard authentication" below). The default keeps the zero-setup local posture.                                                                                                           |
+| `AGENTX_AUTH_SECRET`         | (auto-generated) | Session-signing secret for `AGENTX_AUTH=enabled`. Generated and persisted on first enabled boot if unset; set explicitly when running multiple replicas.                                                                                        |
+| `AGENTX_PUBLIC_URL`          | -                | The externally reachable base URL when running behind a proxy/domain with auth enabled (used for auth callbacks/cookies).                                                                                                                       |
+| `AGENTX_TRUSTED_ORIGINS`     | -                | Comma-separated extra origins allowed to make authenticated browser requests (e.g. a dev dashboard on another port).                                                                                                                            |
 
 Trace ingest and pattern matching on phrase/regex both work with no keys configured at all - only
 judge scoring and semantic pattern detection need a provider key.
@@ -138,8 +138,7 @@ hosting the dashboard on the internet):
 - The first visit shows an owner-setup screen. The first account created becomes the owner of a
   default organization and takes over every existing project on the instance. Later signups join
   that organization as members.
-- Signing in is what grants the dashboard its project list (and each project's API key); the
-  unauthenticated bootstrap endpoint is disabled in this mode.
+- Signing in is what grants the dashboard its project list (and each project's API key);
 - SDK ingest is unchanged in both modes: it authenticates with project API keys, never sessions.
   Enabling or disabling auth never breaks a deployed integration.
 - Identity is standard [better-auth](https://better-auth.com) (email/password out of the box),
@@ -172,27 +171,27 @@ Monitor and Online Evaluators run against every OTel-ingested span by default; s
 
 OTel traffic is a first-class citizen of the full loop, via three attribute conventions:
 
-| Span attribute | Effect |
-| --- | --- |
-| `session.id`, `gen_ai.conversation.id`, or `agentx.session_id` | Groups traces into a conversation on the Sessions surface - session coherence scoring and session-scoped Online Evaluators apply, exactly like SDK traffic. Without one, spans still group by OTel trace id. |
-| `agentx.prompt_name` (+ optional `agentx.version`) | Tags the trace for the Improve loop - prompt-registry evidence gathering and version comparison work as if the SDK's `metadata={"promptName": ...}` had been passed. |
-| `gen_ai.tool.name` on a child span | The tool call is folded up into its root interaction's `tool_calls` (with `success`/`error` from the span's status), lighting up the Tool quality column, the built-in Tool failure check, and Tool Schema evidence. In-batch only: a parent exported in an earlier OTLP batch isn't updated retroactively. |
+| Span attribute                                                 | Effect                                                                                                                                                                                                                                                                                                      |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `session.id`, `gen_ai.conversation.id`, or `agentx.session_id` | Groups traces into a conversation on the Sessions surface - session coherence scoring and session-scoped Online Evaluators apply, exactly like SDK traffic. Without one, spans still group by OTel trace id.                                                                                                |
+| `agentx.prompt_name` (+ optional `agentx.version`)             | Tags the trace for the Improve loop - prompt-registry evidence gathering and version comparison work as if the SDK's `metadata={"promptName": ...}` had been passed.                                                                                                                                        |
+| `gen_ai.tool.name` on a child span                             | The tool call is folded up into its root interaction's `tool_calls` (with `success`/`error` from the span's status), lighting up the Tool quality column, the built-in Tool failure check, and Tool Schema evidence. In-batch only: a parent exported in an earlier OTLP batch isn't updated retroactively. |
 
 Known gap: gRPC transport isn't supported (HTTP only).
 
 ## What's in this repo
 
-| Path | What it is |
-| --- | --- |
-| `cli/` | Go CLI (`agentx`/`agentx-server`) - installer glue and process supervisor. Launches the bundled engine binary, opens the browser, handles shutdown. |
-| `engine/` | TypeScript governance engine + HTTP API (Trace, Evaluate, Monitor). Compiles to a single native executable via Bun (`bun build --compile`) so end users never need Node/Bun installed. |
-| `packages/judge-core/` | The LLM-as-judge prompt/scoring logic, published as `@agentx/judge-core` so `engine/` and AgentX's hosted SaaS backend share one implementation. |
-| `web/` | The dashboard - **not tracked in this repo**. Populated by building [AgentX-eval-front](https://github.com/AgentX-ai/AgentX-eval-front) in self-host mode, or by downloading its prebuilt release asset (see [Dashboard release process](#dashboard-release-process)). |
-| `skills/` | Claude Code skills for self-host users to copy into their own `.claude/skills/` - e.g. `improve-prompt/`, which drives the Prompt Registry's propose loop using Claude's own reasoning instead of a server-side judge call. |
-| `install.sh` | The `curl \| bash` installer - downloads the platform binary from GitHub Releases. |
-| `build.sh` | Builds a local `dist/` laid out the same way a real install would, for testing the full distribution without cutting a release. |
-| `Dockerfile` | Multi-stage build producing a container image - see [Docker](#docker). |
-| `scripts/` | `smoke-test.sh` / `smoke_test.py` - end-to-end verification against a real running engine and the real Python SDK. |
+| Path                   | What it is                                                                                                                                                                                                                                                             |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cli/`                 | Go CLI (`agentx`/`agentx-server`) - installer glue and process supervisor. Launches the bundled engine binary, opens the browser, handles shutdown.                                                                                                                    |
+| `engine/`              | TypeScript governance engine + HTTP API (Trace, Evaluate, Monitor). Compiles to a single native executable via Bun (`bun build --compile`) so end users never need Node/Bun installed.                                                                                 |
+| `packages/judge-core/` | The LLM-as-judge prompt/scoring logic, published as `@agentx/judge-core` so `engine/` and AgentX's hosted SaaS backend share one implementation.                                                                                                                       |
+| `web/`                 | The dashboard - **not tracked in this repo**. Populated by building [AgentX-eval-front](https://github.com/AgentX-ai/AgentX-eval-front) in self-host mode, or by downloading its prebuilt release asset (see [Dashboard release process](#dashboard-release-process)). |
+| `skills/`              | Claude Code skills for self-host users to copy into their own `.claude/skills/` - e.g. `improve-prompt/`, which drives the Prompt Registry's propose loop using Claude's own reasoning instead of a server-side judge call.                                            |
+| `install.sh`           | The `curl \| bash` installer - downloads the platform binary from GitHub Releases.                                                                                                                                                                                     |
+| `build.sh`             | Builds a local `dist/` laid out the same way a real install would, for testing the full distribution without cutting a release.                                                                                                                                        |
+| `Dockerfile`           | Multi-stage build producing a container image - see [Docker](#docker).                                                                                                                                                                                                 |
+| `scripts/`             | `smoke-test.sh` / `smoke_test.py` - end-to-end verification against a real running engine and the real Python SDK.                                                                                                                                                     |
 
 ## Building from source
 
@@ -342,7 +341,7 @@ end-user feedback).
 
 **Known gaps:**
 
-- The self-host build ships the full frontend bundle rather than one trimmed to just Governance  - 
+- The self-host build ships the full frontend bundle rather than one trimmed to just Governance -
   tracked as a follow-up in `AgentX-eval-front`.
 - No hot-reload loop between an `AgentX-eval-front` dev server and this engine yet.
 - Autotune's candidate-branch creation/evaluation/merging is out of scope, not deferred: it's

--- a/engine/package.json
+++ b/engine/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "predev": "yarn workspace @agentx/judge-core build",
-    "dev": "tsx watch --env-file-if-exists=.env src/index.ts",
+    "dev": "tsx watch --env-file-if-exists=.env src/index.ts < /dev/null",
     "prebuild": "yarn workspace @agentx/judge-core build",
     "build": "tsc -p tsconfig.build.json",
     "start": "node --env-file-if-exists=.env dist/index.js",

--- a/engine/src/core/evaluate/runs.ts
+++ b/engine/src/core/evaluate/runs.ts
@@ -573,10 +573,39 @@ export async function appendResults(
       status,
       createdAt: new Date(),
     };
+    // Conflict-tolerant on (run_id, idempotency_key): the getExistingResult pre-check above is
+    // only a cost saver (skip re-scoring), not a guarantee - a client whose first submission is
+    // still scoring in another request (sync scoring can outlive HTTP timeouts) races this
+    // insert, and the loser used to surface the raw UNIQUE constraint as an error. Losing the
+    // race is a duplicate, not a failure.
+    let won: boolean;
     if (db.kind === "sqlite") {
-      await db.db.insert(db.schema.evaluationRunResults).values(resultRow);
+      const res = await db.db.insert(db.schema.evaluationRunResults).values(resultRow).onConflictDoNothing();
+      won = ((res as { changes?: number })?.changes ?? 1) > 0;
     } else {
-      await db.db.insert(db.schema.evaluationRunResults).values(resultRow);
+      const ret = await db.db
+        .insert(db.schema.evaluationRunResults)
+        .values(resultRow)
+        .onConflictDoNothing()
+        .returning({ id: db.schema.evaluationRunResults.id });
+      won = ret.length > 0;
+    }
+    if (!won) {
+      duplicates++;
+      const winner = await getExistingResult(db, runId, item.idempotencyKey);
+      scoredResults.push({
+        idempotencyKey: item.idempotencyKey,
+        rating: winner?.rating ?? rating,
+        justification: winner?.justification ?? justification,
+        status: winner?.status ?? status,
+        vectorSimilarity: winner?.vectorSimilarity ?? similarity.vectorSimilarity,
+        jaccardSimilarity: winner?.jaccardSimilarity ?? similarity.jaccardSimilarity,
+        bleuScore: winner?.bleuScore ?? similarity.bleuScore,
+        rougeScore: winner?.rougeScore ?? similarity.rougeScore,
+        codeScorerResults: winner?.codeScorerResults ?? (codeScorerResults.length > 0 ? codeScorerResults : null),
+        deduped: true,
+      });
+      continue;
     }
 
     accepted++;

--- a/engine/src/core/monitor/feedback.ts
+++ b/engine/src/core/monitor/feedback.ts
@@ -72,6 +72,25 @@ export async function createFeedback(db: Db, signalId: string, input: CreateFeed
   return toWire(row);
 }
 
+// True when this event already carries feedback judgeTuning.ts would count as a correction
+// (same triple as its corrections filter). Used by signals.ts to skip the canned baseline
+// disagreement write when the correction dialog's detailed row is already in - the baseline
+// must never land AFTER a real rationale and clobber it in latest-wins keying.
+export async function hasCorrectionForEvent(db: Db, signalId: string, eventId: string): Promise<boolean> {
+  const cond = and(
+    eq(db.schema.monitorSignalFeedback.signalId, signalId),
+    eq(db.schema.monitorSignalFeedback.projectId, db.projectId)
+  );
+  const rows =
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.monitorSignalFeedback).where(cond).all()
+      : await db.db.select().from(db.schema.monitorSignalFeedback).where(cond);
+  return (rows as FeedbackRow[]).some(
+    r =>
+      r.eventId === eventId && (r.correctedScore !== null || r.metric === "false-positive" || r.queuedForAutotune === true)
+  );
+}
+
 export async function listFeedbackForSignal(db: Db, signalId: string) {
   const cond = and(eq(db.schema.monitorSignalFeedback.signalId, signalId), eq(db.schema.monitorSignalFeedback.projectId, db.projectId));
   const rows =

--- a/engine/src/core/monitor/judgeTuning.ts
+++ b/engine/src/core/monitor/judgeTuning.ts
@@ -39,7 +39,7 @@ const VALIDATE_CONTROL_CAP = 6;
 const DEFAULT_BAD_THRESHOLD = 5;
 
 export type GroundTruth = {
-  source: "correction" | "review" | "outcome" | "feedback";
+  source: "correction" | "confirmed" | "review" | "outcome" | "feedback";
   isBad: boolean;
   // The human's own words: a correction's rationale, or an outcome/feedback reason.
   detail: string | null;
@@ -124,10 +124,22 @@ export async function getEvaluatorCalibration(
     (db.kind === "sqlite"
       ? db.db.select().from(db.schema.monitorSignalFeedback).where(feedbackCond).all()
       : await db.db.select().from(db.schema.monitorSignalFeedback).where(feedbackCond)) as FeedbackCorrectionRow[]
-  ).filter(c => c.correctedScore !== null || c.metric === "false-positive" || c.queuedForAutotune === true);
+  ).filter(
+    c =>
+      c.correctedScore !== null || c.metric === "false-positive" || c.metric === "confirmed" || c.queuedForAutotune === true
+  );
   const correctionByEvent = new Map<string, FeedbackCorrectionRow>();
+  const confirmationByEvent = new Map<string, FeedbackCorrectionRow>();
   for (const c of corrections) {
-    if (c.eventId) correctionByEvent.set(c.eventId, c); // later rows overwrite: latest correction wins
+    if (!c.eventId) continue;
+    // Confirms ("the flag was right", written by the Review queue's Confirm - signals.ts) are the
+    // agreement half of the labeling. Kept in their own map so a bare confirm never outranks an
+    // explicit re-score/false-positive on the same event in this latest-wins keying.
+    if (c.metric === "confirmed" && c.correctedScore === null && !c.queuedForAutotune) {
+      confirmationByEvent.set(c.eventId, c);
+    } else {
+      correctionByEvent.set(c.eventId, c); // later rows overwrite: latest correction wins
+    }
   }
 
   // Labeled human-review rows, windowed on reviewedAt: the calibration pair the review queue
@@ -171,6 +183,7 @@ export async function getEvaluatorCalibration(
 
   for (const event of events) {
     const correction = correctionByEvent.get(event.id);
+    const confirmation = confirmationByEvent.get(event.id);
     const review = reviewByTrace.get(event.traceId);
     const outcome = outcomeByTrace.get(event.traceId);
     const judgedBad = event.rating < threshold;
@@ -200,6 +213,17 @@ export async function getEvaluatorCalibration(
         source: "correction",
         isBad: !judgedBad,
         detail: correction.rationale,
+        correctedScore: null,
+        reportedBy: null,
+      };
+    } else if (confirmation) {
+      // "Confirm" in signal review: event-specific human agreement that the flagged response was
+      // genuinely bad. Ranked above the trace-level streams (review/outcome) because it labels
+      // exactly this verdict, below explicit corrections which carry more information.
+      groundTruth = {
+        source: "confirmed",
+        isBad: true,
+        detail: confirmation.rationale,
         correctedScore: null,
         reportedBy: null,
       };

--- a/engine/src/core/monitor/signals.ts
+++ b/engine/src/core/monitor/signals.ts
@@ -383,5 +383,42 @@ export async function updateSignal(db: Db, id: string, patch: UpdateSignalInput)
   } else {
     await db.db.update(db.schema.monitorSignals).set(setValues).where(updateCond);
   }
+
+  // Human verdicts on judge-raised signals are calibration ground truth, and BOTH directions
+  // are recorded here so no client can forget half the loop:
+  //   - Confirm (-> triaged): AGREEMENT - "the flag was right". Symmetric labeling is what makes
+  //     calibration honest; recording only disagreements lets a judge accumulate evidence
+  //     exclusively against itself.
+  //   - Wrong judgement (-> resolved/false_positive): DISAGREEMENT baseline - guaranteed even
+  //     when the user closes the correction dialog without writing a rationale. The dialog's
+  //     detailed correction lands later on the same event and outranks this row in
+  //     judgeTuning.ts (explicit corrections > confirms; latest correction wins).
+  // Written once per transition, pinned to the newest occurrence's event so the label pairs
+  // with the exact verdict.
+  const becameTriaged = nextStatus === "triaged" && existing.status !== "triaged";
+  const becameFalsePositive =
+    nextStatus === "resolved" &&
+    updated.resolutionReason === "false_positive" &&
+    !(existing.status === "resolved" && existing.resolutionReason === "false_positive");
+  if ((becameTriaged || becameFalsePositive) && existing.patternKey.startsWith("online-eval:")) {
+    const occurrences = await listOccurrencesForSignal(db, id); // createdAt ASC - newest last
+    const newest = occurrences[occurrences.length - 1];
+    if (newest) {
+      const { createFeedback, hasCorrectionForEvent } = await import("./feedback.js");
+      // A wrong-judgement resolve that followed the correction dialog already has a richer
+      // disagreement row on this event - the canned baseline must not overwrite it.
+      if (!becameTriaged && (await hasCorrectionForEvent(db, id, newest.id).catch(() => false))) {
+        return toWire(updated);
+      }
+      await createFeedback(db, id, {
+        metric: becameTriaged ? "confirmed" : "false-positive",
+        rationale: becameTriaged
+          ? "Human confirmed the flagged issue during signal review"
+          : "Resolved as wrong judgement during signal review",
+        occurrenceId: newest.id,
+        originalScore: newest.rating ?? undefined,
+      }).catch(() => undefined);
+    }
+  }
   return toWire(updated);
 }

--- a/engine/src/routes/evaluateDashboard.ts
+++ b/engine/src/routes/evaluateDashboard.ts
@@ -1509,6 +1509,9 @@ async function toEvaluateWire(db: Db, run: FullRunRow, includeResults: boolean) 
     creator: LOCAL_USER,
     executor: LOCAL_USER,
     status: run.status,
+    // Parity with /custom-agent-evaluations/runs summaries - clients listing runs from either
+    // surface can count results without fetching each run's detail.
+    resultCount: results.length,
     liveStatistics: {
       averageRating,
       minRating: rated.length ? Math.min(...rated) : null,

--- a/engine/src/test/confirmAgreement.integration.test.ts
+++ b/engine/src/test/confirmAgreement.integration.test.ts
@@ -1,0 +1,127 @@
+import http from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startEngine, postJson, type TestEngine } from "./server.js";
+
+// Confirming a judge-raised signal is the AGREEMENT half of judge calibration: before this,
+// only disagreements (wrong-judgement corrections, outcomes, review labels) were recorded, so a
+// judge could only ever accumulate evidence against itself and its agreement rate was censored.
+// "Confirm" (PATCH status -> triaged, signals.ts) now writes a metric:"confirmed" feedback row
+// pinned to the newest occurrence's event, and judgeTuning counts it as event-level ground
+// truth: isBad true -> agreement when the judge flagged.
+
+let engine: TestEngine;
+let key: string;
+let judgeStub: http.Server;
+let stubUrl: string;
+
+const api = (path: string, init?: Parameters<TestEngine["json"]>[1]) =>
+  engine.json(`/api/v1${path}`, { apiKey: key, ...(init ?? {}) });
+
+beforeAll(async () => {
+  judgeStub = http.createServer((req, res) => {
+    req.resume();
+    req.on("end", () => {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          id: "resp_stub",
+          output_text: JSON.stringify({ rating: 2, justification: "stub says bad" }),
+          usage: { input_tokens: 5, output_tokens: 5 },
+        })
+      );
+    });
+  });
+  await new Promise<void>(resolve => judgeStub.listen(0, "127.0.0.1", resolve));
+  const address = judgeStub.address();
+  stubUrl = `http://127.0.0.1:${typeof address === "object" && address ? address.port : 0}`;
+
+  engine = await startEngine({ OPENAI_API_KEY: "", ANTHROPIC_API_KEY: "", GEMINI_API_KEY: "" });
+  const created = await engine.json("/api/v1/projects", { ...postJson({ name: "confirm-agreement" }), apiKey: null });
+  key = (created.body as { project: { apiKey: string } }).project.apiKey;
+
+  const model = await api(
+    "/agent-monitoring/portability/models",
+    postJson({
+      id: "stub-judge-c",
+      provider: "custom",
+      label: "Stub judge C",
+      baseUrl: stubUrl,
+      pricePerMInputTokens: 0,
+      pricePerMOutputTokens: 0,
+    })
+  );
+  expect(model.status).toBe(201);
+
+  const scorer = await api(
+    "/agent-monitoring/judge-scorers",
+    postJson({
+      name: "confirm-judge",
+      judge: { evaluationCriteria: "Anything.", judgeModel: "stub-judge-c" },
+      online: { enabled: true, sampleRate: 1, alertThreshold: 5 },
+    })
+  );
+  expect(scorer.status).toBe(201);
+}, 90_000);
+
+afterAll(async () => {
+  await engine?.stop();
+  await new Promise<void>(resolve => judgeStub.close(() => resolve()));
+});
+
+describe("Confirm records judge agreement", () => {
+  it("confirming a judge signal raises the evaluator's agreement count", async () => {
+    await api("/ingest/traces", postJson({ name: "confirm-agent", input: "q", output: "bad answer", span_id: "c-1" }));
+    await new Promise(r => setTimeout(r, 2000));
+
+    const signals = await api("/agent-monitoring/signals?polarity=all");
+    const signal = ((signals.body as { signals: Array<{ _id: string; patternKey?: string; summary: string }> }).signals ?? []).find(
+      s => s.summary.includes("confirm-judge")
+    );
+    expect(signal, JSON.stringify(signals.body).slice(0, 400)).toBeTruthy();
+
+    const evaluators = await api("/agent-monitoring/online-evaluators");
+    const evaluator = ((evaluators.body as { evaluators: Array<{ _id: string; name: string }> }).evaluators ?? []).find(
+      e => e.name === "confirm-judge"
+    )!;
+    const before = (await api(`/agent-monitoring/online-evaluators/${evaluator._id}/calibration?window=24h`))
+      .body as { agreements: number; withGroundTruth: number };
+
+    const confirm = await api(`/agent-monitoring/signals/${signal!._id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status: "triaged", reviewStatus: "reviewed" }),
+    });
+    expect(confirm.status).toBe(200);
+
+    const after = (await api(`/agent-monitoring/online-evaluators/${evaluator._id}/calibration?window=24h`))
+      .body as { agreements: number; withGroundTruth: number };
+    expect(after.withGroundTruth).toBe(before.withGroundTruth + 1);
+    expect(after.agreements).toBe(before.agreements + 1);
+
+    // Confirming again (e.g. re-triage from the table) must not double-count: the write only
+    // happens on the transition INTO triaged.
+    await api(`/agent-monitoring/signals/${signal!._id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status: "triaged" }),
+    });
+    const again = (await api(`/agent-monitoring/online-evaluators/${evaluator._id}/calibration?window=24h`))
+      .body as { withGroundTruth: number };
+    expect(again.withGroundTruth).toBe(after.withGroundTruth);
+
+    // Wrong judgement (resolved/false_positive) writes the DISAGREEMENT baseline engine-side,
+    // and an explicit correction outranks the earlier confirm on the same event: same event
+    // count, but the verdict flips from agreement to over-flagged.
+    const resolve = await api(`/agent-monitoring/signals/${signal!._id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status: "resolved", resolutionReason: "false_positive" }),
+    });
+    expect(resolve.status).toBe(200);
+    const flipped = (await api(`/agent-monitoring/online-evaluators/${evaluator._id}/calibration?window=24h`))
+      .body as { agreements: number; overFlagged: number; withGroundTruth: number };
+    expect(flipped.withGroundTruth).toBe(after.withGroundTruth);
+    expect(flipped.agreements).toBe(after.agreements - 1);
+    expect(flipped.overFlagged).toBe(1);
+  });
+});

--- a/engine/src/test/resultsIdempotency.integration.test.ts
+++ b/engine/src/test/resultsIdempotency.integration.test.ts
@@ -1,0 +1,84 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startEngine, postJson, type TestEngine } from "./server.js";
+
+// Regression: batch result submission is scored synchronously inside the request, so a client
+// whose HTTP timeout is shorter than scoring re-POSTs the same batch WHILE the first request is
+// still inserting. The engine's duplicate handling was check-then-insert - the racing loser hit
+// the (run_id, idempotency_key) UNIQUE constraint and the whole batch failed with a raw SQLite
+// error instead of being deduped (hit live by selfhost_demo/03 on 2026-08-27). The insert is
+// conflict-tolerant now: every concurrent submission of the same batch succeeds, rows are
+// written exactly once, and losers are reported as duplicates.
+
+let engine: TestEngine;
+let key: string;
+let runId: string;
+
+const api = (path: string, init?: Parameters<TestEngine["json"]>[1]) =>
+  engine.json(`/api/v1${path}`, { apiKey: key, ...(init ?? {}) });
+
+beforeAll(async () => {
+  engine = await startEngine({ OPENAI_API_KEY: "", ANTHROPIC_API_KEY: "", GEMINI_API_KEY: "" });
+  const created = await engine.json("/api/v1/projects", { ...postJson({ name: "results-idempotency" }), apiKey: null });
+  key = (created.body as { project: { apiKey: string } }).project.apiKey;
+
+  const dataset = await api(
+    "/custom-agent-evaluations/datasets",
+    postJson({
+      name: "idempotency-set",
+      questions: [
+        { main_question: { question: "q1", expectedResults: "a1" } },
+        { main_question: { question: "q2", expectedResults: "a2" } },
+      ],
+    })
+  );
+  expect(dataset.status).toBe(201);
+  const datasetId = (dataset.body as { _id?: string; id?: string })._id ?? (dataset.body as { id: string }).id;
+
+  const run = await api("/custom-agent-evaluations/runs", postJson({ datasetId, runSource: "sdk" }));
+  expect(run.status).toBe(201);
+  runId = (run.body as { runId: string }).runId;
+}, 90_000);
+
+afterAll(async () => {
+  await engine?.stop();
+});
+
+const batch = (batchId: string) => ({
+  batchId,
+  results: [
+    { idempotencyKey: "case-0-run-1", questionIndex: 0, runNumber: 1, input: "q1", output: { text: "a1" } },
+    { idempotencyKey: "case-1-run-1", questionIndex: 1, runNumber: 1, input: "q2", output: { text: "a2" } },
+  ],
+});
+
+describe("concurrent duplicate batch submission", () => {
+  it("both submissions succeed, rows land exactly once, losers count as duplicates", async () => {
+    // The exact shape of the timeout-retry race: the same results (same idempotency keys, fresh
+    // batch ids - the client mints a new uuid per attempt) in flight simultaneously.
+    const [first, second] = await Promise.all([
+      api(`/custom-agent-evaluations/runs/${runId}/results`, postJson(batch("batch-a"))),
+      api(`/custom-agent-evaluations/runs/${runId}/results`, postJson(batch("batch-b"))),
+    ]);
+
+    expect(first.status, JSON.stringify(first.body)).toBe(200);
+    expect(second.status, JSON.stringify(second.body)).toBe(200);
+
+    const a = first.body as { accepted: number; duplicates: number };
+    const b = second.body as { accepted: number; duplicates: number };
+    // Between the two racing requests every result is accepted exactly once - however the race
+    // interleaved - and the rest are reported back as duplicates, never as errors.
+    expect(a.accepted + b.accepted).toBe(2);
+    expect(a.duplicates + b.duplicates).toBe(2);
+
+    // A later straight retry (first request long finished) is the classic dedupe path.
+    const third = await api(`/custom-agent-evaluations/runs/${runId}/results`, postJson(batch("batch-c")));
+    expect(third.status).toBe(200);
+    expect((third.body as { accepted: number }).accepted).toBe(0);
+    expect((third.body as { duplicates: number }).duplicates).toBe(2);
+
+    const submitted = await api(`/custom-agent-evaluations/runs/${runId}/missing-results`);
+    expect(submitted.status).toBe(200);
+    const keys = (submitted.body as { submittedKeys: string[] }).submittedKeys;
+    expect(keys.sort()).toEqual(["case-0-run-1", "case-1-run-1"]);
+  });
+});


### PR DESCRIPTION
<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
