### PR TITLE
Insights: dataset coverage of production topics, and the probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -857,3 +857,73 @@ deleted project's API key stops authenticating, that the default project is refu
 that an unknown id 404s, and that an unauthenticated delete is rejected without removing anything.
 The cascade assertion was checked both ways: with the table loop disabled it fails with `traces
 kept rows for a deleted project: expected 1 to be +0`.
+
+---
+
+Topics knew what production was asked about and Evaluate knew what the datasets tested, and the
+two had never been introduced. Nobody could answer "does our suite look anything like our
+traffic?", so dataset quality was a feeling. **Insights** is the join: `GET
+/api/v1/insights/coverage` groups the window's `monitor_classifications` by intent, assigns every
+dataset case to the topic it belongs to, and reports traffic-weighted coverage, topic breadth, and
+risk-weighted coverage. The gap between the first and third is the finding worth having - it says
+you test what is common rather than what is dangerous.
+
+The measurement is the part that needed care. Counting cases per topic would have been the obvious
+implementation and it would have been worthless, because the whole point of knowing where the gaps
+are is to then generate cases, and any count-based number is inflated by generating near-copies of
+one you already have. Coverage is instead a facility-location value: the average, over the topic's
+real traces, of the best similarity any assigned case reaches to that trace. A duplicate adds
+nothing because the maximum is already satisfied, so the anti-gaming property falls out of the
+formula rather than needing a rule. `targetCases` (scaled by traffic and observed risk, `sqrt` on
+traffic so a topic carrying 40% of requests does not demand 40% of the test budget) survives as
+guidance for what to write next, and becomes the measure only in the degraded path, where there is
+no geometry to measure depth with.
+
+That distinction was not theoretical. The first implementation took `min(countRatio, depth)`,
+which reads plausibly and quietly reintroduces exactly the flaw the metric exists to prevent: the
+duplicate-inflation test - six near-identical cases against a two-case baseline - failed with
+`expected 0.857 to be less than or equal to 0.287`. The count term was doing the talking. Removing
+it is what makes the anti-gaming claim true rather than merely stated.
+
+The **probe** is the inverse lookup, and the cheap half: `POST /insights/probe` embeds one query
+and compares it against the cached case embeddings, with no LLM in the verdict path.
+`POST /insights/probe/batch` does the same for a pasted list - a launch spec, a support macro
+export - which is the only answer here to the cold-start problem, since the topic map only knows
+traffic that has already happened. Its bands are not new constants: `SIMILARITY_BANDS` is exported
+from `core/evaluate/curation.ts`, which already carries the measured calibration for
+`text-embedding-3-small`, so the probe's "covered" verdict is *defined* as "`addCaseToDataset`
+would reject this query as a duplicate" and the two features cannot drift apart.
+
+The probe answers two questions rather than one, deliberately. "Is it tested?" is useless without
+"does anyone ask it?", because a query with no coverage AND no traffic is not a hole in the suite,
+and reporting it as one would send a team writing tests for traffic that does not exist. That case
+gets its own verdict (`untested-and-unasked`) and its own wording. Similarly, the nearest case's
+`expectedResults` always comes back beside the score: query-to-query similarity measures topical
+resemblance, not that the case asserts the same behaviour, and claiming "covered" on phrasing
+alone is the one way this loses a user's trust in a single interaction.
+
+Everything degrades rather than failing. Without an embeddings key, coverage and the probe fall
+back to Jaccard over content words - a genuinely weaker signal on a different scale, so it carries
+its own thresholds and every response says `degraded: true` with a reason. `insight_case_embeddings`
+caches one embedding per distinct case query, keyed by a content hash rather than the case's
+position, so editing a case re-embeds it while reordering costs nothing; a cached NULL is a
+remembered failure, which is what stops a missing key from re-attempting a doomed call on every
+request. The table carries `project_id`, so `deleteProject`'s schema-derived cascade picks it up
+without anyone touching that function.
+
+Nothing here writes a dataset. A gap is reported; cases still land through the existing
+preview → human review → append path, which is what keeps a coverage number from being inflated by
+rows nobody looked at.
+
+Verified in `insights.integration.test.ts` by driving the core directly against a real database
+with embeddings *injected* rather than computed - unit vectors at chosen angles, whose cosines are
+exactly `cos(Δangle)`, so every band-boundary assertion is arithmetic instead of a guess about
+what an embedding model will return today. It covers a covered topic and a missing one, unique
+sessions counted through the join to `traces` rather than raw request volume, risk weighted toward
+observed issues over sentiment, the risk-weighted number falling below the traffic-weighted one
+when a failing topic is untested, duplicate cases not moving coverage, the honesty delta between
+case presence and real depth, off-map cases, and all four probe verdicts including the lexical
+fallback (exercised, not mocked away - the mocked embedder returns null for unregistered text,
+exactly as a missing key does). `contract.integration.test.ts` drives the three new endpoints live
+against the real engine, including the empty state, which is the common first view of this screen
+since Topics is opt-in and sampled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -927,3 +927,39 @@ fallback (exercised, not mocked away - the mocked embedder returns null for unre
 exactly as a missing key does). `contract.integration.test.ts` drives the three new endpoints live
 against the real engine, including the empty state, which is the common first view of this screen
 since Topics is opt-in and sampled.
+
+Verified against a real install's database (340 classified traces, 54 datasets), which immediately
+found two things unit tests could not.
+
+The first: the classifier coins near-duplicate labels, and Phase 0's group-by-intent-string made
+that actively misleading. That install carried both "Refund request" (7 cases, covered) and
+"Request a refund" (0 cases, MISSING) - one topic reported twice, one half of it inventing a gap
+that did not exist, and its traffic share split down the middle. Same for "Reset Password" and
+"Reset forgotten password". So `mergeSynonymousTopics` merges intent labels whose trace centroids
+are close, using embeddings already stored on `monitor_classifications` - no new API calls, and it
+works with no LLM key at all.
+
+Its threshold is 0.87, and deliberately NOT curation.ts's 0.75: that constant compares two single
+query strings, this compares centroids of averaged input+output embeddings, which run much higher.
+Measured on that install: "refund request" vs "request a refund" 0.909 and "reset password" vs
+"reset forgotten password" 0.902 (must merge), against "order tracking" vs "missing package" 0.822
+and "refund policy inquiry" vs "request a refund" 0.813 (must NOT - asking the rules and asking for
+money back have different correct answers). 0.87 splits those with ~0.05 either side. Reusing 0.75
+would have merged order tracking into missing package. Candidates are compared against the seed's
+centroid rather than the growing one, so a chain of pairwise-similar topics cannot collect into one
+blob.
+
+The second: the window default. Every monitoring surface defaults to 7d, and Insights inherited it
+- but that install's 318 classified traces were all older than seven days, so the screen read
+"nothing classified yet" while the 30d window was full. Those charts are about recent health, where
+a short window is the point; coverage is accumulated test debt against a sampled classifier, so it
+defaults to 30d now.
+
+Also verified through the real dashboard (AgentX-eval-front, `yarn dev:selfhost` against this
+engine): the tab renders 43% traffic-weighted / 6 of 35 topics / 8% risk-weighted on that data, and
+the probe distinguishes the two cases it exists to distinguish - "I want to cancel my subscription
+today" comes back a real gap naming the "Cancel subscription" topic at 11% of traffic, while "can I
+pay my invoice in martian dollars" comes back not-covered-and-not-asked rather than a fabricated
+gap. The nearest-case panel earned its place there: for the cancellation query the closest case is
+about being charged AFTER cancelling, a billing dispute rather than how to cancel, which the
+similarity score alone would never have revealed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -905,10 +905,11 @@ alone is the one way this loses a user's trust in a single interaction.
 Everything degrades rather than failing. Without an embeddings key, coverage and the probe fall
 back to Jaccard over content words - a genuinely weaker signal on a different scale, so it carries
 its own thresholds and every response says `degraded: true` with a reason. `insight_case_embeddings`
-caches one embedding per distinct case query, keyed by a content hash rather than the case's
-position, so editing a case re-embeds it while reordering costs nothing; a cached NULL is a
-remembered failure, which is what stops a missing key from re-attempting a doomed call on every
-request. The table carries `project_id`, so `deleteProject`'s schema-derived cascade picks it up
+caches embeddings per distinct case, keyed by a content hash rather than the case's position, so
+editing a case re-embeds it while reordering costs nothing. A failure is never cached: it cannot be
+told apart from a missing key at the computeEmbedding boundary, and caching it as permanent would
+exclude those cases forever. The no-key case short-circuits before any call instead, so nothing
+retries in a doomed loop. The table carries `project_id`, so `deleteProject`'s schema-derived cascade picks it up
 without anyone touching that function.
 
 Nothing here writes a dataset. A gap is reported; cases still land through the existing

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ browser, and prints a local API key for the SDK. Prefer a container? See [Docker
   downvote raises a signal directly) feed Overview's **Judge Calibration** card, which measures
   how often the automated verdicts agreed with reality; and a **Model Comparison** card
   aggregates quality/cost/latency per model from real traffic.
+- **Insights** - does your dataset look anything like your traffic? Joins the topics production
+  actually produces (from Monitor's classified traces) to the cases in your datasets, and reports
+  three numbers: traffic-weighted coverage, topic breadth, and risk-weighted coverage - the gap
+  between the first and third being the useful one ("you test what is common, not what is
+  dangerous"). Coverage is a *facility-location* value over the topic's real traces rather than a
+  case count, so near-duplicate cases add nothing and the number cannot be inflated by generating
+  copies. Includes a **probe**: ask whether the datasets cover one specific query (or paste a
+  whole list - a launch spec, a support macro export - as a pre-launch gate). The probe's
+  "covered" verdict reuses the exact similarity threshold `addCaseToDataset` dedupes on, so
+  covered means *the dataset would reject this query as a duplicate*, and it distinguishes a real
+  gap from a question nobody asks rather than inventing work. Degrades to labelled lexical
+  matching without an embeddings key; never writes a dataset.
 - **Judge tuning** - the judges get judged: each online evaluator's verdicts are measured
   against recorded reality (human re-scores, outcomes, user votes), and its own grading criteria
   can be rewritten from the disagreements - validated by exact re-judging (fixes the cases it got

--- a/docs/insights-topic-coverage-plan.md
+++ b/docs/insights-topic-coverage-plan.md
@@ -1,17 +1,42 @@
 # Insights: production topic coverage of evaluation datasets
 
-**Status:** Phase 0 is implemented and shipped (`engine/src/core/insights/`,
-`engine/src/routes/insights.ts`). Phases 1-3 below are still design.
+**Status:** Phase 0 is implemented and shipped, plus one piece of Phase 1 pulled forward.
+Phases 1-3 below are otherwise still design.
 
-Two things changed during implementation, and this document has been corrected rather than left
+| Shipped | Where |
+|---|---|
+| Coverage sweep, three headline numbers, topic states | `engine/src/core/insights/coverage.ts` |
+| Case extraction + embedding cache | `engine/src/core/insights/cases.ts` |
+| The probe (single + batch) | `engine/src/core/insights/probe.ts` |
+| Routes + wire contract | `engine/src/routes/insights.ts`, `engine/src/contract/wire.ts` |
+| Tests | `engine/src/test/insights.integration.test.ts`, `contract.integration.test.ts` |
+| **Insights tab** | `AgentX-eval-front`, branch `claude/insights-dataset-topic-coverage-mo44s9` |
+
+**Four things changed during implementation.** This document has been corrected rather than left
 describing something the code does not do:
 
-- Coverage is the facility-location value **alone**, never blended with the case count. The first
-  implementation took `min(countRatio, depth)`, which quietly reintroduced duplicate-inflation -
-  the anti-gaming test failed with `expected 0.857 to be less than or equal to 0.287`. See §4.2.
-- Phase 0 assigns cases to topics by **argmax**, not the softmax of §3.2. With intent-string
-  topics there are no real centroid boundaries yet for a soft assignment to smooth over; softmax
-  arrives with the clustering in Phase 1.
+1. **Coverage is the facility-location value alone**, never blended with the case count. The first
+   implementation took `min(countRatio, depth)`, which quietly reintroduced duplicate-inflation -
+   the anti-gaming test failed with `expected 0.857 to be less than or equal to 0.287`. See §4.2.
+2. **Cases assign to topics by argmax**, not the softmax of §3.2. With intent-string topics there
+   are no real centroid boundaries for a soft assignment to smooth over; softmax arrives with the
+   full clustering.
+3. **Topic merging was pulled forward from Phase 1** - see the calibration note in §3.1. Running
+   against a real install made it non-optional rather than a refinement.
+4. **The window defaults to 30d**, not the 7d every monitoring surface uses. On a real install
+   every classified trace was older than seven days, so the screen read "nothing classified yet"
+   while the 30d window was full. Those charts are recent health; this is accumulated test debt
+   measured against a *sampled* classifier.
+
+**Validated against a real install** (340 classified traces, 54 datasets), which found (3) and (4)
+- neither was reachable from the unit tests. It reports 43% traffic-weighted / 6 of 35 topics /
+8% risk-weighted on that data, and the probe returns a real gap for "I want to cancel my
+subscription today" (naming the `Cancel subscription` topic at 11% of traffic) while returning
+*not-covered-and-not-asked* for "can I pay my invoice in martian dollars".
+
+Still **unverified**: the Postgres DDL (mirrors the SQLite path, needs `AGENTX_TEST_DB_URL`), and
+the non-degraded similarity path end-to-end (no `OPENAI_API_KEY` was available, so the real-data
+run exercised the labelled lexical fallback).
 
 ## 1. The idea in one line
 
@@ -72,6 +97,30 @@ rows carrying:
 
 This is exactly the "true unsupervised clustering ... a materially bigger piece left for
 a future pass" that `topics.ts`'s header defers. Insights is the reason to do it.
+
+**Partly shipped, ahead of schedule.** Full centroid clustering is still Phase 1, but the
+*merging* half could not wait: on a real install the classifier had coined both "Refund request"
+(7 cases, covered) and "Request a refund" (0 cases, **missing**) - one topic reported twice, half
+of it inventing a gap that did not exist, its traffic share split between the two. Same for
+"Reset Password" / "Reset forgotten password". `mergeSynonymousTopics` merges intent labels whose
+trace centroids are close, using embeddings **already stored** on `monitor_classifications` - no
+new API calls, and it works with no LLM key at all.
+
+The threshold is **0.87**, and deliberately not curation.ts's 0.75: that constant compares two
+single query strings, this compares centroids of *averaged* input+output embeddings, which run
+much higher. Measured on that install:
+
+| pair | cosine | verdict |
+|---|---|---|
+| refund request / request a refund | 0.909 | must merge |
+| reset password / reset forgotten password | 0.902 | must merge |
+| order tracking / missing package | 0.822 | must **not** |
+| refund policy inquiry / request a refund | 0.813 | must **not** |
+
+0.87 splits those with ~0.05 of margin either side. Reusing 0.75 would have merged "where is my
+order" with "it never arrived" - different questions with different correct answers. Candidates
+are compared against the *seed's* centroid rather than the growing one, so a chain of
+pairwise-similar topics (a~b, b~c) cannot collect into one blob when a and c are unrelated.
 
 Topic assignment for a new trace becomes centroid proximity, which means the sweep is
 also a **novelty detector**: a trace whose best cosine to every centroid is below a floor
@@ -560,13 +609,14 @@ wire shape needs to be settled in this plan's review, before UI work starts.
 
 ## 10. Phasing
 
-**Phase 0 - the screen, and the probe.** *(shipped)* Case embedding cache, string-grouped topics from
+**Phase 0 - the screen, and the probe.** *(shipped, engine + dashboard)* Case embedding cache, string-grouped topics from
 existing `intent` values, count-based coverage, three headline tiles, topic map states,
 per-topic panel - plus the single-query and batch **probe** (§7), which needs none of the
 topic machinery and is the fastest way to make the idea tangible. Ships the mockup. No
 clustering, no sweep. Proves the concept and settles the wire contract.
 
-**Phase 1 - real topics.** Consolidation sweep, centroids, soft assignment,
+**Phase 1 - real topics.** *(synonym merging shipped early - see §3.1; the rest outstanding.)*
+Consolidation sweep, centroids, soft assignment,
 facility-location coverage, sub-mode analysis, and the full attribute row (§4.3) including
 unique-session weighting. The numbers become defensible.
 
@@ -586,7 +636,10 @@ Good-Turing unknown mass, CI coverage gate.
 Each phase is independently shippable and each one leaves the product better than it
 found it.
 
-## 11. Open questions - need a decision before Phase 0
+## 11. Open questions - still open
+
+Phase 0 shipped without settling these; each one is now a decision about what Phase 1 does,
+not a blocker. #1 and #5 are the two that would change the schema.
 
 1. **Scope of a coverage number.** Per project, per agent, or per (agent x dataset)? An
    agent may run dataset B while topic X is covered only by dataset A, which would report

--- a/docs/insights-topic-coverage-plan.md
+++ b/docs/insights-topic-coverage-plan.md
@@ -104,7 +104,7 @@ Why this is the right shape:
   `max` is already satisfied. The anti-gaming property falls out of the math instead of
   needing a separate rule.
 - It rewards *spread*: covering three phrasings of a request beats three copies of one.
-- Sub-mode coverage (§4.4) is the same number computed per sub-cluster - one formula, not
+- Sub-mode coverage (§4.5) is the same number computed per sub-cluster - one formula, not
   a second system.
 - It reuses the 0.75 similarity calibration already in `curation.ts`.
 
@@ -113,7 +113,31 @@ Why this is the right shape:
 `degraded: true`. Every embedding path in this repo already returns null on failure; this
 must too. A degraded number is labelled, never silently wrong.
 
-### 4.3 Per-topic target - not a flat constant
+### 4.3 Per-topic attributes - the row behind every tile
+
+Coverage is a verdict; these are the evidence it is computed from, and each is shown in the
+topic detail panel so the verdict is auditable.
+
+| Attribute | Source | Notes |
+|---|---|---|
+| Traffic share | `insight_topics.trafficCount` | Volume |
+| **Unique sessions / customers** | `traces.sessionId`; customer via a configurable `metadata` key | See below - volume alone lies |
+| **Declared business risk** | Human-set per topic, seeded by heuristic | Distinct from observed risk - see 4.6 |
+| Observed failure frequency | `issueType != none`, signals, outcome reports | Its own column, not only a risk input |
+| Approved dataset cases | Assigned cases with a human-reviewed expected answer | "Approved", not "present" |
+| Case diversity | Facility-location value (4.2) | The anti-duplicate term |
+| **Last dataset update** | Max `source.addedAt` over the topic's cases | Case-side staleness |
+| **Ground-truth confidence** | See 4.7 | How much the expected answers are worth |
+
+**Unique sessions matter more than request count.** 500 requests from 3 sessions is one
+customer hammering a retry loop; 500 from 400 sessions is real demand. Weighting a coverage
+target by raw traffic would over-invest in the first. `traces.sessionId` is first-class and
+free. Customer identity is not - there is no customer column, only `traces.metadata`, so
+customer-level counting ships as an opt-in configured metadata key (`insight_settings.customerKey`)
+and degrades to sessions when unset. Volume weight becomes
+`sqrt(requests) * log(1 + uniqueSessions)`, so concentration is discounted without being ignored.
+
+### 4.4 Per-topic target - not a flat constant
 
 The mockup shows "0 / 6 target" and "12 / 10 target". A flat target per topic is wrong:
 a narrow topic is finished at 3 cases, a sprawling one is thin at 20.
@@ -130,7 +154,7 @@ clustering step. **Coverage targets driven by measured semantic diversity, not j
 volume**, is the part of this that ordinary eval tooling does not do. `sqrt` on traffic
 so a 40%-of-traffic topic doesn't demand 40% of the test budget.
 
-### 4.4 Sub-mode coverage: the sharp insight
+### 4.5 Sub-mode coverage: the sharp insight
 
 Within a topic, k-means its trace embeddings into sub-clusters (k from `spread`), then
 compute the same facility-location value per sub-cluster. This produces the finding that
@@ -142,20 +166,7 @@ actually changes what someone does on Monday:
 
 That is a materially better product than a green tile.
 
-### 4.5 The three headline numbers
-
-Matching the mockup exactly:
-
-- **Traffic-weighted coverage** = `SUM_t trafficShare(t) * coverage(t)` -
-  "share of real requests represented by a reviewed test case".
-- **Topic breadth** = `count(coverage(t) >= threshold) / topicCount` - the 5/8 tile.
-- **Risk-weighted coverage** = `SUM_t normRisk(t) * coverage(t)` -
-  "high-impact scenarios adequately tested".
-
-The traffic/risk gap is the headline story: 68% vs 51% says *you test what is common, not
-what is dangerous*. That single sentence is the reason this feature sells.
-
-### 4.6 Risk score, and why it must be explainable
+### 4.6 Risk: declared and observed are two different things
 
 `risk(t)` blends, all joinable through `traceId` today:
 
@@ -168,6 +179,114 @@ what is dangerous*. That single sentence is the reason this feature sells.
 
 The API returns the **components alongside the score**, never a bare number. "High risk"
 that can't be explained gets ignored the second time a user sees it.
+
+But everything in that table is *observed* risk - it is derived from failures that already
+happened. That is circular for exactly the topics this feature exists to catch. The mockup's own
+example makes the point: **Account closure, 10% of traffic, 0 cases, 0% coverage**. It has no
+failure history, because it is barely exercised - so observed risk scores it low and it sinks
+down the queue. The same is true of payment approval, KYC, anything destructive and rare.
+
+So risk is two fields, not one:
+
+- **`observedRisk`** - derived from the table above. Automatic, always available, backward-looking.
+- **`declaredRisk`** - a human-set business criticality per topic (`none`/`low`/`high`/`critical`,
+  reusing `severity.ts`'s vocabulary rather than inventing a fifth scale). Seeded by a one-time
+  LLM pass over topic labels for irreversible or regulated actions (closure, refund, payment,
+  identity, data deletion), then owned by the team. Forward-looking, and the only thing that can
+  rank an untested danger correctly.
+
+`risk(t) = max(observedRisk, declaredRisk)`, deliberately `max` and not a blend: a topic that is
+either demonstrably failing or declared business-critical is risky, and averaging lets one signal
+mask the other. **Risk-weighted coverage is computed on this combined value** - otherwise the
+headline number it produces has the same blind spot as the metric it is meant to correct.
+
+### 4.7 Ground-truth confidence - what a case is actually worth
+
+A dataset case whose `expectedResults` was auto-drafted and rubber-stamped is not worth the same
+as one a reviewer wrote against a real failure. Coverage that treats them alike is measuring
+paperwork. Nothing in the current plan captured this, and the repo already holds the provenance:
+
+| Confidence input | Source | Signal |
+|---|---|---|
+| Human-written vs `suggestExpected`-drafted expected answer | `curation.ts` provenance | Was a person's judgment applied |
+| Reviewer label on the source trace | `review_queue_items.label` - *"A label is ground truth"* | The strongest per-case evidence |
+| Confirmed by a real-world outcome | `outcome_reports` joined via `source.traceId` | Reality agreed |
+| Corrected score vs judge score | `review_queue_items.correctedScore` / `judgeScoreAtQueue` | A human actively disagreed and fixed it |
+| Case has never been run | evaluation run history | Untested test |
+
+`groundTruthConfidence` in [0,1] per case, rolled up per topic. It feeds case adequacy (4.8) and
+is surfaced on its own, because "34 covered topics, but 11 of them rest on unverified expected
+answers" is a finding a team acts on.
+
+### 4.8 Case adequacy - decomposed, then combined carefully
+
+A topic is not covered because it has one dataset row. Adequacy in [0,1] per topic, from six
+factors, each independently displayable:
+
+| Factor | Meaning |
+|---|---|
+| `volume` | Reviewed cases against target (4.4) |
+| `diversity` | Facility-location value (4.2) - variants and phrasings |
+| `edgeCases` | Coverage of the topic's *failure* sub-modes specifically, not just its sub-modes |
+| `groundTruth` | Confidence roll-up (4.7) |
+| `recency` | See the correction below |
+| `reviewerConfidence` | Explicit reviewer signal where one exists |
+
+Then:
+
+```
+                  SUM_t  productionWeight(t) * adequacy(t)
+coverage      =   ------------------------------------------
+                  SUM_t  productionWeight(t)
+```
+
+with `productionWeight` = traffic share, breadth (uniform), or combined risk, giving the three
+headline numbers from one formula.
+
+**Two corrections this decomposition needs, or it will misreport:**
+
+**Do not multiply the factors.** Six factors at a respectable 0.8 each multiply to 0.26. A topic
+that is genuinely decent at everything renders as catastrophic, every topic goes red, and people
+stop reading the page - the classic way a well-intentioned composite score dies. Use a **weighted
+geometric mean** (`exp(SUM w_i * ln f_i)` with `SUM w_i = 1`), which keeps the "one bad factor
+drags the score" property that makes a product attractive here, while staying on the same scale
+as its inputs. Two factors are **gates** rather than terms - zero reviewed cases or zero ground
+truth caps adequacy outright, because no amount of diversity rescues a topic with no verified
+expected answer.
+
+**Recency must be relative, not absolute.** A two-year-old case for a topic whose behaviour has
+not changed is fine; a three-month-old case for a topic that drifted last week is stale. Raw case
+age would flag the first and miss the second - exactly backwards. Measure recency as case age
+*against centroid movement since that case was added* (7.2 already computes the drift). This is
+the case-side complement to the **Stale** topic state, and the two are independent failure modes:
+the traffic moved, or the test rotted.
+
+### 4.9 One number, or four?
+
+Quality-adjusted coverage is **not** a fourth metric sitting beside the other three. It is the
+same three metrics with `adequacy(t)` substituted for the crude "has cases" term - which is what
+4.8's formula already does. Shipping four co-equal percentages would leave a reader asking which
+one is the real one, and they would pick whichever is highest.
+
+So: **three headline numbers, all quality-adjusted**, exactly matching the mockup's tiles:
+
+- **Traffic-weighted coverage** - `productionWeight` = traffic share.
+  *"Share of real requests represented by an adequate test case."*
+- **Topic breadth** - count of topics whose adequacy clears a threshold, over topic count. The 5/8 tile.
+- **Risk-weighted coverage** - `productionWeight` = `max(observedRisk, declaredRisk)`.
+  *"High-impact scenarios adequately tested."*
+
+Plus one secondary number that earns its place precisely because it is a comparison:
+
+> **68% by case presence, 41% quality-adjusted.**
+
+That **honesty delta** is arguably the most valuable figure on the page. A large gap means the
+dataset is a facade - rows exist, confidence does not - and it is the single number that tells a
+team whether their next hour goes into *writing new cases* or *verifying the ones they have*.
+No other eval tool distinguishes those two kinds of work.
+
+The traffic-versus-risk gap remains the headline story (*you test what is common, not what is
+dangerous*); the presence-versus-quality gap is the second story (*you have rows, not tests*).
 
 ## 5. Topic states and the map
 
@@ -290,6 +409,16 @@ engine/src/core/insights/
   Keyed by content hash so an edited case re-embeds and an unchanged one never does.
 - `insight_coverage_snapshots` - projectId, agentId, datasetId, computedAt, the three
   headline numbers, per-topic json. Powers deltas and the CI gate.
+- `insight_topics.declaredRisk` - the human-owned business criticality (§4.6). The only
+  hand-editable field in the whole feature; everything else is derived, which is why it needs a
+  real owner and an edit route rather than a config file.
+- `insight_case_meta` - per (datasetId, caseKey): `groundTruthConfidence`, its component flags,
+  `addedAt`, `lastRunAt`. Separate from `insight_case_embeddings` because confidence changes when
+  a review lands, while the embedding only changes when the text does - different write
+  frequencies, different invalidation.
+- `insight_settings` - per project: `customerKey` (the `traces.metadata` key holding customer
+  identity, §4.3), adequacy factor weights, coverage thresholds. Weights must be inspectable and
+  editable, or the composite score is a black box nobody trusts.
 
 **Compute posture.** Clustering + coverage is far too heavy for a request. Follow
 `improvementSweep.ts`: a leased background sweep (`sweepLease.ts`) on a schedule plus an
@@ -320,8 +449,14 @@ map states, per-topic panel. Ships the mockup. No clustering, no sweep. Proves t
 concept and settles the wire contract.
 
 **Phase 1 - real topics.** Consolidation sweep, centroids, soft assignment,
-facility-location coverage, risk scoring, sub-mode analysis. The numbers become
-defensible.
+facility-location coverage, sub-mode analysis, and the full attribute row (§4.3) including
+unique-session weighting. The numbers become defensible.
+
+**Phase 1.5 - adequacy.** `declaredRisk` and its edit route, ground-truth confidence, the
+six-factor adequacy score with its geometric-mean combination, and the presence-vs-quality
+honesty delta. Worth its own phase rather than folding into Phase 1: it is the step that turns
+three plausible percentages into three defensible ones, and it is where a rushed combination rule
+would quietly poison every number downstream.
 
 **Phase 2 - the flywheel.** Generation briefs, MMR trace selection, topic-grounded
 synthesis, marginal-coverage-per-case ranking. Insights starts producing work, not just
@@ -346,6 +481,14 @@ found it.
    on Overview? It reads as its own thing, but it is only ever acted on from a dataset.
 4. **Do we backfill?** `monitor_classifications.embedding` is explicitly not backfilled
    for older rows. Topics built from a partial history will under-count older traffic.
-5. **Naming.** "Insights" is generic and `attention.ts` already owns the word `insight`
+5. **Who owns `declaredRisk`?** It is the one field a human must set, and the whole
+   risk-weighted number depends on it. Seeding it from an LLM pass over topic labels gets a
+   usable default on day one, but if nobody ever corrects it the feature is ranking danger by
+   guess. Does it belong to whoever owns the agent, or does it need a review step?
+6. **Adequacy weights: shipped default or per-project?** Six factors need six weights. A fixed
+   default is legible and comparable across projects; per-project weights are honest about
+   differing priorities but make two teams' 68% incomparable. Recommendation: ship one default,
+   make it visible, allow override later.
+7. **Naming.** "Insights" is generic and `attention.ts` already owns the word `insight`
    for its one-line digest. *Coverage*, *Gaps*, or *Dataset Fit* are all sharper. Worth
    deciding before it reaches the wire contract and becomes hard to rename.

--- a/docs/insights-topic-coverage-plan.md
+++ b/docs/insights-topic-coverage-plan.md
@@ -1,6 +1,17 @@
 # Insights: production topic coverage of evaluation datasets
 
-**Status:** plan, not implemented. No code changes accompany this document.
+**Status:** Phase 0 is implemented and shipped (`engine/src/core/insights/`,
+`engine/src/routes/insights.ts`). Phases 1-3 below are still design.
+
+Two things changed during implementation, and this document has been corrected rather than left
+describing something the code does not do:
+
+- Coverage is the facility-location value **alone**, never blended with the case count. The first
+  implementation took `min(countRatio, depth)`, which quietly reintroduced duplicate-inflation -
+  the anti-gaming test failed with `expected 0.857 to be less than or equal to 0.287`. See §4.2.
+- Phase 0 assigns cases to topics by **argmax**, not the softmax of §3.2. With intent-string
+  topics there are no real centroid boundaries yet for a soft assignment to smooth over; softmax
+  arrives with the clustering in Phase 1.
 
 ## 1. The idea in one line
 
@@ -549,7 +560,7 @@ wire shape needs to be settled in this plan's review, before UI work starts.
 
 ## 10. Phasing
 
-**Phase 0 - the screen, and the probe.** Case embedding cache, string-grouped topics from
+**Phase 0 - the screen, and the probe.** *(shipped)* Case embedding cache, string-grouped topics from
 existing `intent` values, count-based coverage, three headline tiles, topic map states,
 per-topic panel - plus the single-query and batch **probe** (§7), which needs none of the
 topic machinery and is the fastest way to make the idea tangible. Ships the mockup. No

--- a/docs/insights-topic-coverage-plan.md
+++ b/docs/insights-topic-coverage-plan.md
@@ -64,7 +64,7 @@ a future pass" that `topics.ts`'s header defers. Insights is the reason to do it
 
 Topic assignment for a new trace becomes centroid proximity, which means the sweep is
 also a **novelty detector**: a trace whose best cosine to every centroid is below a floor
-is not in any known topic. See §7.
+is not in any known topic. See §8.
 
 ### 3.2 Soft assignment, not argmax
 
@@ -257,7 +257,7 @@ expected answer.
 **Recency must be relative, not absolute.** A two-year-old case for a topic whose behaviour has
 not changed is fine; a three-month-old case for a topic that drifted last week is stale. Raw case
 age would flag the first and miss the second - exactly backwards. Measure recency as case age
-*against centroid movement since that case was added* (7.2 already computes the drift). This is
+*against centroid movement since that case was added* (8.2 already computes the drift). This is
 the case-side complement to the **Stale** topic state, and the two are independent failure modes:
 the traffic moved, or the test rotted.
 
@@ -343,7 +343,111 @@ that breaks it - and shouldn't want to. A coverage number inflated by unreviewed
 generated cases is the exact failure mode §4.2 exists to prevent. Ship it as a stated
 principle, not an omission.
 
-## 7. Ideas worth doing that the obvious version misses
+## 7. Ask the dataset a question
+
+Everything above is a *sweep*: it computes coverage for topics production already produced.
+That leaves an obvious question unanswerable — **"is this specific thing tested?"** — which is
+the question people actually have, in the words they actually have it in. The probe is the
+inverse lookup: type a query, get a calibrated verdict.
+
+It is also, unexpectedly, the cheapest thing in this plan. One embedding call, cosine against
+the cached case embeddings and the topic centroids, no LLM in the verdict path, sub-second.
+
+### 7.1 It must answer three questions, not one
+
+The naive version answers only the first, and is actively misleading for it:
+
+1. **Is there a test for this?** Nearest cases by cosine.
+2. **Does production actually ask this?** Nearest centroid and its traffic share.
+3. **Would it be adequately covered?** The adequacy (§4.8) of the topic it lands in.
+
+Cross the first two and the real product appears:
+
+| | **Production asks this** | **Production doesn't** |
+|---|---|---|
+| **Dataset covers it** | Fine. Show the case, move on. | **Dead test weight** — the off-map finding (§5), reached from the other direction |
+| **Dataset doesn't** | **A real gap.** Offer to generate. | **A hypothesis, not a gap.** Say so plainly. |
+
+That bottom-right cell is why the naive version is dangerous. A query with no coverage *and* no
+traffic is not a hole in the suite - and answering "not covered!" would send a team writing tests
+for things nobody asks. Insights should say: *"nothing in production resembles this either -
+it may be worth testing anyway, but this is not a gap in your coverage of real traffic."*
+Refusing to manufacture work is a feature.
+
+### 7.2 Calibrated verdicts, using the numbers the repo already measured
+
+A raw cosine ("0.62") means nothing to anyone. `curation.ts` has already done the calibration
+work for `text-embedding-3-small` - measured paraphrase pairs at 0.82-0.88, related-but-distinct
+questions at 0.48-0.56 - so the bands come for free and need no second calibration to maintain:
+
+| Similarity | Verdict | Wording |
+|---|---|---|
+| >= 0.75 | **Covered** | "Effectively the same question as an existing case." |
+| 0.56 - 0.75 | **Adjacent** | "Nearest case asks something related, not this." |
+| < 0.56 | **Not covered** | "Nothing in the dataset is close." |
+
+The 0.75 band boundary is deliberately the *same constant* `addCaseToDataset` dedupes on. That
+gives the feature a property worth stating out loud:
+
+> **"Covered" means the dataset would reject this query as a duplicate.**
+
+One threshold, one embedding model, two features that can never disagree with each other. If
+someone recalibrates the constant, both move together.
+
+### 7.3 Show the expected answer, and don't overclaim
+
+Embedding similarity between a query and a case's *query* measures topical resemblance - it does
+not prove the case tests the same behaviour. Two questions can be near-identical in phrasing
+while the case's `expectedResults` asserts something else entirely.
+
+So the result always shows the nearest case's expected answer next to its similarity, and the
+verdict is phrased as evidence rather than judgment. The human makes the final call. Claiming
+"covered" on phrasing alone is the one way this feature loses trust in a single interaction.
+
+### 7.4 Batch mode: coverage against traffic that doesn't exist yet
+
+The single-query probe generalises for free, and the generalisation is the valuable half. Paste
+a list - a PRD's user stories, a support macro export, a compliance checklist, a launch spec -
+and get a coverage report over questions production has *never seen*.
+
+> *"We launch crypto withdrawals next month. Here are the 15 things users will ask. How much of
+> that does our suite cover today?"* — **0 of 15.**
+
+This is forward-looking coverage, and it solves the cold-start problem the rest of this plan
+cannot: the topic map only knows the past, so a brand-new surface is invisible to it until it
+has already shipped and started failing. Batch probe is the pre-launch gate.
+
+### 7.5 Two dividends
+
+**It seeds `declaredRisk` from real behaviour.** §4.6 asks who declares business criticality and
+admits a human has to. Probe queries answer it implicitly: the scenarios people type in are the
+ones they are worried about. Log them, and *"queries probed repeatedly that production has never
+produced"* becomes a ranked candidate list for declared risk - inferred from what the team
+actually fears, not from an LLM guessing at topic labels.
+
+**A gap flows straight into generation.** A "not covered" verdict with traffic nearby is one
+click from §6: if real traces sit near the query, curate those (real user language, always
+preferred, ranked by the MMR selection already specified); if none do, pass the query itself to
+`generateSyntheticCases` as guidance. Same preview -> human -> append landing path, nothing new.
+
+### 7.6 Why this ships in Phase 0
+
+The probe needs **no clustering, no sweep, no topic layer** - only case embeddings and one query
+embedding. It works on day one, before `insight_topics` exists, degrading to "nearest cases, no
+traffic context" (and saying so).
+
+That makes it the best Phase 0 deliverable in the plan: it is the moment the whole idea becomes
+tangible to someone who has not read this document. A coverage percentage is an assertion a
+reader has to take on faith. Typing *"what happens if a customer asks to close their account
+while a refund is pending"* and getting back **"nothing in your dataset is within 0.4 of this"**
+is a demonstration.
+
+```
+POST /insights/probe        { query }            -> verdict, nearest cases, topic, traffic, adequacy
+POST /insights/probe/batch  { queries[] }        -> the same per query, plus a rollup
+```
+
+## 8. Ideas worth doing that the obvious version misses
 
 **7.1 Unknown unknowns - Good-Turing.** The topic map can only show topics we have seen.
 Classification is *sampled* (`topicsSampleRate`), so it is a survey, and surveys have a
@@ -385,7 +489,7 @@ which is why coverage rows key on `(topicId, datasetId)` and not on the dataset 
 last seen in production, and did production behaviour in that topic change since? Surfaces
 tests that are now testing a world that no longer exists. Same data, read backwards.
 
-## 8. Shape of the code
+## 9. Shape of the code
 
 New module directory, mirroring how `core/monitor/` and `core/evaluate/` are organised:
 
@@ -435,18 +539,21 @@ or a UMAP fit.
 | `GET /insights/topics/:id` | the detail panel: traffic share, cases vs target, coverage, risk components, sub-modes, suggested action |
 | `POST /insights/topics/:id/brief` | the generation brief (selected traces, failure evidence, style anchors) |
 | `POST /insights/topics/:id/generate` | topic-grounded synthesis -> preview cases (no write) |
+| `POST /insights/probe` | calibrated verdict for one query: nearest cases, topic, traffic, adequacy |
+| `POST /insights/probe/batch` | the same per query, plus a rollup - the pre-launch gate |
 | `POST /insights/recompute` | force the sweep |
 
 Zod schemas go in `contract/wire.ts` alongside the existing monitor schemas - the
 dashboard (`AgentX-eval-front`, separate private repo) consumes that contract, so the
 wire shape needs to be settled in this plan's review, before UI work starts.
 
-## 9. Phasing
+## 10. Phasing
 
-**Phase 0 - the screen, on data we already have.** Case embedding cache, string-grouped
-topics from existing `intent` values, count-based coverage, three headline tiles, topic
-map states, per-topic panel. Ships the mockup. No clustering, no sweep. Proves the
-concept and settles the wire contract.
+**Phase 0 - the screen, and the probe.** Case embedding cache, string-grouped topics from
+existing `intent` values, count-based coverage, three headline tiles, topic map states,
+per-topic panel - plus the single-query and batch **probe** (§7), which needs none of the
+topic machinery and is the fastest way to make the idea tangible. Ships the mockup. No
+clustering, no sweep. Proves the concept and settles the wire contract.
 
 **Phase 1 - real topics.** Consolidation sweep, centroids, soft assignment,
 facility-location coverage, sub-mode analysis, and the full attribute row (§4.3) including
@@ -468,7 +575,7 @@ Good-Turing unknown mass, CI coverage gate.
 Each phase is independently shippable and each one leaves the product better than it
 found it.
 
-## 10. Open questions - need a decision before Phase 0
+## 11. Open questions - need a decision before Phase 0
 
 1. **Scope of a coverage number.** Per project, per agent, or per (agent x dataset)? An
    agent may run dataset B while topic X is covered only by dataset A, which would report

--- a/docs/insights-topic-coverage-plan.md
+++ b/docs/insights-topic-coverage-plan.md
@@ -1,0 +1,351 @@
+# Insights: production topic coverage of evaluation datasets
+
+**Status:** plan, not implemented. No code changes accompany this document.
+
+## 1. The idea in one line
+
+We already know *what production does* (the topic map, from `monitor_classifications`)
+and *what we test* (dataset cases). **Insights** is the join between the two: for every
+topic real users bring us, how well is it represented by reviewed test cases - and where
+it isn't, produce the cases.
+
+Today those two halves never meet. Topics is pure observability
+(`core/monitor/topics.ts`: "it never raises a Signal ... pure observability"), and
+datasets are grown one trace at a time through Curate, with nobody asking whether the
+resulting set actually resembles the traffic. Insights makes dataset quality a
+*measured* property instead of a felt one, and turns the measurement into a work queue.
+
+## 2. What already exists (and why this is cheap to build)
+
+| Piece | Where | What Insights takes from it |
+|---|---|---|
+| Per-trace classification: `intent`, `sentiment`, `issueType` | `core/monitor/topics.ts` | The raw topic signal |
+| **Embedding persisted per classification** | `monitor_classifications.embedding` | The single most important asset - traces already live in a vector space |
+| UMAP map view, `MIN_POINTS_FOR_MAP`, `MAX_MAP_POINTS` | `topics.ts::getTopicsMap` | Precedent for "derived view, recomputed, capped, degrades honestly" |
+| Cosine + dedupe threshold **0.75**, calibrated for `text-embedding-3-small` | `core/evaluate/curation.ts` | The same similarity scale, reused rather than re-invented |
+| `previewCaseFromTrace` / `previewCaseFromSession` / `suggestExpected` / `addCaseToDataset` | `curation.ts` | The generation *landing* path - preview, human edits, append |
+| `generateSyntheticCases` | `core/evaluate/synthesize.ts` | Cold-start generation, extended here with topic grounding |
+| Severity vocabulary | `core/shared/severity.ts` | Risk weighting |
+| Outcome reports (real-world ground truth, `isNegative`) | `core/outcomes/outcomeReports.ts` | The strongest risk input we have |
+| Background sweep + lease | `core/shared/sweepLease.ts`, `improvementSweep.ts` | How the expensive recompute runs |
+| Cache-miss-returns-null, compute in background | `core/monitor/attention.ts` | The exact request-path posture to copy |
+
+Insights is mostly *arithmetic over vectors we already store*. The expensive parts
+(classification, embedding) are already paid for.
+
+## 3. The crux: one vector space for traffic and tests
+
+Coverage is only comparable if traces and dataset cases are projected into the **same**
+space. That is the whole design.
+
+- Traces: already embedded (`monitor_classifications.embedding`).
+- Cases: embed `main_question.query` once, cache by content hash.
+- Topics: a **persisted centroid**, not a string.
+
+### 3.1 From free-text intents to stable topics
+
+`intent` is an LLM-written free-text label, steered toward reuse but still drifting
+("refund request" vs "requested refund"). Joining coverage on strings would be brittle
+and would silently split a topic in half.
+
+A **topic consolidation sweep** clusters classification embeddings (agglomerative,
+cosine, average-linkage; HDBSCAN if we want noise handling) and writes `insight_topics`
+rows carrying:
+
+- stable `id`
+- `centroid` (mean unit vector)
+- `label` (LLM-written from the cluster's medoid traces) + `aliases` (the intent strings
+  that fell in)
+- `radius` / `spread` (mean cosine distance to centroid) - used below
+- `trafficCount`, `trafficShare`
+
+This is exactly the "true unsupervised clustering ... a materially bigger piece left for
+a future pass" that `topics.ts`'s header defers. Insights is the reason to do it.
+
+Topic assignment for a new trace becomes centroid proximity, which means the sweep is
+also a **novelty detector**: a trace whose best cosine to every centroid is below a floor
+is not in any known topic. See §7.
+
+### 3.2 Soft assignment, not argmax
+
+Assigning each case to its single nearest topic throws away information and makes the
+numbers jumpy at cluster boundaries. Instead, a case contributes to topics by a softmax
+over cosine to the top-k centroids, with two rules:
+
+- **Floor:** best cosine below `OFF_MAP_FLOOR` (~0.45 on this embedding scale) - the case
+  matches *no* topic. This is itself a finding: **dead test weight**, cases exercising
+  something production never asks. Nobody reports this today.
+- **Ambiguity:** if top-2 are within epsilon, the case genuinely spans both; the split
+  contribution is correct, not a rounding error.
+
+## 4. Measuring coverage honestly
+
+### 4.1 Why "number of cases" is the wrong metric
+
+Ten near-duplicate refund cases is not ten times the coverage of one. A metric that can
+be inflated by pasting the same case is worthless, and worse, it will be inflated,
+because we are about to build a button that generates cases.
+
+### 4.2 The metric: facility-location coverage
+
+For topic `t`, let `T` be its trace embeddings (sampled, capped) and `C` the dataset
+cases assigned to it. Define
+
+```
+coverage(t) = (1 / |T|) * SUM over x in T of  max over c in C of  sim(x, c)
+```
+
+clipped and rescaled so that "a case sitting right on a trace" reads as 1 and "nothing
+nearby" reads as 0. This is the classic submodular **facility-location** value.
+
+Why this is the right shape:
+
+- Diminishing returns are automatic - a duplicate case adds nearly nothing, because the
+  `max` is already satisfied. The anti-gaming property falls out of the math instead of
+  needing a separate rule.
+- It rewards *spread*: covering three phrasings of a request beats three copies of one.
+- Sub-mode coverage (§4.4) is the same number computed per sub-cluster - one formula, not
+  a second system.
+- It reuses the 0.75 similarity calibration already in `curation.ts`.
+
+**Fallback:** with no `OPENAI_API_KEY` (or embeddings that failed), degrade to
+`min(1, distinctCases(t) / target(t))` grouped by intent string, and mark the response
+`degraded: true`. Every embedding path in this repo already returns null on failure; this
+must too. A degraded number is labelled, never silently wrong.
+
+### 4.3 Per-topic target - not a flat constant
+
+The mockup shows "0 / 6 target" and "12 / 10 target". A flat target per topic is wrong:
+a narrow topic is finished at 3 cases, a sprawling one is thin at 20.
+
+```
+target(t) = ceil( BASE
+                + K_TRAFFIC * sqrt(trafficShare(t))
+                + K_RISK    * risk(t)
+                + K_SPREAD  * spread(t) )
+```
+
+`spread(t)` is the topic's measured intra-cluster diameter - we already have it from the
+clustering step. **Coverage targets driven by measured semantic diversity, not just
+volume**, is the part of this that ordinary eval tooling does not do. `sqrt` on traffic
+so a 40%-of-traffic topic doesn't demand 40% of the test budget.
+
+### 4.4 Sub-mode coverage: the sharp insight
+
+Within a topic, k-means its trace embeddings into sub-clusters (k from `spread`), then
+compute the same facility-location value per sub-cluster. This produces the finding that
+actually changes what someone does on Monday:
+
+> *Password reset: 12 cases, 100% headline coverage. Three sub-modes - MFA lockout,
+> corporate SSO, recovery-email bounced - have no case within 0.5. 100% is the average of
+> a well-covered happy path and three uncovered failure modes.*
+
+That is a materially better product than a green tile.
+
+### 4.5 The three headline numbers
+
+Matching the mockup exactly:
+
+- **Traffic-weighted coverage** = `SUM_t trafficShare(t) * coverage(t)` -
+  "share of real requests represented by a reviewed test case".
+- **Topic breadth** = `count(coverage(t) >= threshold) / topicCount` - the 5/8 tile.
+- **Risk-weighted coverage** = `SUM_t normRisk(t) * coverage(t)` -
+  "high-impact scenarios adequately tested".
+
+The traffic/risk gap is the headline story: 68% vs 51% says *you test what is common, not
+what is dangerous*. That single sentence is the reason this feature sells.
+
+### 4.6 Risk score, and why it must be explainable
+
+`risk(t)` blends, all joinable through `traceId` today:
+
+| Input | Source | Weight rationale |
+|---|---|---|
+| Negative outcome reports | `outcome_reports.isNegative` | Confirmed real-world harm - strongest available truth |
+| Open failure Signals, severity-weighted | `monitor_signals` + `severity.ts` | Someone already triaged this as bad |
+| `issueType != "none"` density | `monitor_classifications` | Cheap, always available |
+| Negative sentiment density | `monitor_classifications` | Weakest; user frustration is noisy |
+
+The API returns the **components alongside the score**, never a bare number. "High risk"
+that can't be explained gets ignored the second time a user sees it.
+
+## 5. Topic states and the map
+
+Three states, matching the mockup's legend:
+
+- **Covered** - `coverage >= target` and no uncovered sub-mode above a traffic floor.
+- **Underrepresented** - `0 < coverage < target`.
+- **Missing** - no case assigned at all.
+
+Plus two states the mockup doesn't have and should:
+
+- **Stale** - covered, but the topic's centroid has drifted since the cases were written
+  (§7). Green that quietly stopped being true is worse than red.
+- **Off-map cases** - not a topic state, a dataset-level list: cases matching no topic.
+  Either dead weight or evidence the topic sweep is missing something. Presented as a
+  question, not a verdict.
+
+## 6. The generation flywheel
+
+A gap is not "generate 6 cases". It is a **generation brief** built from real evidence:
+
+1. **Medoids** - the traces nearest the centroid: what this topic normally looks like.
+2. **Uncovered sub-mode representatives** - traces from sub-clusters with no nearby case.
+   These are the cases actually worth writing.
+3. **Failure evidence** - traces in this topic with `issueType != none`, an open Signal,
+   or a negative outcome report. These become *regression* cases with a known-bad actual
+   output already attached.
+4. **Style anchors** - two existing cases from the target dataset, exactly as
+   `synthesize.ts` already does.
+
+Two paths, both landing in the existing human-review flow:
+
+**Curate (preferred).** Real traces, real user language, no synthetic staleness. Insights'
+job is *selection*: which traces to promote. Use **maximum marginal relevance** - close to
+the uncovered region, far from cases already in the dataset:
+
+```
+score(x) = sim(x, uncoveredCentroid) - LAMBDA * max over c in C of sim(x, c)
+```
+
+This is active learning applied to test curation. Compare with the status quo ("scroll the
+trace list, pick some recent ones"). Selected traces go through
+`previewCaseFromTrace` -> `suggestExpected` -> human -> `addCaseToDataset`, which already
+dedupes at 0.75, so a bad suggestion is rejected by machinery that exists.
+
+**Synthesize.** For genuinely missing topics with too few real traces, extend
+`generateSyntheticCases` with a topic-grounded mode: the SOURCE becomes real trace
+excerpts plus the topic label, rather than a pasted document. Same schema, same route
+shape, same human review.
+
+**Nothing auto-adds.** Both `curation.ts` and `synthesize.ts` state this posture
+explicitly ("Nothing lands in a dataset unreviewed"). Insights must not be the feature
+that breaks it - and shouldn't want to. A coverage number inflated by unreviewed
+generated cases is the exact failure mode §4.2 exists to prevent. Ship it as a stated
+principle, not an omission.
+
+## 7. Ideas worth doing that the obvious version misses
+
+**7.1 Unknown unknowns - Good-Turing.** The topic map can only show topics we have seen.
+Classification is *sampled* (`topicsSampleRate`), so it is a survey, and surveys have a
+species-estimation problem with a known answer. Let `f1` be topics observed exactly once.
+The Good-Turing / Chao1 estimate of unobserved mass gives an honest line:
+
+> *~7% of traffic falls in topics seen too rarely to name. Coverage is 68% +/- 7.*
+
+Cheap to compute from counts we already have, statistically respectable, and it doubles as
+the nudge to raise the sample rate. No eval tool ships this. It reframes the product from
+"here is your score" to "here is your score and how much we can't see" - which is the
+posture that earns trust from the people who buy this.
+
+**7.2 Novelty and drift.** Because centroids are persisted, a trace below `OFF_MAP_FLOOR`
+against every centroid is novel. Track the novelty rate per day: a rising rate is an
+*emerging topic* before it is big enough to cluster. Feed it into the existing Signal
+machinery so it lands in the surfaces people already watch. Related: recompute coverage
+against last month's centroids to attribute a coverage drop correctly -
+*"71% -> 62%, not because tests were deleted, because traffic moved."* Coverage that only
+falls when you delete a test is a lagging indicator; this makes it leading.
+
+**7.3 Coverage as a CI gate.** Snapshot coverage per run; fail a CI eval run when
+risk-weighted coverage of critical topics drops below a threshold. This is what makes
+Insights load-bearing rather than a dashboard people visit twice. Natural fit with
+`agentx_list_ci_runs` and the existing eval CI path.
+
+**7.4 Cost-aware coverage.** Every topic's cases cost tokens to run. Present the
+**marginal coverage per case** for each proposed case (the facility-location gain) so a
+team on a budget adds the 5 cases that buy the most coverage, not 30 that buy the same.
+Submodular greedy selection gives this for free and is provably within 1-1/e of optimal.
+
+**7.5 Judge-blind-spot coverage.** A second, orthogonal axis: are the *scorers* covering
+the topic, or is a whole topic being graded by a generic judge that never looks at what
+matters there? Same join, different right-hand side (`evaluation_settings` / judge
+scorers instead of cases). Out of scope for v1, but the schema should not preclude it -
+which is why coverage rows key on `(topicId, datasetId)` and not on the dataset alone.
+
+**7.6 Reverse direction - dataset provenance debt.** For each *case*, when was its topic
+last seen in production, and did production behaviour in that topic change since? Surfaces
+tests that are now testing a world that no longer exists. Same data, read backwards.
+
+## 8. Shape of the code
+
+New module directory, mirroring how `core/monitor/` and `core/evaluate/` are organised:
+
+```
+engine/src/core/insights/
+  topics.ts      # consolidation sweep: cluster, centroid, label, aliases, spread
+  coverage.ts    # case embedding cache, soft assignment, facility-location coverage
+  risk.ts        # risk score + explainable components
+  gaps.ts        # gap ranking, MMR trace selection, generation briefs
+  snapshots.ts   # history, deltas, CI gate evaluation
+```
+
+**Schema** (both `schema.sqlite.ts` and `schema.pg.ts`, per repo convention):
+
+- `insight_topics` - id, projectId, label, aliases (json), centroid (json number[]),
+  spread, trafficCount, updatedAt
+- `monitor_classifications.topicId` - nullable FK, backfilled by the sweep. A column
+  rather than a join table: assignment is 1:1 and this keeps the aggregate queries the
+  same shape they are today.
+- `insight_case_embeddings` - datasetId, caseKey (content hash), embedding (json), model.
+  Keyed by content hash so an edited case re-embeds and an unchanged one never does.
+- `insight_coverage_snapshots` - projectId, agentId, datasetId, computedAt, the three
+  headline numbers, per-topic json. Powers deltas and the CI gate.
+
+**Compute posture.** Clustering + coverage is far too heavy for a request. Follow
+`improvementSweep.ts`: a leased background sweep (`sweepLease.ts`) on a schedule plus an
+explicit `POST /insights/recompute`. Reads serve the last snapshot. Follow
+`attention.ts` exactly for the cache-miss case: return what we have immediately, compute
+in the background, let the next poll pick it up. Never block a dashboard load on an LLM
+or a UMAP fit.
+
+**Routes** - `engine/src/routes/insights.ts`:
+
+| Route | Returns |
+|---|---|
+| `GET /insights/coverage` | three headline numbers, topic list w/ state, degraded flag, unknown-mass estimate |
+| `GET /insights/topics/:id` | the detail panel: traffic share, cases vs target, coverage, risk components, sub-modes, suggested action |
+| `POST /insights/topics/:id/brief` | the generation brief (selected traces, failure evidence, style anchors) |
+| `POST /insights/topics/:id/generate` | topic-grounded synthesis -> preview cases (no write) |
+| `POST /insights/recompute` | force the sweep |
+
+Zod schemas go in `contract/wire.ts` alongside the existing monitor schemas - the
+dashboard (`AgentX-eval-front`, separate private repo) consumes that contract, so the
+wire shape needs to be settled in this plan's review, before UI work starts.
+
+## 9. Phasing
+
+**Phase 0 - the screen, on data we already have.** Case embedding cache, string-grouped
+topics from existing `intent` values, count-based coverage, three headline tiles, topic
+map states, per-topic panel. Ships the mockup. No clustering, no sweep. Proves the
+concept and settles the wire contract.
+
+**Phase 1 - real topics.** Consolidation sweep, centroids, soft assignment,
+facility-location coverage, risk scoring, sub-mode analysis. The numbers become
+defensible.
+
+**Phase 2 - the flywheel.** Generation briefs, MMR trace selection, topic-grounded
+synthesis, marginal-coverage-per-case ranking. Insights starts producing work, not just
+describing it.
+
+**Phase 3 - the moat.** Snapshots and deltas, drift attribution, novelty alerts,
+Good-Turing unknown mass, CI coverage gate.
+
+Each phase is independently shippable and each one leaves the product better than it
+found it.
+
+## 10. Open questions - need a decision before Phase 0
+
+1. **Scope of a coverage number.** Per project, per agent, or per (agent x dataset)? An
+   agent may run dataset B while topic X is covered only by dataset A, which would report
+   green while the agent's actual suite is blind. Recommendation: compute per
+   `(agentId, datasetId)` and roll up, since only the rolled-up view is meaningful on the
+   Overview page but only the pair is actionable.
+2. **Embedding budget.** Case embeddings are cheap and cached; re-clustering thousands of
+   traces nightly is not free. Cap and sample, following `MAX_MAP_POINTS`'s precedent?
+3. **Does Insights get its own nav section**, or live as a tab under Datasets and a card
+   on Overview? It reads as its own thing, but it is only ever acted on from a dataset.
+4. **Do we backfill?** `monitor_classifications.embedding` is explicitly not backfilled
+   for older rows. Topics built from a partial history will under-count older traffic.
+5. **Naming.** "Insights" is generic and `attention.ts` already owns the word `insight`
+   for its one-line digest. *Coverage*, *Gaps*, or *Dataset Fit* are all sharper. Worth
+   deciding before it reaches the wire contract and becomes hard to rename.

--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -326,13 +326,15 @@ export const insightTopicSchema = z
     priority: z.number(),
     riskComponents: z.object({ issueRate: z.number(), negativeSentimentRate: z.number() }).strict(),
     suggestedAction: z.string(),
+    caseDatasets: z.array(z.object({ id: z.string(), name: z.string(), count: z.number() }).strict()),
+    sampleCases: z.array(z.object({ datasetId: z.string(), query: z.string() }).strict()),
   })
   .strict();
 
 export const insightsCoverageResponseSchema = z
   .object({
     window: z.enum(["24h", "7d", "30d"]),
-    datasetId: z.string().nullable(),
+    datasetIds: z.array(z.string()),
     degraded: z.boolean(),
     provisional: z.boolean(),
     degradedReason: z.string().nullable(),
@@ -345,7 +347,16 @@ export const insightsCoverageResponseSchema = z
     datasets: z.array(z.object({ id: z.string(), name: z.string(), caseCount: z.number() }).strict()),
     topics: z.array(insightTopicSchema),
     offMapCases: z.array(
-      z.object({ datasetId: z.string(), index: z.number(), query: z.string(), bestSimilarity: z.number() }).strict()
+      z
+        .object({
+          datasetId: z.string(),
+          index: z.number(),
+          query: z.string(),
+          bestSimilarity: z.number(),
+          expectedResults: z.string().nullable(),
+          nearestTopic: z.string().nullable(),
+        })
+        .strict()
     ),
     caseEmbeddingsPending: z.number(),
   })

--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -313,6 +313,7 @@ export const judgeScorersResponseSchema = z.object({ judgeScorers: z.array(judge
 export const insightTopicSchema = z
   .object({
     topic: z.string(),
+    coverageBasis: z.enum(["depth", "count"]),
     aliases: z.array(z.string()),
     state: z.enum(["covered", "underrepresented", "missing"]),
     trafficShare: z.number(),
@@ -336,7 +337,7 @@ export const insightsCoverageResponseSchema = z
     insufficientData: z.boolean(),
     trafficWeightedCoverage: z.number(),
     topicBreadth: z.object({ covered: z.number(), total: z.number() }).strict(),
-    riskWeightedCoverage: z.number(),
+    riskWeightedCoverage: z.number().nullable(),
     presenceCoverage: z.number(),
     honestyDelta: z.number(),
     topics: z.array(insightTopicSchema),

--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -334,6 +334,7 @@ export const insightsCoverageResponseSchema = z
     window: z.enum(["24h", "7d", "30d"]),
     datasetId: z.string().nullable(),
     degraded: z.boolean(),
+    provisional: z.boolean(),
     degradedReason: z.string().nullable(),
     insufficientData: z.boolean(),
     trafficWeightedCoverage: z.number(),

--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -323,6 +323,7 @@ export const insightTopicSchema = z
     targetCases: z.number(),
     coverage: z.number(),
     risk: z.number(),
+    priority: z.number(),
     riskComponents: z.object({ issueRate: z.number(), negativeSentimentRate: z.number() }).strict(),
     suggestedAction: z.string(),
   })
@@ -340,6 +341,7 @@ export const insightsCoverageResponseSchema = z
     riskWeightedCoverage: z.number().nullable(),
     presenceCoverage: z.number(),
     honestyDelta: z.number(),
+    datasets: z.array(z.object({ id: z.string(), name: z.string(), caseCount: z.number() }).strict()),
     topics: z.array(insightTopicSchema),
     offMapCases: z.array(
       z.object({ datasetId: z.string(), index: z.number(), query: z.string(), bestSimilarity: z.number() }).strict()

--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -327,7 +327,7 @@ export const insightTopicSchema = z
     riskComponents: z.object({ issueRate: z.number(), negativeSentimentRate: z.number() }).strict(),
     suggestedAction: z.string(),
     caseDatasets: z.array(z.object({ id: z.string(), name: z.string(), count: z.number() }).strict()),
-    sampleCases: z.array(z.object({ datasetId: z.string(), query: z.string() }).strict()),
+    sampleCases: z.array(z.object({ datasetId: z.string(), query: z.string(), count: z.number() }).strict()),
   })
   .strict();
 

--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -308,6 +308,84 @@ export const judgeScorerSchema = z
 
 export const judgeScorersResponseSchema = z.object({ judgeScorers: z.array(judgeScorerSchema) }).strict();
 
+// ---- Insights: dataset coverage of production topics -----------------------------------------
+
+export const insightTopicSchema = z
+  .object({
+    topic: z.string(),
+    state: z.enum(["covered", "underrepresented", "missing"]),
+    trafficShare: z.number(),
+    traceCount: z.number(),
+    uniqueSessions: z.number(),
+    caseCount: z.number(),
+    targetCases: z.number(),
+    coverage: z.number(),
+    risk: z.number(),
+    riskComponents: z.object({ issueRate: z.number(), negativeSentimentRate: z.number() }).strict(),
+    suggestedAction: z.string(),
+  })
+  .strict();
+
+export const insightsCoverageResponseSchema = z
+  .object({
+    window: z.enum(["24h", "7d", "30d"]),
+    datasetId: z.string().nullable(),
+    degraded: z.boolean(),
+    degradedReason: z.string().nullable(),
+    insufficientData: z.boolean(),
+    trafficWeightedCoverage: z.number(),
+    topicBreadth: z.object({ covered: z.number(), total: z.number() }).strict(),
+    riskWeightedCoverage: z.number(),
+    presenceCoverage: z.number(),
+    honestyDelta: z.number(),
+    topics: z.array(insightTopicSchema),
+    offMapCases: z.array(
+      z.object({ datasetId: z.string(), index: z.number(), query: z.string(), bestSimilarity: z.number() }).strict()
+    ),
+    caseEmbeddingsPending: z.number(),
+  })
+  .strict();
+
+export const insightsProbeResponseSchema = z
+  .object({
+    query: z.string(),
+    verdict: z.enum(["covered", "adjacent", "gap", "untested-and-unasked"]),
+    similarity: z.number(),
+    bands: z.object({ covered: z.number(), related: z.number() }).strict(),
+    degraded: z.boolean(),
+    nearestCases: z.array(
+      z
+        .object({
+          datasetId: z.string(),
+          datasetName: z.string(),
+          index: z.number(),
+          query: z.string(),
+          expectedResults: z.string().nullable(),
+          similarity: z.number(),
+        })
+        .strict()
+    ),
+    topic: z.object({ topic: z.string(), trafficShare: z.number(), traceCount: z.number() }).strict().nullable(),
+    explanation: z.string(),
+  })
+  .strict();
+
+export const insightsProbeBatchResponseSchema = z
+  .object({
+    results: z.array(insightsProbeResponseSchema),
+    rollup: z
+      .object({
+        total: z.number(),
+        covered: z.number(),
+        adjacent: z.number(),
+        gap: z.number(),
+        untestedAndUnasked: z.number(),
+      })
+      .strict(),
+    degraded: z.boolean(),
+  })
+  .strict();
+
 // ---- registry --------------------------------------------------------------------------------
 
 // What /api/v1/openapi.json publishes and the contract test iterates. Grows a row per surface
@@ -375,5 +453,26 @@ export const WIRE_CONTRACT = [
     summary: "Judge scorer catalog",
     response: judgeScorersResponseSchema,
     name: "JudgeScorersResponse",
+  },
+  {
+    method: "get" as const,
+    path: "/insights/coverage",
+    summary: "Dataset coverage of the topics production actually produces",
+    response: insightsCoverageResponseSchema,
+    name: "InsightsCoverageResponse",
+  },
+  {
+    method: "post" as const,
+    path: "/insights/probe",
+    summary: "Ask whether the datasets cover one specific query",
+    response: insightsProbeResponseSchema,
+    name: "InsightsProbeResponse",
+  },
+  {
+    method: "post" as const,
+    path: "/insights/probe/batch",
+    summary: "The same verdict for a list of queries, plus a rollup",
+    response: insightsProbeBatchResponseSchema,
+    name: "InsightsProbeBatchResponse",
   },
 ];

--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -313,6 +313,7 @@ export const judgeScorersResponseSchema = z.object({ judgeScorers: z.array(judge
 export const insightTopicSchema = z
   .object({
     topic: z.string(),
+    aliases: z.array(z.string()),
     state: z.enum(["covered", "underrepresented", "missing"]),
     trafficShare: z.number(),
     traceCount: z.number(),

--- a/engine/src/core/evaluate/curation.ts
+++ b/engine/src/core/evaluate/curation.ts
@@ -147,12 +147,11 @@ const normalize = normalizeText;
 // ("what's your refund policy" vs "how long does a refund take") score 0.48-0.56, so 0.75 splits
 // the two populations with real margin on both sides. Recalibrate if the embedding model changes.
 //
-// Exported because core/insights/ reports coverage against these same two populations: its
-// "covered" verdict is DEFINED as "addCaseToDataset would reject this query as a duplicate", so
-// the two features share one constant and can never disagree about what "the same question"
-// means. RELATED is the floor of the related-but-distinct band above - below it, two questions
-// have nothing measurable in common; between the two, they are adjacent but not interchangeable.
-export const SIMILARITY_BANDS = { covered: 0.75, related: 0.56 } as const;
+// Exported so core/insights/ scores against the same two populations: its "covered" verdict means
+// "addCaseToDataset would reject this as a duplicate". `related` is the FLOOR of the measured
+// related band (0.48), not its ceiling - a pair at 0.50 is genuinely related and must not be
+// reported as having nothing in common.
+export const SIMILARITY_BANDS = { covered: 0.75, related: 0.48 } as const;
 
 const DEDUPE_SIMILARITY_THRESHOLD = SIMILARITY_BANDS.covered;
 const DEDUPE_EMBEDDING_CAP = 100;

--- a/engine/src/core/evaluate/curation.ts
+++ b/engine/src/core/evaluate/curation.ts
@@ -5,6 +5,7 @@ import { reconstructMessages } from "./portability.js";
 import { getDataset, updateDataset, extractSimilarityConfig, extractCodeScorers } from "./datasets.js";
 import { callJudgeJson, computeEmbedding, DEFAULT_JUDGE_MODEL } from "./judge.js";
 import { extractText } from "../monitor/events.js";
+import { cosine, normalizeText } from "../shared/vector.js";
 
 // The Curate step: turn what production actually did (a trace, or a whole session) into a golden
 // dataset case - the flywheel that grows regression tests out of real failures instead of
@@ -139,30 +140,21 @@ type ExistingQuestion = {
   source?: { traceId?: unknown; sessionId?: unknown };
 };
 
-function normalize(s: string): string {
-  return s.toLowerCase().replace(/\s+/g, " ").trim();
-}
-
-function cosine(a: number[], b: number[]): number {
-  let dot = 0;
-  let na = 0;
-  let nb = 0;
-  for (let i = 0; i < Math.min(a.length, b.length); i++) {
-    const x = a[i] ?? 0;
-    const y = b[i] ?? 0;
-    dot += x * y;
-    na += x * x;
-    nb += y * y;
-  }
-  const denom = Math.sqrt(na) * Math.sqrt(nb);
-  return denom === 0 ? 0 : dot / denom;
-}
+const normalize = normalizeText;
 
 // Calibrated for text-embedding-3-small (DEFAULT_EMBEDDING_MODEL), whose cosines run well below
 // older models': measured paraphrase pairs score 0.82-0.88 while related-but-distinct questions
 // ("what's your refund policy" vs "how long does a refund take") score 0.48-0.56, so 0.75 splits
 // the two populations with real margin on both sides. Recalibrate if the embedding model changes.
-const DEDUPE_SIMILARITY_THRESHOLD = 0.75;
+//
+// Exported because core/insights/ reports coverage against these same two populations: its
+// "covered" verdict is DEFINED as "addCaseToDataset would reject this query as a duplicate", so
+// the two features share one constant and can never disagree about what "the same question"
+// means. RELATED is the floor of the related-but-distinct band above - below it, two questions
+// have nothing measurable in common; between the two, they are adjacent but not interchangeable.
+export const SIMILARITY_BANDS = { covered: 0.75, related: 0.56 } as const;
+
+const DEDUPE_SIMILARITY_THRESHOLD = SIMILARITY_BANDS.covered;
 const DEDUPE_EMBEDDING_CAP = 100;
 
 export type DuplicateInfo = { reason: "same-source" | "same-query" | "similar-query"; existingQuery: string; similarity?: number };

--- a/engine/src/core/evaluate/datasets.ts
+++ b/engine/src/core/evaluate/datasets.ts
@@ -200,12 +200,20 @@ export async function deleteDataset(
     eq(db.schema.evaluationSettingsVersions.evaluationSettingsId, id),
     eq(db.schema.evaluationSettingsVersions.projectId, db.projectId)
   );
+  // Cached case embeddings (core/insights/cases.ts) key off datasetId and nothing else deletes
+  // them, so without this they outlive every dataset they ever described.
+  const caseEmbeddingsCond = and(
+    eq(db.schema.insightCaseEmbeddings.datasetId, id),
+    eq(db.schema.insightCaseEmbeddings.projectId, db.projectId)
+  );
   if (db.kind === "sqlite") {
+    await db.db.delete(db.schema.insightCaseEmbeddings).where(caseEmbeddingsCond);
     await db.db.delete(db.schema.datasetVersions).where(datasetVersionsCond);
     await db.db.delete(db.schema.evaluationSettingsVersions).where(settingsVersionsCond);
     await db.db.delete(db.schema.evaluationSettings).where(twinCond);
     await db.db.delete(db.schema.datasets).where(datasetCond);
   } else {
+    await db.db.delete(db.schema.insightCaseEmbeddings).where(caseEmbeddingsCond);
     await db.db.delete(db.schema.datasetVersions).where(datasetVersionsCond);
     await db.db.delete(db.schema.evaluationSettingsVersions).where(settingsVersionsCond);
     await db.db.delete(db.schema.evaluationSettings).where(twinCond);

--- a/engine/src/core/evaluate/judge.ts
+++ b/engine/src/core/evaluate/judge.ts
@@ -335,6 +335,13 @@ export async function computeVectorSimilarity(
 // computeVectorSimilarityShared, but it's unexported and embeddings are self-host-only here
 // anyway (matching computeVectorSimilarity's own reasoning for staying out of the shared
 // package), so this calls the OpenAI client directly rather than adding a new export there.
+// Whether embeddings can be attempted at all. Lets callers distinguish "no key configured"
+// (permanent, don't retry) from "the call failed" (transient, do retry) - computeEmbedding
+// returns null for both.
+export async function embeddingsAvailable(): Promise<boolean> {
+  return (await getOpenAI()) !== null;
+}
+
 export async function computeEmbedding(text: string, model: string = DEFAULT_EMBEDDING_MODEL): Promise<number[] | null> {
   const trimmed = text.trim();
   if (!trimmed) {

--- a/engine/src/core/evaluate/judge.ts
+++ b/engine/src/core/evaluate/judge.ts
@@ -344,46 +344,111 @@ export async function embeddingsAvailable(): Promise<boolean> {
 
 // Inputs per embeddings request. The endpoint takes an array, so a cold Insights cache asking for
 // ~120 vectors is one or two calls rather than ~120 serialized round trips (which measured ~40s).
-// 128 is well inside the API's per-request input limit and keeps any single failure cheap to retry.
 const MAX_EMBEDDING_BATCH = 128;
+
+/**
+ * The slice of the OpenAI client the batching needs. Narrow on purpose: it lets the split-and-retry
+ * logic below be exercised against a client that fails the way the real API fails, which is the only
+ * behaviour here worth testing and the one a live key cannot demonstrate on demand.
+ */
+export type EmbeddingClient = {
+  embeddings: { create: (args: { model: string; input: string[] }) => Promise<unknown> };
+};
+
+// One request. Returns vectors aligned to `inputs`, or null for the whole call if it failed - the
+// caller decides whether to split and retry.
+async function embedOnce(
+  client: EmbeddingClient,
+  model: string,
+  inputs: string[]
+): Promise<(number[] | null)[] | null> {
+  try {
+    const response = (await client.embeddings.create({ model, input: inputs })) as {
+      data?: { index: number; embedding: unknown }[];
+    };
+    const out: (number[] | null)[] = new Array(inputs.length).fill(null);
+    // Mapped through the response's own `index` rather than positionally: the API documents input
+    // order as preserved, but honoring the explicit index costs nothing and means a reordered
+    // response mislabels no vectors.
+    for (const item of response.data ?? []) {
+      if (item.index >= 0 && item.index < out.length && Array.isArray(item.embedding)) {
+        out[item.index] = item.embedding as number[];
+      }
+    }
+    return out;
+  } catch (err) {
+    // Logged by the caller, which is the only place that knows whether this is a batch about to be
+    // split and retried or a single input that is genuinely unembeddable.
+    logger.debug({ err: err instanceof Error ? err.message : err, inputs: inputs.length }, "Embedding batch failed");
+    return null;
+  }
+}
+
+// Failure isolation is the whole point of splitting rather than giving up on the batch. The API
+// rejects an ENTIRE request when any single input is over the model's token limit, so without this
+// one oversized case would null every vector in its batch - and because the caller rebuilds the
+// same batch next time and caches nothing from a failure, that case would block every other case
+// behind it forever rather than costing only itself. Halving isolates the offender in log2(n)
+// requests; a failed single input is genuinely unembeddable and stays null.
+async function embedSplit(
+  client: EmbeddingClient,
+  model: string,
+  inputs: string[]
+): Promise<(number[] | null)[]> {
+  const direct = await embedOnce(client, model, inputs);
+  if (direct) {
+    return direct;
+  }
+  if (inputs.length === 1) {
+    // Nothing left to split. This one text cannot be embedded - almost always because it is over
+    // the model's input limit - so it stays null and every other case is unaffected.
+    logger.error({ chars: inputs[0]?.length ?? 0 }, "Embedding failed for a single input; skipping it");
+    return [null];
+  }
+  const mid = Math.ceil(inputs.length / 2);
+  const [left, right] = await Promise.all([
+    embedSplit(client, model, inputs.slice(0, mid)),
+    embedSplit(client, model, inputs.slice(mid)),
+  ]);
+  return [...left, ...right];
+}
 
 // Batched sibling of computeEmbedding, for callers that already know every text they need. Returns
 // one slot per input, aligned by index, holding null wherever the text was blank, no key is set, or
-// the call failed - the same per-item graceful degradation computeEmbedding gives, so a partial
-// result is usable rather than fatal and the null slots simply retry on the next call.
-export async function computeEmbeddings(
+// that individual text could not be embedded - the same per-item graceful degradation
+// computeEmbedding gives, so a partial result is usable rather than fatal and the null slots simply
+// retry on the next call.
+export async function embedBatched(
+  client: EmbeddingClient,
   texts: string[],
   model: string = DEFAULT_EMBEDDING_MODEL
 ): Promise<(number[] | null)[]> {
   const out: (number[] | null)[] = new Array(texts.length).fill(null);
-  const client = await getOpenAI();
-  if (!client) {
-    return out;
-  }
   // Blank text never reaches the API: it has no meaningful vector, and an empty string in the
-  // input array is a request-level error that would take the whole chunk down with it.
+  // input array is a request-level error that would take the whole chunk down with it. It keeps its
+  // slot so the caller's indexing holds.
   const wanted = texts.map((text, index) => ({ index, text: text.trim() })).filter(entry => entry.text.length > 0);
 
   for (let start = 0; start < wanted.length; start += MAX_EMBEDDING_BATCH) {
     const chunk = wanted.slice(start, start + MAX_EMBEDDING_BATCH);
-    try {
-      const response = await client.embeddings.create({ model, input: chunk.map(entry => entry.text) });
-      // Map each vector back through the response's own `index` rather than positionally: the API
-      // documents input order as preserved, but honoring the explicit index costs nothing and means
-      // a reordered response mislabels no vectors.
-      for (const item of response.data ?? []) {
-        const entry = chunk[item.index];
-        if (entry && Array.isArray(item.embedding)) {
-          out[entry.index] = item.embedding;
-        }
-      }
-    } catch (err) {
-      // Only this chunk's slots stay null. Nothing is cached from a failure, so the next call
-      // retries exactly the texts that did not come back.
-      logger.error({ err: err }, "Batch embedding computation failed:");
-    }
+    const vectors = await embedSplit(
+      client,
+      model,
+      chunk.map(entry => entry.text)
+    );
+    chunk.forEach((entry, position) => {
+      out[entry.index] = vectors[position] ?? null;
+    });
   }
   return out;
+}
+
+export async function computeEmbeddings(
+  texts: string[],
+  model: string = DEFAULT_EMBEDDING_MODEL
+): Promise<(number[] | null)[]> {
+  const client = (await getOpenAI()) as EmbeddingClient | null;
+  return client ? embedBatched(client, texts, model) : new Array(texts.length).fill(null);
 }
 
 export async function computeEmbedding(text: string, model: string = DEFAULT_EMBEDDING_MODEL): Promise<number[] | null> {

--- a/engine/src/core/evaluate/judge.ts
+++ b/engine/src/core/evaluate/judge.ts
@@ -342,6 +342,50 @@ export async function embeddingsAvailable(): Promise<boolean> {
   return (await getOpenAI()) !== null;
 }
 
+// Inputs per embeddings request. The endpoint takes an array, so a cold Insights cache asking for
+// ~120 vectors is one or two calls rather than ~120 serialized round trips (which measured ~40s).
+// 128 is well inside the API's per-request input limit and keeps any single failure cheap to retry.
+const MAX_EMBEDDING_BATCH = 128;
+
+// Batched sibling of computeEmbedding, for callers that already know every text they need. Returns
+// one slot per input, aligned by index, holding null wherever the text was blank, no key is set, or
+// the call failed - the same per-item graceful degradation computeEmbedding gives, so a partial
+// result is usable rather than fatal and the null slots simply retry on the next call.
+export async function computeEmbeddings(
+  texts: string[],
+  model: string = DEFAULT_EMBEDDING_MODEL
+): Promise<(number[] | null)[]> {
+  const out: (number[] | null)[] = new Array(texts.length).fill(null);
+  const client = await getOpenAI();
+  if (!client) {
+    return out;
+  }
+  // Blank text never reaches the API: it has no meaningful vector, and an empty string in the
+  // input array is a request-level error that would take the whole chunk down with it.
+  const wanted = texts.map((text, index) => ({ index, text: text.trim() })).filter(entry => entry.text.length > 0);
+
+  for (let start = 0; start < wanted.length; start += MAX_EMBEDDING_BATCH) {
+    const chunk = wanted.slice(start, start + MAX_EMBEDDING_BATCH);
+    try {
+      const response = await client.embeddings.create({ model, input: chunk.map(entry => entry.text) });
+      // Map each vector back through the response's own `index` rather than positionally: the API
+      // documents input order as preserved, but honoring the explicit index costs nothing and means
+      // a reordered response mislabels no vectors.
+      for (const item of response.data ?? []) {
+        const entry = chunk[item.index];
+        if (entry && Array.isArray(item.embedding)) {
+          out[entry.index] = item.embedding;
+        }
+      }
+    } catch (err) {
+      // Only this chunk's slots stay null. Nothing is cached from a failure, so the next call
+      // retries exactly the texts that did not come back.
+      logger.error({ err: err }, "Batch embedding computation failed:");
+    }
+  }
+  return out;
+}
+
 export async function computeEmbedding(text: string, model: string = DEFAULT_EMBEDDING_MODEL): Promise<number[] | null> {
   const trimmed = text.trim();
   if (!trimmed) {

--- a/engine/src/core/insights/cases.ts
+++ b/engine/src/core/insights/cases.ts
@@ -1,0 +1,161 @@
+import { createHash } from "node:crypto";
+import { and, eq, inArray } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import type { Db } from "../../storage/db.js";
+import { computeEmbedding } from "../evaluate/judge.js";
+import { DEFAULT_EMBEDDING_MODEL } from "@agentx/judge-core";
+import { listDatasets } from "../evaluate/datasets.js";
+import { normalizeText } from "../shared/vector.js";
+import { logger } from "../../log.js";
+
+// The dataset half of Insights: pull every case's question text out of the datasets' `questions`
+// JSON and give each one a cached embedding, so coverage (coverage.ts) and the probe (probe.ts)
+// can compare cases against production traffic in one vector space.
+//
+// Only the MAIN question is embedded, not follow-ups. A follow-up only makes sense as the second
+// turn of its own case - on its own it is usually a fragment ("and if it's expired?") that would
+// land nowhere near any topic and drag the case's assignment with it. The case is represented by
+// the thing a user would actually walk in and ask.
+
+export type DatasetCase = {
+  datasetId: string;
+  datasetName: string;
+  // Index into the dataset's `questions` array - the address the dashboard needs to link to it.
+  index: number;
+  query: string;
+  expectedResults: string | null;
+  // sha256 of the normalized query: stable across reordering, changes when the text is edited.
+  caseKey: string;
+  embedding: number[] | null;
+};
+
+type QuestionShape = {
+  main_question?: { query?: unknown; expectedResults?: unknown };
+};
+
+export function caseKeyFor(query: string): string {
+  return createHash("sha256").update(normalizeText(query)).digest("hex").slice(0, 32);
+}
+
+// New embeddings computed in a single request. A first call on a large dataset warms part of the
+// cache and reports `degraded` for the rest; the next call picks up where this one stopped. That
+// is deliberately preferable to either blocking a dashboard load on 400 sequential embedding
+// calls or silently reporting a coverage number computed from a third of the dataset.
+const MAX_NEW_EMBEDDINGS_PER_REQUEST = 60;
+
+export async function listDatasetCases(db: Db, datasetId?: string): Promise<DatasetCase[]> {
+  const datasets = (await listDatasets(db)) as { _id: string; name: string; questions?: unknown }[];
+  const wanted = datasetId ? datasets.filter(d => d._id === datasetId) : datasets;
+  const cases: DatasetCase[] = [];
+  for (const dataset of wanted) {
+    const questions = Array.isArray(dataset.questions) ? (dataset.questions as QuestionShape[]) : [];
+    questions.forEach((question, index) => {
+      const query = typeof question?.main_question?.query === "string" ? question.main_question.query.trim() : "";
+      if (!query) {
+        return;
+      }
+      const expected = question.main_question?.expectedResults;
+      cases.push({
+        datasetId: dataset._id,
+        datasetName: dataset.name,
+        index,
+        query,
+        expectedResults: typeof expected === "string" && expected.trim() ? expected.trim() : null,
+        caseKey: caseKeyFor(query),
+        embedding: null,
+      });
+    });
+  }
+  return cases;
+}
+
+type CacheRow = { datasetId: string; caseKey: string; embedding: unknown };
+
+async function readCache(db: Db, datasetIds: string[]): Promise<Map<string, number[] | null>> {
+  const byKey = new Map<string, number[] | null>();
+  if (datasetIds.length === 0) {
+    return byKey;
+  }
+  const cond = and(
+    eq(db.schema.insightCaseEmbeddings.projectId, db.projectId),
+    inArray(db.schema.insightCaseEmbeddings.datasetId, datasetIds)
+  );
+  const rows = (
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.insightCaseEmbeddings).where(cond).all()
+      : await db.db.select().from(db.schema.insightCaseEmbeddings).where(cond)
+  ) as CacheRow[];
+  for (const row of rows) {
+    // A cached NULL is a remembered failure, and must stay distinct from "not cached yet" - it is
+    // the whole reason a missing OPENAI_API_KEY doesn't re-attempt an embedding per case per
+    // request forever. Map.has() separates the two; a bare get() would not.
+    byKey.set(`${row.datasetId}:${row.caseKey}`, Array.isArray(row.embedding) ? (row.embedding as number[]) : null);
+  }
+  return byKey;
+}
+
+async function writeCache(
+  db: Db,
+  entry: { datasetId: string; caseKey: string; query: string; embedding: number[] | null }
+): Promise<void> {
+  const row = {
+    id: nanoid(),
+    projectId: db.projectId,
+    datasetId: entry.datasetId,
+    caseKey: entry.caseKey,
+    query: entry.query,
+    embedding: entry.embedding,
+    model: entry.embedding ? DEFAULT_EMBEDDING_MODEL : null,
+    createdAt: new Date(),
+  };
+  try {
+    if (db.kind === "sqlite") {
+      db.db.insert(db.schema.insightCaseEmbeddings).values(row).run();
+    } else {
+      await db.db.insert(db.schema.insightCaseEmbeddings).values(row);
+    }
+  } catch (err) {
+    // The unique index on (project_id, dataset_id, case_key) is doing its job: two concurrent
+    // dashboard polls raced to embed the same case. The other one won and the value is identical,
+    // so there is nothing to repair.
+    logger.debug({ err: err instanceof Error ? err.message : err }, "Insight case embedding already cached");
+  }
+}
+
+export type CaseEmbeddingResult = {
+  cases: DatasetCase[];
+  /** True when at least one case has a usable embedding - i.e. cosine coverage is meaningful. */
+  embedded: boolean;
+  /** Cases still without an embedding when this call returned (cap hit, or no LLM key). */
+  pending: number;
+};
+
+// Fills in `embedding` on the given cases, reading the cache first and computing at most
+// MAX_NEW_EMBEDDINGS_PER_REQUEST new ones. Never throws: an embedding failure is recorded as a
+// cached null and the caller degrades to the lexical fallback, exactly as every other embedding
+// path in this repo does.
+export async function attachCaseEmbeddings(db: Db, cases: DatasetCase[]): Promise<CaseEmbeddingResult> {
+  const datasetIds = Array.from(new Set(cases.map(c => c.datasetId)));
+  const cache = await readCache(db, datasetIds);
+  let budget = MAX_NEW_EMBEDDINGS_PER_REQUEST;
+  let embedded = false;
+  let pending = 0;
+
+  for (const item of cases) {
+    const key = `${item.datasetId}:${item.caseKey}`;
+    if (cache.has(key)) {
+      item.embedding = cache.get(key) ?? null;
+    } else if (budget > 0) {
+      budget--;
+      item.embedding = await computeEmbedding(item.query);
+      await writeCache(db, { datasetId: item.datasetId, caseKey: item.caseKey, query: item.query, embedding: item.embedding });
+      cache.set(key, item.embedding);
+    }
+    if (item.embedding) {
+      embedded = true;
+    } else {
+      pending++;
+    }
+  }
+  return { cases, embedded, pending };
+}

--- a/engine/src/core/insights/cases.ts
+++ b/engine/src/core/insights/cases.ts
@@ -48,9 +48,25 @@ export function caseKeyFor(query: string, expectedResults?: string | null): stri
 // the rest as pending; the next call continues from there.
 const MAX_NEW_EMBEDDINGS_PER_REQUEST = 60;
 
-export async function listDatasetCases(db: Db, datasetId?: string): Promise<DatasetCase[]> {
+// Every dataset in the project with its case count, unaffected by whatever the caller is filtering
+// to. The filter's own control is drawn from this: a picker built from the filtered result has one
+// option left the moment you use it, which is a filter you cannot undo.
+export async function listDatasetSummaries(db: Db): Promise<{ id: string; name: string; caseCount: number }[]> {
   const datasets = (await listDatasets(db)) as { _id: string; name: string; questions?: unknown }[];
-  const wanted = datasetId ? datasets.filter(d => d._id === datasetId) : datasets;
+  return datasets
+    .map(dataset => ({
+      id: dataset._id,
+      name: dataset.name,
+      caseCount: (Array.isArray(dataset.questions) ? (dataset.questions as QuestionShape[]) : []).filter(
+        question => typeof question?.main_question?.query === "string" && question.main_question.query.trim()
+      ).length,
+    }))
+    .sort((a, b) => b.caseCount - a.caseCount || a.name.localeCompare(b.name));
+}
+
+export async function listDatasetCases(db: Db, datasetIds?: string[]): Promise<DatasetCase[]> {
+  const datasets = (await listDatasets(db)) as { _id: string; name: string; questions?: unknown }[];
+  const wanted = datasetIds?.length ? datasets.filter(d => datasetIds.includes(d._id)) : datasets;
   const cases: DatasetCase[] = [];
   for (const dataset of wanted) {
     const questions = Array.isArray(dataset.questions) ? (dataset.questions as QuestionShape[]) : [];

--- a/engine/src/core/insights/cases.ts
+++ b/engine/src/core/insights/cases.ts
@@ -2,45 +2,50 @@ import { createHash } from "node:crypto";
 import { and, eq, inArray } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type { Db } from "../../storage/db.js";
-import { computeEmbedding } from "../evaluate/judge.js";
+import { computeEmbedding, embeddingsAvailable } from "../evaluate/judge.js";
 import { DEFAULT_EMBEDDING_MODEL } from "@agentx/judge-core";
 import { listDatasets } from "../evaluate/datasets.js";
 import { normalizeText } from "../shared/vector.js";
 import { logger } from "../../log.js";
 
-// The dataset half of Insights: pull every case's question text out of the datasets' `questions`
-// JSON and give each one a cached embedding, so coverage (coverage.ts) and the probe (probe.ts)
-// can compare cases against production traffic in one vector space.
+// The dataset half of Insights: each case's text, with cached embeddings.
 //
-// Only the MAIN question is embedded, not follow-ups. A follow-up only makes sense as the second
-// turn of its own case - on its own it is usually a fragment ("and if it's expired?") that would
-// land nowhere near any topic and drag the case's assignment with it. The case is represented by
-// the thing a user would actually walk in and ask.
+// TWO embeddings per case, because there are two comparisons and they live in different spaces:
+//   embedding     - the query alone. Compared against a user's typed query by the probe.
+//   embeddingFull - query + expected result. Compared against TRACE embeddings by coverage, which
+//                   monitor/topics.ts builds from input + output.
+// Scoring a query-only vector against a query+answer vector is a cross-space comparison: it reads
+// systematically low, so cases fall off the map and topics report "missing" that are covered fine.
+//
+// Only the main question is embedded, never follow-ups - a follow-up is a fragment ("and if it's
+// expired?") that would drag its case's assignment somewhere meaningless.
 
 export type DatasetCase = {
   datasetId: string;
   datasetName: string;
-  // Index into the dataset's `questions` array - the address the dashboard needs to link to it.
   index: number;
   query: string;
   expectedResults: string | null;
-  // sha256 of the normalized query: stable across reordering, changes when the text is edited.
   caseKey: string;
+  /** Query only - the probe's space. Null when not yet computed. */
   embedding: number[] | null;
+  /** Query + expected result - the traces' space. Null when not yet computed. */
+  embeddingFull: number[] | null;
 };
 
-type QuestionShape = {
-  main_question?: { query?: unknown; expectedResults?: unknown };
-};
+type QuestionShape = { main_question?: { query?: unknown; expectedResults?: unknown } };
 
-export function caseKeyFor(query: string): string {
-  return createHash("sha256").update(normalizeText(query)).digest("hex").slice(0, 32);
+// Hash of the text that was embedded, so editing a case re-embeds it while reordering costs
+// nothing - a positional key would get that exactly backwards.
+export function caseKeyFor(query: string, expectedResults?: string | null): string {
+  return createHash("sha256")
+    .update(`${normalizeText(query)} ${normalizeText(expectedResults ?? "")}`)
+    .digest("hex")
+    .slice(0, 32);
 }
 
-// New embeddings computed in a single request. A first call on a large dataset warms part of the
-// cache and reports `degraded` for the rest; the next call picks up where this one stopped. That
-// is deliberately preferable to either blocking a dashboard load on 400 sequential embedding
-// calls or silently reporting a coverage number computed from a third of the dataset.
+// Cases embedded per request. A first call on a large dataset warms part of the cache and reports
+// the rest as pending; the next call continues from there.
 const MAX_NEW_EMBEDDINGS_PER_REQUEST = 60;
 
 export async function listDatasetCases(db: Db, datasetId?: string): Promise<DatasetCase[]> {
@@ -54,25 +59,27 @@ export async function listDatasetCases(db: Db, datasetId?: string): Promise<Data
       if (!query) {
         return;
       }
-      const expected = question.main_question?.expectedResults;
+      const raw = question.main_question?.expectedResults;
+      const expectedResults = typeof raw === "string" && raw.trim() ? raw.trim() : null;
       cases.push({
         datasetId: dataset._id,
         datasetName: dataset.name,
         index,
         query,
-        expectedResults: typeof expected === "string" && expected.trim() ? expected.trim() : null,
-        caseKey: caseKeyFor(query),
+        expectedResults,
+        caseKey: caseKeyFor(query, expectedResults),
         embedding: null,
+        embeddingFull: null,
       });
     });
   }
   return cases;
 }
 
-type CacheRow = { datasetId: string; caseKey: string; embedding: unknown };
+type CacheRow = { datasetId: string; caseKey: string; embedding: unknown; embeddingFull: unknown };
 
-async function readCache(db: Db, datasetIds: string[]): Promise<Map<string, number[] | null>> {
-  const byKey = new Map<string, number[] | null>();
+async function readCache(db: Db, datasetIds: string[]): Promise<Map<string, CacheRow>> {
+  const byKey = new Map<string, CacheRow>();
   if (datasetIds.length === 0) {
     return byKey;
   }
@@ -86,72 +93,80 @@ async function readCache(db: Db, datasetIds: string[]): Promise<Map<string, numb
       : await db.db.select().from(db.schema.insightCaseEmbeddings).where(cond)
   ) as CacheRow[];
   for (const row of rows) {
-    // A cached NULL is a remembered failure, and must stay distinct from "not cached yet" - it is
-    // the whole reason a missing OPENAI_API_KEY doesn't re-attempt an embedding per case per
-    // request forever. Map.has() separates the two; a bare get() would not.
-    byKey.set(`${row.datasetId}:${row.caseKey}`, Array.isArray(row.embedding) ? (row.embedding as number[]) : null);
+    byKey.set(`${row.datasetId}:${row.caseKey}`, row);
   }
   return byKey;
 }
 
 async function writeCache(
   db: Db,
-  entry: { datasetId: string; caseKey: string; query: string; embedding: number[] | null }
+  entry: { datasetId: string; caseKey: string; query: string; embedding: number[]; embeddingFull: number[] }
 ): Promise<void> {
-  const row = {
-    id: nanoid(),
-    projectId: db.projectId,
-    datasetId: entry.datasetId,
-    caseKey: entry.caseKey,
-    query: entry.query,
-    embedding: entry.embedding,
-    model: entry.embedding ? DEFAULT_EMBEDDING_MODEL : null,
-    createdAt: new Date(),
-  };
   try {
+    const row = {
+      id: nanoid(),
+      projectId: db.projectId,
+      datasetId: entry.datasetId,
+      caseKey: entry.caseKey,
+      query: entry.query,
+      embedding: entry.embedding,
+      embeddingFull: entry.embeddingFull,
+      model: DEFAULT_EMBEDDING_MODEL,
+      createdAt: new Date(),
+    };
     if (db.kind === "sqlite") {
       db.db.insert(db.schema.insightCaseEmbeddings).values(row).run();
     } else {
       await db.db.insert(db.schema.insightCaseEmbeddings).values(row);
     }
   } catch (err) {
-    // The unique index on (project_id, dataset_id, case_key) is doing its job: two concurrent
-    // dashboard polls raced to embed the same case. The other one won and the value is identical,
-    // so there is nothing to repair.
+    // The unique index did its job: a concurrent poll embedded the same case, to the same value.
     logger.debug({ err: err instanceof Error ? err.message : err }, "Insight case embedding already cached");
   }
 }
 
 export type CaseEmbeddingResult = {
   cases: DatasetCase[];
-  /** True when at least one case has a usable embedding - i.e. cosine coverage is meaningful. */
+  /** At least one case carries usable vectors, so cosine scoring is meaningful. */
   embedded: boolean;
-  /** Cases still without an embedding when this call returned (cap hit, or no LLM key). */
+  /** Cases still unembedded when this returned - cap hit, no key, or a failed call. */
   pending: number;
 };
 
-// Fills in `embedding` on the given cases, reading the cache first and computing at most
-// MAX_NEW_EMBEDDINGS_PER_REQUEST new ones. Never throws: an embedding failure is recorded as a
-// cached null and the caller degrades to the lexical fallback, exactly as every other embedding
-// path in this repo does.
+// Never caches a null. A failed call and a missing key are indistinguishable at computeEmbedding's
+// boundary, and caching that as permanent would exclude those cases forever - adding a key later
+// would not recover them. Instead the no-key case short-circuits before any call, so nothing
+// retries in a doomed loop, and a real failure just stays pending until next time.
 export async function attachCaseEmbeddings(db: Db, cases: DatasetCase[]): Promise<CaseEmbeddingResult> {
   const datasetIds = Array.from(new Set(cases.map(c => c.datasetId)));
   const cache = await readCache(db, datasetIds);
+  const canEmbed = cases.length > 0 && (await embeddingsAvailable());
   let budget = MAX_NEW_EMBEDDINGS_PER_REQUEST;
   let embedded = false;
   let pending = 0;
 
   for (const item of cases) {
-    const key = `${item.datasetId}:${item.caseKey}`;
-    if (cache.has(key)) {
-      item.embedding = cache.get(key) ?? null;
-    } else if (budget > 0) {
+    const cached = cache.get(`${item.datasetId}:${item.caseKey}`);
+    if (cached) {
+      item.embedding = Array.isArray(cached.embedding) ? (cached.embedding as number[]) : null;
+      item.embeddingFull = Array.isArray(cached.embeddingFull) ? (cached.embeddingFull as number[]) : null;
+    } else if (canEmbed && budget > 0) {
       budget--;
-      item.embedding = await computeEmbedding(item.query);
-      await writeCache(db, { datasetId: item.datasetId, caseKey: item.caseKey, query: item.query, embedding: item.embedding });
-      cache.set(key, item.embedding);
+      const fullText = item.expectedResults ? `${item.query}\n\n${item.expectedResults}` : item.query;
+      const [query, full] = await Promise.all([computeEmbedding(item.query), computeEmbedding(fullText)]);
+      if (query && full) {
+        item.embedding = query;
+        item.embeddingFull = full;
+        await writeCache(db, {
+          datasetId: item.datasetId,
+          caseKey: item.caseKey,
+          query: item.query,
+          embedding: query,
+          embeddingFull: full,
+        });
+      }
     }
-    if (item.embedding) {
+    if (item.embedding && item.embeddingFull) {
       embedded = true;
     } else {
       pending++;

--- a/engine/src/core/insights/cases.ts
+++ b/engine/src/core/insights/cases.ts
@@ -51,25 +51,34 @@ const MAX_NEW_EMBEDDINGS_PER_REQUEST = 60;
 // Every dataset in the project with its case count, unaffected by whatever the caller is filtering
 // to. The filter's own control is drawn from this: a picker built from the filtered result has one
 // option left the moment you use it, which is a filter you cannot undo.
-export async function listDatasetSummaries(db: Db): Promise<{ id: string; name: string; caseCount: number }[]> {
-  const datasets = (await listDatasets(db)) as { _id: string; name: string; questions?: unknown }[];
+type DatasetRow = { _id: string; name: string; questions?: unknown };
+
+const questionsOf = (dataset: DatasetRow): QuestionShape[] =>
+  Array.isArray(dataset.questions) ? (dataset.questions as QuestionShape[]) : [];
+
+/** One read of the dataset table, shared by the summaries and the case list below. */
+export async function listDatasetRows(db: Db): Promise<DatasetRow[]> {
+  return (await listDatasets(db)) as DatasetRow[];
+}
+
+export function datasetSummaries(datasets: DatasetRow[]): { id: string; name: string; caseCount: number }[] {
   return datasets
     .map(dataset => ({
       id: dataset._id,
       name: dataset.name,
-      caseCount: (Array.isArray(dataset.questions) ? (dataset.questions as QuestionShape[]) : []).filter(
+      caseCount: questionsOf(dataset).filter(
         question => typeof question?.main_question?.query === "string" && question.main_question.query.trim()
       ).length,
     }))
     .sort((a, b) => b.caseCount - a.caseCount || a.name.localeCompare(b.name));
 }
 
-export async function listDatasetCases(db: Db, datasetIds?: string[]): Promise<DatasetCase[]> {
-  const datasets = (await listDatasets(db)) as { _id: string; name: string; questions?: unknown }[];
+export async function listDatasetCases(db: Db, datasetIds?: string[], preloaded?: DatasetRow[]): Promise<DatasetCase[]> {
+  const datasets = preloaded ?? (await listDatasetRows(db));
   const wanted = datasetIds?.length ? datasets.filter(d => datasetIds.includes(d._id)) : datasets;
   const cases: DatasetCase[] = [];
   for (const dataset of wanted) {
-    const questions = Array.isArray(dataset.questions) ? (dataset.questions as QuestionShape[]) : [];
+    const questions = questionsOf(dataset);
     questions.forEach((question, index) => {
       const query = typeof question?.main_question?.query === "string" ? question.main_question.query.trim() : "";
       if (!query) {
@@ -114,30 +123,47 @@ async function readCache(db: Db, datasetIds: string[]): Promise<Map<string, Cach
   return byKey;
 }
 
-async function writeCache(
-  db: Db,
-  entry: { datasetId: string; caseKey: string; query: string; embedding: number[]; embeddingFull: number[] }
-): Promise<void> {
+type CacheEntry = { datasetId: string; caseKey: string; query: string; embedding: number[]; embeddingFull: number[] };
+
+// One insert for the whole warming pass rather than one per case. This runs on a path the UI polls
+// while the cache warms, so 60 sequential round trips per pass is 60 too many.
+async function writeCache(db: Db, entries: CacheEntry[]): Promise<void> {
+  if (entries.length === 0) {
+    return;
+  }
+  const rows = entries.map(entry => ({
+    id: nanoid(),
+    projectId: db.projectId,
+    datasetId: entry.datasetId,
+    caseKey: entry.caseKey,
+    query: entry.query,
+    embedding: entry.embedding,
+    embeddingFull: entry.embeddingFull,
+    model: DEFAULT_EMBEDDING_MODEL,
+    createdAt: new Date(),
+  }));
   try {
-    const row = {
-      id: nanoid(),
-      projectId: db.projectId,
-      datasetId: entry.datasetId,
-      caseKey: entry.caseKey,
-      query: entry.query,
-      embedding: entry.embedding,
-      embeddingFull: entry.embeddingFull,
-      model: DEFAULT_EMBEDDING_MODEL,
-      createdAt: new Date(),
-    };
     if (db.kind === "sqlite") {
-      db.db.insert(db.schema.insightCaseEmbeddings).values(row).run();
+      db.db.insert(db.schema.insightCaseEmbeddings).values(rows).run();
     } else {
-      await db.db.insert(db.schema.insightCaseEmbeddings).values(row);
+      await db.db.insert(db.schema.insightCaseEmbeddings).values(rows);
     }
   } catch (err) {
-    // The unique index did its job: a concurrent poll embedded the same case, to the same value.
-    logger.debug({ err: err instanceof Error ? err.message : err }, "Insight case embedding already cached");
+    // The unique index did its job: a concurrent poll embedded the same cases, to the same values.
+    // Retried one at a time so one collision does not discard the rest of the batch.
+    logger.debug({ err: err instanceof Error ? err.message : err }, "Insight case embeddings already cached");
+    for (const row of rows) {
+      try {
+        if (db.kind === "sqlite") {
+          db.db.insert(db.schema.insightCaseEmbeddings).values(row).run();
+        } else {
+          await db.db.insert(db.schema.insightCaseEmbeddings).values(row);
+        }
+      } catch {
+        // Already present - the cached value is identical by construction (caseKey is a hash of the
+        // embedded text), so there is nothing to reconcile.
+      }
+    }
   }
 }
 
@@ -147,6 +173,12 @@ export type CaseEmbeddingResult = {
   embedded: boolean;
   /** Cases still unembedded when this returned - cap hit, no key, or a failed call. */
   pending: number;
+  /**
+   * Whether embedding can make progress at all. Without this, "pending > 0" is indistinguishable
+   * between "warming, come back" and "no key, this will never change" - and a caller that polls on
+   * the first reading polls forever on the second.
+   */
+  canEmbed: boolean;
 };
 
 // Never caches a null. A failed call and a missing key are indistinguishable at the embedder's
@@ -191,6 +223,7 @@ export async function attachCaseEmbeddings(db: Db, cases: DatasetCase[]): Promis
     }));
 
     const vectors = await computeEmbeddings(texts);
+    const fresh: CacheEntry[] = [];
     for (const entry of wanted) {
       const query = vectors[entry.query];
       const full = vectors[entry.full];
@@ -199,7 +232,7 @@ export async function attachCaseEmbeddings(db: Db, cases: DatasetCase[]): Promis
       if (query && full) {
         entry.item.embedding = query;
         entry.item.embeddingFull = full;
-        await writeCache(db, {
+        fresh.push({
           datasetId: entry.item.datasetId,
           caseKey: entry.item.caseKey,
           query: entry.item.query,
@@ -208,6 +241,7 @@ export async function attachCaseEmbeddings(db: Db, cases: DatasetCase[]): Promis
         });
       }
     }
+    await writeCache(db, fresh);
   }
 
   let embedded = false;
@@ -219,5 +253,5 @@ export async function attachCaseEmbeddings(db: Db, cases: DatasetCase[]): Promis
       pending++;
     }
   }
-  return { cases, embedded, pending };
+  return { cases, embedded, pending, canEmbed };
 }

--- a/engine/src/core/insights/cases.ts
+++ b/engine/src/core/insights/cases.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { and, eq, inArray } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type { Db } from "../../storage/db.js";
-import { computeEmbedding, embeddingsAvailable } from "../evaluate/judge.js";
+import { computeEmbeddings, embeddingsAvailable } from "../evaluate/judge.js";
 import { DEFAULT_EMBEDDING_MODEL } from "@agentx/judge-core";
 import { listDatasets } from "../evaluate/datasets.js";
 import { normalizeText } from "../shared/vector.js";
@@ -133,7 +133,7 @@ export type CaseEmbeddingResult = {
   pending: number;
 };
 
-// Never caches a null. A failed call and a missing key are indistinguishable at computeEmbedding's
+// Never caches a null. A failed call and a missing key are indistinguishable at the embedder's
 // boundary, and caching that as permanent would exclude those cases forever - adding a key later
 // would not recover them. Instead the no-key case short-circuits before any call, so nothing
 // retries in a doomed loop, and a real failure just stays pending until next time.
@@ -141,31 +141,62 @@ export async function attachCaseEmbeddings(db: Db, cases: DatasetCase[]): Promis
   const datasetIds = Array.from(new Set(cases.map(c => c.datasetId)));
   const cache = await readCache(db, datasetIds);
   const canEmbed = cases.length > 0 && (await embeddingsAvailable());
-  let budget = MAX_NEW_EMBEDDINGS_PER_REQUEST;
-  let embedded = false;
-  let pending = 0;
 
+  const uncached: DatasetCase[] = [];
   for (const item of cases) {
     const cached = cache.get(`${item.datasetId}:${item.caseKey}`);
     if (cached) {
       item.embedding = Array.isArray(cached.embedding) ? (cached.embedding as number[]) : null;
       item.embeddingFull = Array.isArray(cached.embeddingFull) ? (cached.embeddingFull as number[]) : null;
-    } else if (canEmbed && budget > 0) {
-      budget--;
-      const fullText = item.expectedResults ? `${item.query}\n\n${item.expectedResults}` : item.query;
-      const [query, full] = await Promise.all([computeEmbedding(item.query), computeEmbedding(fullText)]);
+    } else if (canEmbed && uncached.length < MAX_NEW_EMBEDDINGS_PER_REQUEST) {
+      uncached.push(item);
+    }
+  }
+
+  if (uncached.length > 0) {
+    // Every text this request needs, gathered before anything is sent, so the whole cold batch is
+    // one or two API calls instead of two per case in sequence. Identical texts share a slot: a
+    // case with no expected result has query and full text the same, and that is the common shape.
+    const texts: string[] = [];
+    const slotOf = new Map<string, number>();
+    const slot = (text: string): number => {
+      const existing = slotOf.get(text);
+      if (existing !== undefined) {
+        return existing;
+      }
+      const next = texts.push(text) - 1;
+      slotOf.set(text, next);
+      return next;
+    };
+    const wanted = uncached.map(item => ({
+      item,
+      query: slot(item.query),
+      full: slot(item.expectedResults ? `${item.query}\n\n${item.expectedResults}` : item.query),
+    }));
+
+    const vectors = await computeEmbeddings(texts);
+    for (const entry of wanted) {
+      const query = vectors[entry.query];
+      const full = vectors[entry.full];
+      // Both or neither: a case with one usable vector is scoreable in one space and silently
+      // absent from the other, which reads as a coverage gap that isn't one.
       if (query && full) {
-        item.embedding = query;
-        item.embeddingFull = full;
+        entry.item.embedding = query;
+        entry.item.embeddingFull = full;
         await writeCache(db, {
-          datasetId: item.datasetId,
-          caseKey: item.caseKey,
-          query: item.query,
+          datasetId: entry.item.datasetId,
+          caseKey: entry.item.caseKey,
+          query: entry.item.query,
           embedding: query,
           embeddingFull: full,
         });
       }
     }
+  }
+
+  let embedded = false;
+  let pending = 0;
+  for (const item of cases) {
     if (item.embedding && item.embeddingFull) {
       embedded = true;
     } else {

--- a/engine/src/core/insights/coverage.ts
+++ b/engine/src/core/insights/coverage.ts
@@ -4,7 +4,7 @@ import { listClassificationsSince, windowConfig, type ClassificationRow } from "
 import type { MonitoringWindow } from "../monitor/events.js";
 import { SIMILARITY_BANDS } from "../evaluate/curation.js";
 import { centroid, contentWords, cosine, normalizeText, overlap } from "../shared/vector.js";
-import { listDatasetCases, attachCaseEmbeddings, type DatasetCase } from "./cases.js";
+import { listDatasetCases, listDatasetSummaries, attachCaseEmbeddings, type DatasetCase } from "./cases.js";
 
 // The join between what production does (monitor_classifications) and what the datasets test.
 // Derived on read: there is no insight_topics table, and topics are the classifier's own `intent`
@@ -43,11 +43,19 @@ export type TopicCoverage = {
   priority: number;
   riskComponents: { issueRate: number; negativeSentimentRate: number };
   suggestedAction: string;
+  /**
+   * Which suites the assigned cases came from, complete. "6/5 cases" says a topic is covered; it
+   * does not say the cover is six near-identical cases in one smoke dataset, which is a different
+   * conclusion about whether to trust it.
+   */
+  caseDatasets: { id: string; name: string; count: number }[];
+  /** The closest assigned cases, best first - what this topic already tests, in its own words. */
+  sampleCases: { datasetId: string; query: string }[];
 };
 
 export type CoverageResult = {
   window: MonitoringWindow;
-  datasetId: string | null;
+  datasetIds: string[];
   /** True when the numbers came from the lexical fallback rather than embeddings. */
   degraded: boolean;
   /**
@@ -79,7 +87,16 @@ export type CoverageResult = {
   datasets: { id: string; name: string; caseCount: number }[];
   topics: TopicCoverage[];
   /** Cases matching no topic: either dead test weight, or a topic the classifier hasn't seen. */
-  offMapCases: { datasetId: string; index: number; query: string; bestSimilarity: number }[];
+  offMapCases: {
+    datasetId: string;
+    index: number;
+    query: string;
+    bestSimilarity: number;
+    /** What the case asserts. Deciding a case is dead weight without reading it is a guess. */
+    expectedResults: string | null;
+    /** Nearest topic even though it did not clear the bar - names what "0.45" is 0.45 against. */
+    nearestTopic: string | null;
+  }[];
   caseEmbeddingsPending: number;
 };
 
@@ -335,6 +352,19 @@ function facilityLocation(assigned: DatasetCase[], group: TopicGroup, sim: Simil
   return total / usable.length;
 }
 
+const SAMPLE_CASES = 6;
+
+// Grouped by dataset, biggest first, so "where does this coverage come from" is one glance.
+function caseDatasetsFor(assigned: DatasetCase[]): { id: string; name: string; count: number }[] {
+  const byId = new Map<string, { id: string; name: string; count: number }>();
+  for (const item of assigned) {
+    const entry = byId.get(item.datasetId) ?? { id: item.datasetId, name: item.datasetName, count: 0 };
+    entry.count++;
+    byId.set(item.datasetId, entry);
+  }
+  return Array.from(byId.values()).sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
+
 function suggestedActionFor(state: CoverageState, topic: string, gap: number, pending: number): string {
   if (state === "missing") {
     // Unembedded cases count toward no topic, so a topic can read "missing" while cases for it sit
@@ -352,25 +382,21 @@ function suggestedActionFor(state: CoverageState, topic: string, gap: number, pe
 
 export async function getCoverage(
   db: Db,
-  options: { window: MonitoringWindow; datasetId?: string }
+  options: { window: MonitoringWindow; datasetIds?: string[] }
 ): Promise<CoverageResult> {
   const { days } = windowConfig(options.window);
   const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
   const rows = await listClassificationsSince(db, since);
-  const datasetId = options.datasetId ?? null;
+  const datasetIds = options.datasetIds ?? [];
 
   const allGroups = groupByIntent(rows);
   const groups = allGroups.filter(g => g.rows.length >= MIN_TRACES_PER_TOPIC);
-  const cases = await listDatasetCases(db, options.datasetId);
+  const cases = await listDatasetCases(db, options.datasetIds);
   const { embedded, pending } = await attachCaseEmbeddings(db, cases);
 
-  const datasetCounts = new Map<string, { id: string; name: string; caseCount: number }>();
-  for (const item of cases) {
-    const entry = datasetCounts.get(item.datasetId) ?? { id: item.datasetId, name: item.datasetName, caseCount: 0 };
-    entry.caseCount++;
-    datasetCounts.set(item.datasetId, entry);
-  }
-  const datasets = Array.from(datasetCounts.values()).sort((a, b) => b.caseCount - a.caseCount);
+  // Always the complete list, never just what the filter selected - this is what the filter's own
+  // control is built from.
+  const datasets = await listDatasetSummaries(db);
 
   const anyTraceEmbeddings = groups.some(g => g.embeddings.length > 0);
   const sim = embedded && anyTraceEmbeddings ? embeddingSimilarity() : lexicalSimilarity();
@@ -390,7 +416,7 @@ export async function getCoverage(
   if (groups.length === 0) {
     return {
       window: options.window,
-      datasetId,
+      datasetIds,
       degraded: sim.kind !== "embedding",
       degradedReason,
       provisional: pending > 0,
@@ -447,6 +473,12 @@ export async function getCoverage(
         index: item.index,
         query: item.query,
         bestSimilarity: Math.round(Math.max(0, best?.score ?? 0) * 1000) / 1000,
+        // Both carried so the UI can show the case rather than just name it. "Delete this test" is
+        // a decision nobody should make from a query string and a score alone: the expected result
+        // is what the case actually asserts, and the nearest topic says what it was measured
+        // against - which is often the thing that makes an off-map case obviously fine.
+        expectedResults: item.expectedResults,
+        nearestTopic: bestGroup?.topic ?? null,
       });
       continue;
     }
@@ -522,6 +554,11 @@ export async function getCoverage(
         negativeSentimentRate: Math.round(negativeSentimentRate * 1000) / 1000,
       },
       suggestedAction: suggestedActionFor(state, group.topic, Math.max(1, targetCases - assigned.length), pending),
+      caseDatasets: caseDatasetsFor(assigned),
+      // Capped: a well-covered topic can carry twenty near-identical cases, and the reader needs
+      // to recognise what is already tested, not to page through it. caseDatasets keeps the full
+      // count honest above it.
+      sampleCases: assigned.slice(0, SAMPLE_CASES).map(item => ({ datasetId: item.datasetId, query: item.query })),
     };
   });
 
@@ -548,7 +585,7 @@ export async function getCoverage(
 
   return {
     window: options.window,
-    datasetId,
+    datasetIds,
     degraded: sim.kind !== "embedding",
     degradedReason,
     provisional: pending > 0,

--- a/engine/src/core/insights/coverage.ts
+++ b/engine/src/core/insights/coverage.ts
@@ -34,6 +34,13 @@ export type TopicCoverage = {
   coverage: number;
   /** 0-1, observed only - see riskComponents. Phase 1.5 adds declared business risk. */
   risk: number;
+  /**
+   * What closing this gap is worth. Sorting the map by traffic alone makes a reader do the
+   * traffic-vs-risk arithmetic themselves, which is the arithmetic the whole feature exists to
+   * do for them - so risk is weighted heavily enough here that a dangerous, rarely-asked topic
+   * can outrank a common, harmless one.
+   */
+  priority: number;
   riskComponents: { issueRate: number; negativeSentimentRate: number };
   suggestedAction: string;
 };
@@ -58,6 +65,12 @@ export type CoverageResult = {
    * you have" - two different afternoons of work that no single percentage distinguishes.
    */
   honestyDelta: number;
+  /**
+   * The datasets this number was computed over. Without it a project-wide figure silently mixes
+   * every dataset in the project - on a real install, 54 of them - and nobody can tell whether a
+   * gap belongs to the suite they care about. Also drives the dashboard's dataset filter.
+   */
+  datasets: { id: string; name: string; caseCount: number }[];
   topics: TopicCoverage[];
   /** Cases matching no topic: either dead test weight, or a topic the classifier hasn't seen. */
   offMapCases: { datasetId: string; index: number; query: string; bestSimilarity: number }[];
@@ -313,6 +326,14 @@ export async function getCoverage(
   const cases = await listDatasetCases(db, options.datasetId);
   const { embedded, pending } = await attachCaseEmbeddings(db, cases);
 
+  const datasetCounts = new Map<string, { id: string; name: string; caseCount: number }>();
+  for (const item of cases) {
+    const entry = datasetCounts.get(item.datasetId) ?? { id: item.datasetId, name: item.datasetName, caseCount: 0 };
+    entry.caseCount++;
+    datasetCounts.set(item.datasetId, entry);
+  }
+  const datasets = Array.from(datasetCounts.values()).sort((a, b) => b.caseCount - a.caseCount);
+
   const anyTraceEmbeddings = groups.some(g => g.embeddings.length > 0);
   const sim = embedded && anyTraceEmbeddings ? embeddingSimilarity() : lexicalSimilarity();
   const degradedReason =
@@ -334,6 +355,7 @@ export async function getCoverage(
       riskWeightedCoverage: null,
       presenceCoverage: 0,
       honestyDelta: 0,
+      datasets,
       topics: [],
       offMapCases: [],
       caseEmbeddingsPending: pending,
@@ -419,6 +441,14 @@ export async function getCoverage(
     const depth = facilityLocation(assigned, group, sim);
     const coverage = depth === null ? Math.min(1, assigned.length / targetCases) : depth;
 
+    // Risk AMPLIFIES exposure rather than substituting for it. Adding the two instead would give
+    // a 0.1%-of-traffic topic with high risk a bigger number than a 20%-of-traffic one, which is
+    // not a queue anybody should work: a topic nobody asks is worth nothing to test however
+    // dangerous it sounds. Multiplying keeps that at zero, while the 3x lets a failing topic
+    // outrank a healthy one carrying up to four times its traffic. (1 - coverage) so a covered
+    // topic is worth nothing to work on, however busy.
+    const priority = (1 - coverage) * trafficShare * (1 + 3 * risk);
+
     const state: CoverageState =
       assigned.length === 0 ? "missing" : coverage >= COVERED_THRESHOLD ? "covered" : "underrepresented";
 
@@ -440,6 +470,7 @@ export async function getCoverage(
       targetCases,
       coverage: Math.round(coverage * 1000) / 1000,
       risk: Math.round(risk * 1000) / 1000,
+      priority: Math.round(priority * 10000) / 10000,
       riskComponents: {
         issueRate: Math.round(issueRate * 1000) / 1000,
         negativeSentimentRate: Math.round(negativeSentimentRate * 1000) / 1000,
@@ -480,6 +511,7 @@ export async function getCoverage(
     riskWeightedCoverage: totalRisk === 0 ? null : weighted(t => t.risk, t => t.coverage),
     presenceCoverage,
     honestyDelta: Math.round((presenceCoverage - trafficWeightedCoverage) * 1000) / 1000,
+    datasets,
     topics,
     offMapCases,
     caseEmbeddingsPending: pending,

--- a/engine/src/core/insights/coverage.ts
+++ b/engine/src/core/insights/coverage.ts
@@ -284,9 +284,14 @@ function facilityLocation(assigned: DatasetCase[], group: TopicGroup, sim: Simil
   return total / usable.length;
 }
 
-function suggestedActionFor(state: CoverageState, topic: string, gap: number): string {
+function suggestedActionFor(state: CoverageState, topic: string, gap: number, pending: number): string {
   if (state === "missing") {
-    return `No case covers "${topic}". Curate the production traces in this topic, or generate candidate cases grounded in them.`;
+    // Unembedded cases count toward no topic, so a topic can read "missing" while cases for it sit
+    // in the queue. Telling someone to write a case that already exists is worse than saying
+    // nothing, so the advice waits until there is nothing left to index.
+    return pending > 0
+      ? `No case is assigned to "${topic}" yet, but ${pending} case${pending === 1 ? " is" : "s are"} still being indexed - this may resolve on its own.`
+      : `No case covers "${topic}". Curate the production traces in this topic, or generate candidate cases grounded in them.`;
   }
   if (state === "underrepresented") {
     return `Add roughly ${gap} more case${gap === 1 ? "" : "s"} for "${topic}", covering phrasings the existing ones don't reach.`;
@@ -356,6 +361,12 @@ export async function getCoverage(
       }
     }
     if (!bestGroup || bestScore < sim.bands.related) {
+      // Off-map is only a real finding under embeddings. Lexical matching compares a case's words
+      // against a topic LABEL, which most legitimate cases do not overlap - on real data that
+      // produced 84 "dead test weight" entries that were nothing of the sort.
+      if (sim.kind !== "embedding") {
+        continue;
+      }
       // "Off map" has to mean no topic at all, not "no topic big enough to report". A case whose
       // topic exists but sits under MIN_TRACES_PER_TOPIC is covering real (if rare) traffic, and
       // listing it as dead test weight would be telling the user to delete a good test.
@@ -381,6 +392,9 @@ export async function getCoverage(
     db,
     rows.map(r => r.traceId).filter((id): id is string => !!id)
   );
+
+  type RawTopic = { trafficShare: number; coverage: number; risk: number; caseCount: number };
+  const raw: RawTopic[] = [];
 
   const topics: TopicCoverage[] = groups.map(group => {
     const assigned = assignments.get(group.topic) ?? [];
@@ -408,6 +422,8 @@ export async function getCoverage(
     const state: CoverageState =
       assigned.length === 0 ? "missing" : coverage >= COVERED_THRESHOLD ? "covered" : "underrepresented";
 
+    raw.push({ trafficShare, coverage, risk, caseCount: assigned.length });
+
     const sessions = new Set(
       group.rows.map(r => (r.traceId ? (sessionByTrace.get(r.traceId) ?? `trace:${r.traceId}`) : null)).filter((id): id is string => !!id)
     );
@@ -428,24 +444,27 @@ export async function getCoverage(
         issueRate: Math.round(issueRate * 1000) / 1000,
         negativeSentimentRate: Math.round(negativeSentimentRate * 1000) / 1000,
       },
-      suggestedAction: suggestedActionFor(state, group.topic, Math.max(1, targetCases - assigned.length)),
+      suggestedAction: suggestedActionFor(state, group.topic, Math.max(1, targetCases - assigned.length), pending),
     };
   });
 
   topics.sort((a, b) => b.trafficShare - a.trafficShare);
 
-  const weighted = (weightOf: (t: TopicCoverage) => number, valueOf: (t: TopicCoverage) => number): number => {
-    const totalWeight = topics.reduce((sum, t) => sum + weightOf(t), 0);
+  // Weights and values come from `raw`, not the rounded fields on TopicCoverage. Rounding to 3dp
+  // is for display; feeding it back into the maths drops any topic under 0.0005 of traffic to a
+  // weight of exactly zero, so on a busy install the long tail silently stops counting.
+  const weighted = (weightOf: (t: RawTopic) => number, valueOf: (t: RawTopic) => number): number => {
+    const totalWeight = raw.reduce((sum, t) => sum + weightOf(t), 0);
     if (totalWeight === 0) {
       return 0;
     }
-    return Math.round((topics.reduce((sum, t) => sum + weightOf(t) * valueOf(t), 0) / totalWeight) * 1000) / 1000;
+    return Math.round((raw.reduce((sum, t) => sum + weightOf(t) * valueOf(t), 0) / totalWeight) * 1000) / 1000;
   };
 
   const trafficWeightedCoverage = weighted(t => t.trafficShare, t => t.coverage);
   // A healthy install has zero risk everywhere, and `weighted` returns 0 for a zero denominator -
   // which would render as 0% risk-weighted coverage, indistinguishable from testing nothing.
-  const totalRisk = topics.reduce((sum, t) => sum + t.risk, 0);
+  const totalRisk = raw.reduce((sum, t) => sum + t.risk, 0);
   // Presence: does the topic have any case at all. The crude number the honesty delta measures
   // the real one against.
   const presenceCoverage = weighted(t => t.trafficShare, t => (t.caseCount > 0 ? 1 : 0));
@@ -457,7 +476,7 @@ export async function getCoverage(
     degradedReason,
     insufficientData: false,
     trafficWeightedCoverage,
-    topicBreadth: { covered: topics.filter(t => t.coverage >= COVERED_THRESHOLD).length, total: topics.length },
+    topicBreadth: { covered: raw.filter(t => t.coverage >= COVERED_THRESHOLD).length, total: raw.length },
     riskWeightedCoverage: totalRisk === 0 ? null : weighted(t => t.risk, t => t.coverage),
     presenceCoverage,
     honestyDelta: Math.round((presenceCoverage - trafficWeightedCoverage) * 1000) / 1000,

--- a/engine/src/core/insights/coverage.ts
+++ b/engine/src/core/insights/coverage.ts
@@ -1,0 +1,397 @@
+import { and, eq, inArray } from "drizzle-orm";
+import type { Db } from "../../storage/db.js";
+import { listClassificationsSince, windowConfig, type ClassificationRow } from "../monitor/topics.js";
+import type { MonitoringWindow } from "../monitor/events.js";
+import { SIMILARITY_BANDS } from "../evaluate/curation.js";
+import { centroid, contentWords, cosine, jaccard, normalizeText } from "../shared/vector.js";
+import { listDatasetCases, attachCaseEmbeddings, type DatasetCase } from "./cases.js";
+
+// Insights, Phase 0: the join between what production does (monitor_classifications) and what the
+// datasets test. Everything here is derived on read - there is no insight_topics table yet, and
+// topics are the `intent` strings the classifier already writes, grouped and normalized. Real
+// centroid clustering is Phase 1; the point of this pass is that the numbers are honest about
+// which of the two they were computed with, never that they are final.
+//
+// Two similarity regimes, one code path. With embeddings we use cosine and the bands
+// core/evaluate/curation.ts already calibrated for text-embedding-3-small. Without them (no
+// OPENAI_API_KEY, or a dataset whose cases haven't been embedded yet) we fall back to Jaccard
+// over content words, which is a genuinely weaker signal on a different scale - so it carries its
+// own thresholds and every response says `degraded: true`. A degraded number is labelled, never
+// silently passed off as the real one.
+
+export type CoverageState = "covered" | "underrepresented" | "missing";
+
+export type TopicCoverage = {
+  topic: string;
+  state: CoverageState;
+  /** Share of classified traffic in the window, 0-1. */
+  trafficShare: number;
+  traceCount: number;
+  uniqueSessions: number;
+  /** Cases assigned to this topic. */
+  caseCount: number;
+  targetCases: number;
+  /** 0-1. Facility-location value over the topic's traces, or the count ratio when degraded. */
+  coverage: number;
+  /** 0-1, observed only - see riskComponents. Phase 1.5 adds declared business risk. */
+  risk: number;
+  riskComponents: { issueRate: number; negativeSentimentRate: number };
+  suggestedAction: string;
+};
+
+export type CoverageResult = {
+  window: MonitoringWindow;
+  datasetId: string | null;
+  /** True when the numbers came from the lexical fallback rather than embeddings. */
+  degraded: boolean;
+  degradedReason: string | null;
+  /** No classified traffic in the window - Topics is opt-in and sampled, so this is common. */
+  insufficientData: boolean;
+  trafficWeightedCoverage: number;
+  topicBreadth: { covered: number; total: number };
+  riskWeightedCoverage: number;
+  /** The same traffic-weighted number computed on case presence alone - see honestyDelta. */
+  presenceCoverage: number;
+  /**
+   * presenceCoverage - trafficWeightedCoverage. A large gap means the dataset has rows where it
+   * does not have depth, which is the difference between "write new cases" and "deepen the ones
+   * you have" - two different afternoons of work that no single percentage distinguishes.
+   */
+  honestyDelta: number;
+  topics: TopicCoverage[];
+  /** Cases matching no topic: either dead test weight, or a topic the classifier hasn't seen. */
+  offMapCases: { datasetId: string; index: number; query: string; bestSimilarity: number }[];
+  caseEmbeddingsPending: number;
+};
+
+// A topic needs at least this many classified traces before it gets a coverage verdict. Below it,
+// one stray classification would become a "missing topic" with a target and a suggested action -
+// noise dressed up as a work item, the same failure getTopicsMap's MIN_POINTS_FOR_MAP guards.
+const MIN_TRACES_PER_TOPIC = 2;
+
+// Lexical fallback bands. Deliberately NOT the cosine ones: Jaccard over content words runs on a
+// different scale, and reusing 0.75 there would report almost everything as uncovered.
+const LEXICAL_BANDS = { covered: 0.5, related: 0.25 } as const;
+
+// Coverage target: a floor everything gets, plus traffic and risk. sqrt on traffic so a topic
+// carrying 40% of requests doesn't demand 40% of the test budget. Phase 1 adds the spread term
+// (a topic's measured intra-cluster diameter), which needs the clustering this pass doesn't do.
+const TARGET_BASE = 2;
+const TARGET_K_TRAFFIC = 6;
+const TARGET_K_RISK = 3;
+
+// Coverage at or above this counts the topic as covered for the breadth tile.
+const COVERED_THRESHOLD = 0.7;
+
+// monitor_classifications carries a traceId but no sessionId, so unique-session counts need the
+// one join in this module. It matters: 500 requests from 3 sessions is one customer stuck in a
+// retry loop, 500 from 400 sessions is real demand, and weighting a coverage target by raw
+// request count would over-invest in the first. A trace with no sessionId (SDK calls that never
+// set one) counts as its own session rather than being dropped - it IS a distinct interaction.
+async function sessionsByTraceId(db: Db, traceIds: string[]): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  if (traceIds.length === 0) {
+    return map;
+  }
+  // Chunked: a 30-day window can hold far more classified traces than SQLite's bound-parameter
+  // limit (999 on the builds this ships against), and a single inArray of every id would throw
+  // rather than degrade - on the busiest installs, which are exactly the ones this feature is for.
+  const CHUNK = 400;
+  for (let start = 0; start < traceIds.length; start += CHUNK) {
+    const chunk = traceIds.slice(start, start + CHUNK);
+    const cond = and(eq(db.schema.traces.projectId, db.projectId), inArray(db.schema.traces.id, chunk));
+    const rows = (
+      db.kind === "sqlite"
+        ? db.db.select({ id: db.schema.traces.id, sessionId: db.schema.traces.sessionId }).from(db.schema.traces).where(cond).all()
+        : await db.db.select({ id: db.schema.traces.id, sessionId: db.schema.traces.sessionId }).from(db.schema.traces).where(cond)
+    ) as { id: string; sessionId: string | null }[];
+    for (const row of rows) {
+      if (row.sessionId) {
+        map.set(row.id, row.sessionId);
+      }
+    }
+  }
+  return map;
+}
+
+export type TopicGroup = {
+  topic: string;
+  rows: ClassificationRow[];
+  embeddings: number[][];
+  centroid: number[] | null;
+  words: Set<string>;
+};
+
+// Group by normalized intent, keep the most common original casing as the display label. The
+// classifier is already steered toward reusing labels verbatim (see topics.ts's
+// existingIntentsBlock), so this only has to absorb the casing/whitespace drift that steering
+// doesn't cover - it is not a substitute for the Phase 1 clustering.
+export function groupByIntent(rows: ClassificationRow[]): TopicGroup[] {
+  type Bucket = { labels: Map<string, number>; rows: ClassificationRow[] };
+  const byKey = new Map<string, Bucket>();
+  for (const row of rows) {
+    const key = normalizeText(row.intent);
+    if (!key) {
+      continue;
+    }
+    const entry: Bucket = byKey.get(key) ?? { labels: new Map<string, number>(), rows: [] };
+    entry.labels.set(row.intent, (entry.labels.get(row.intent) ?? 0) + 1);
+    entry.rows.push(row);
+    byKey.set(key, entry);
+  }
+  return Array.from(byKey.values()).map(entry => {
+    const label = Array.from(entry.labels.entries()).sort((a, b) => b[1] - a[1])[0]![0];
+    const embeddings = entry.rows
+      .map(r => r.embedding)
+      .filter((e): e is number[] => Array.isArray(e) && e.length > 0);
+    return {
+      topic: label,
+      rows: entry.rows,
+      embeddings,
+      centroid: centroid(embeddings),
+      words: contentWords(label),
+    };
+  });
+}
+
+type Similarity = {
+  kind: "embedding" | "lexical";
+  bands: { covered: number; related: number };
+  /** Case-to-topic score, used for assignment. */
+  toTopic(item: DatasetCase, group: TopicGroup): number;
+  /** Case-to-single-trace score, used for the facility-location value. */
+  toTrace(item: DatasetCase, row: ClassificationRow): number;
+};
+
+function embeddingSimilarity(): Similarity {
+  return {
+    kind: "embedding",
+    bands: SIMILARITY_BANDS,
+    toTopic: (item, group) => (item.embedding && group.centroid ? cosine(item.embedding, group.centroid) : -1),
+    toTrace: (item, row) =>
+      item.embedding && Array.isArray(row.embedding) && row.embedding.length > 0 ? cosine(item.embedding, row.embedding) : -1,
+  };
+}
+
+function lexicalSimilarity(): Similarity {
+  const cache = new Map<string, Set<string>>();
+  const words = (item: DatasetCase): Set<string> => {
+    let w = cache.get(item.caseKey);
+    if (!w) {
+      w = contentWords(item.query);
+      cache.set(item.caseKey, w);
+    }
+    return w;
+  };
+  return {
+    kind: "lexical",
+    bands: LEXICAL_BANDS,
+    toTopic: (item, group) => jaccard(words(item), group.words),
+    // No per-trace text is stored on a classification row, so the lexical regime has nothing
+    // finer than the topic label to compare against. Coverage therefore degrades to the topic
+    // score itself - which is exactly why this path is reported as degraded.
+    toTrace: (item, _row) => -1,
+  };
+}
+
+// Facility-location: the average, over the topic's traces, of the best similarity any assigned
+// case achieves to that trace. Duplicated cases add nothing because the max is already satisfied,
+// so the metric cannot be inflated by generating near-copies - which matters, because generating
+// cases is the point of the feature. Rescaled from the related band up to the covered band so a
+// case sitting on a trace reads as 1 and an unrelated one as 0.
+function facilityLocation(assigned: DatasetCase[], group: TopicGroup, sim: Similarity): number | null {
+  if (assigned.length === 0) {
+    return 0;
+  }
+  const usable = group.rows.filter(row => Array.isArray(row.embedding) && row.embedding.length > 0);
+  if (sim.kind !== "embedding" || usable.length === 0) {
+    return null;
+  }
+  const { covered, related } = sim.bands;
+  let total = 0;
+  for (const row of usable) {
+    let best = -1;
+    for (const item of assigned) {
+      const score = sim.toTrace(item, row);
+      if (score > best) {
+        best = score;
+      }
+    }
+    total += Math.max(0, Math.min(1, (best - related) / (covered - related)));
+  }
+  return total / usable.length;
+}
+
+function suggestedActionFor(state: CoverageState, topic: string, gap: number): string {
+  if (state === "missing") {
+    return `No case covers "${topic}". Curate the production traces in this topic, or generate candidate cases grounded in them.`;
+  }
+  if (state === "underrepresented") {
+    return `Add roughly ${gap} more case${gap === 1 ? "" : "s"} for "${topic}", covering phrasings the existing ones don't reach.`;
+  }
+  return "No new case required; refresh examples when production behavior changes.";
+}
+
+export async function getCoverage(
+  db: Db,
+  options: { window: MonitoringWindow; datasetId?: string }
+): Promise<CoverageResult> {
+  const { days } = windowConfig(options.window);
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  const rows = await listClassificationsSince(db, since);
+  const datasetId = options.datasetId ?? null;
+
+  const allGroups = groupByIntent(rows);
+  const groups = allGroups.filter(g => g.rows.length >= MIN_TRACES_PER_TOPIC);
+  const cases = await listDatasetCases(db, options.datasetId);
+  const { embedded, pending } = await attachCaseEmbeddings(db, cases);
+
+  const anyTraceEmbeddings = groups.some(g => g.embeddings.length > 0);
+  const sim = embedded && anyTraceEmbeddings ? embeddingSimilarity() : lexicalSimilarity();
+  const degradedReason =
+    sim.kind === "embedding"
+      ? null
+      : !embedded
+        ? "No dataset case embeddings are available yet - set OPENAI_API_KEY, or wait for the cache to warm."
+        : "No classified trace carries an embedding, so coverage falls back to label matching.";
+
+  if (groups.length === 0) {
+    return {
+      window: options.window,
+      datasetId,
+      degraded: sim.kind !== "embedding",
+      degradedReason,
+      insufficientData: true,
+      trafficWeightedCoverage: 0,
+      topicBreadth: { covered: 0, total: 0 },
+      riskWeightedCoverage: 0,
+      presenceCoverage: 0,
+      honestyDelta: 0,
+      topics: [],
+      offMapCases: [],
+      caseEmbeddingsPending: pending,
+    };
+  }
+
+  // Assign each case to its best-matching topic, or to none when nothing clears the related
+  // band. Argmax, not the softmax the plan specifies for Phase 1: with intent-string topics
+  // there are no real centroid boundaries for a soft assignment to be smoothing over yet.
+  const assignments = new Map<string, DatasetCase[]>();
+  const offMapCases: CoverageResult["offMapCases"] = [];
+  for (const item of cases) {
+    let bestGroup: TopicGroup | null = null;
+    let bestScore = -1;
+    for (const group of groups) {
+      const score = sim.toTopic(item, group);
+      if (score > bestScore) {
+        bestScore = score;
+        bestGroup = group;
+      }
+    }
+    if (!bestGroup || bestScore < sim.bands.related) {
+      // "Off map" has to mean no topic at all, not "no topic big enough to report". A case whose
+      // topic exists but sits under MIN_TRACES_PER_TOPIC is covering real (if rare) traffic, and
+      // listing it as dead test weight would be telling the user to delete a good test.
+      const matchesRareTopic = allGroups.some(group => sim.toTopic(item, group) >= sim.bands.related);
+      if (matchesRareTopic) {
+        continue;
+      }
+      offMapCases.push({
+        datasetId: item.datasetId,
+        index: item.index,
+        query: item.query,
+        bestSimilarity: Math.round(Math.max(0, bestScore) * 1000) / 1000,
+      });
+      continue;
+    }
+    const list = assignments.get(bestGroup.topic) ?? [];
+    list.push(item);
+    assignments.set(bestGroup.topic, list);
+  }
+
+  const totalTraces = groups.reduce((sum, g) => sum + g.rows.length, 0);
+  const sessionByTrace = await sessionsByTraceId(
+    db,
+    rows.map(r => r.traceId).filter((id): id is string => !!id)
+  );
+
+  const topics: TopicCoverage[] = groups.map(group => {
+    const assigned = assignments.get(group.topic) ?? [];
+    const trafficShare = group.rows.length / totalTraces;
+
+    const issues = group.rows.filter(r => r.issueType !== "none").length;
+    const negative = group.rows.filter(r => r.sentiment === "negative").length;
+    const issueRate = issues / group.rows.length;
+    const negativeSentimentRate = negative / group.rows.length;
+    // Issues weigh more than sentiment: an issueType is a statement about the response, a
+    // negative sentiment is a statement about the user's mood, and only one of those is
+    // reliably the agent's fault.
+    const risk = Math.min(1, issueRate * 0.7 + negativeSentimentRate * 0.3);
+
+    const targetCases = Math.ceil(TARGET_BASE + TARGET_K_TRAFFIC * Math.sqrt(trafficShare) + TARGET_K_RISK * risk);
+    // Coverage is the facility-location value ALONE whenever embeddings allow it - never blended
+    // with the case count. Mixing the two would reintroduce exactly what this metric exists to
+    // prevent: six near-identical cases raise the count ratio while the max-similarity term is
+    // already satisfied, so any formula reading the count would report them as better coverage
+    // than one well-placed case. `targetCases` stays a guidance number (how many more to write,
+    // and the sizing shown in the panel), and becomes the measure only in the degraded path,
+    // where there is no geometry to measure depth with.
+    const depth = facilityLocation(assigned, group, sim);
+    const coverage = depth === null ? Math.min(1, assigned.length / targetCases) : depth;
+
+    const state: CoverageState =
+      assigned.length === 0 ? "missing" : coverage >= COVERED_THRESHOLD ? "covered" : "underrepresented";
+
+    const sessions = new Set(
+      group.rows.map(r => (r.traceId ? (sessionByTrace.get(r.traceId) ?? `trace:${r.traceId}`) : null)).filter((id): id is string => !!id)
+    );
+
+    return {
+      topic: group.topic,
+      state,
+      trafficShare: Math.round(trafficShare * 1000) / 1000,
+      traceCount: group.rows.length,
+      uniqueSessions: sessions.size,
+      caseCount: assigned.length,
+      targetCases,
+      coverage: Math.round(coverage * 1000) / 1000,
+      risk: Math.round(risk * 1000) / 1000,
+      riskComponents: {
+        issueRate: Math.round(issueRate * 1000) / 1000,
+        negativeSentimentRate: Math.round(negativeSentimentRate * 1000) / 1000,
+      },
+      suggestedAction: suggestedActionFor(state, group.topic, Math.max(1, targetCases - assigned.length)),
+    };
+  });
+
+  topics.sort((a, b) => b.trafficShare - a.trafficShare);
+
+  const weighted = (weightOf: (t: TopicCoverage) => number, valueOf: (t: TopicCoverage) => number): number => {
+    const totalWeight = topics.reduce((sum, t) => sum + weightOf(t), 0);
+    if (totalWeight === 0) {
+      return 0;
+    }
+    return Math.round((topics.reduce((sum, t) => sum + weightOf(t) * valueOf(t), 0) / totalWeight) * 1000) / 1000;
+  };
+
+  const trafficWeightedCoverage = weighted(t => t.trafficShare, t => t.coverage);
+  // Presence: does the topic have any case at all. The crude number the honesty delta measures
+  // the real one against.
+  const presenceCoverage = weighted(t => t.trafficShare, t => (t.caseCount > 0 ? 1 : 0));
+
+  return {
+    window: options.window,
+    datasetId,
+    degraded: sim.kind !== "embedding",
+    degradedReason,
+    insufficientData: false,
+    trafficWeightedCoverage,
+    topicBreadth: { covered: topics.filter(t => t.coverage >= COVERED_THRESHOLD).length, total: topics.length },
+    riskWeightedCoverage: weighted(t => t.risk, t => t.coverage),
+    presenceCoverage,
+    honestyDelta: Math.round((presenceCoverage - trafficWeightedCoverage) * 1000) / 1000,
+    topics,
+    offMapCases,
+    caseEmbeddingsPending: pending,
+  };
+}

--- a/engine/src/core/insights/coverage.ts
+++ b/engine/src/core/insights/coverage.ts
@@ -6,23 +6,20 @@ import { SIMILARITY_BANDS } from "../evaluate/curation.js";
 import { centroid, contentWords, cosine, jaccard, normalizeText } from "../shared/vector.js";
 import { listDatasetCases, attachCaseEmbeddings, type DatasetCase } from "./cases.js";
 
-// Insights, Phase 0: the join between what production does (monitor_classifications) and what the
-// datasets test. Everything here is derived on read - there is no insight_topics table yet, and
-// topics are the `intent` strings the classifier already writes, grouped and normalized. Real
-// centroid clustering is Phase 1; the point of this pass is that the numbers are honest about
-// which of the two they were computed with, never that they are final.
+// The join between what production does (monitor_classifications) and what the datasets test.
+// Derived on read: there is no insight_topics table, and topics are the classifier's own `intent`
+// strings, normalized and merged by centroid proximity.
 //
-// Two similarity regimes, one code path. With embeddings we use cosine and the bands
-// core/evaluate/curation.ts already calibrated for text-embedding-3-small. Without them (no
-// OPENAI_API_KEY, or a dataset whose cases haven't been embedded yet) we fall back to Jaccard
-// over content words, which is a genuinely weaker signal on a different scale - so it carries its
-// own thresholds and every response says `degraded: true`. A degraded number is labelled, never
-// silently passed off as the real one.
+// Two similarity regimes, one code path: cosine with the bands curation.ts calibrated, or - with
+// no embeddings - Jaccard over content words, which is weaker and on a different scale, so it
+// carries its own thresholds and every response says `degraded: true`.
 
 export type CoverageState = "covered" | "underrepresented" | "missing";
 
 export type TopicCoverage = {
   topic: string;
+  /** Which measure produced `coverage` - the global `degraded` flag can't answer this per topic. */
+  coverageBasis: "depth" | "count";
   /** Other intent labels the classifier used for this same topic, merged in. */
   aliases: string[];
   state: CoverageState;
@@ -51,7 +48,8 @@ export type CoverageResult = {
   insufficientData: boolean;
   trafficWeightedCoverage: number;
   topicBreadth: { covered: number; total: number };
-  riskWeightedCoverage: number;
+  /** Null when no topic carries any observed risk - 0% would read as "nothing is tested". */
+  riskWeightedCoverage: number | null;
   /** The same traffic-weighted number computed on case presence alone - see honestyDelta. */
   presenceCoverage: number;
   /**
@@ -66,10 +64,9 @@ export type CoverageResult = {
   caseEmbeddingsPending: number;
 };
 
-// A topic needs at least this many classified traces before it gets a coverage verdict. Below it,
-// one stray classification would become a "missing topic" with a target and a suggested action -
-// noise dressed up as a work item, the same failure getTopicsMap's MIN_POINTS_FOR_MAP guards.
-const MIN_TRACES_PER_TOPIC = 2;
+// Below this, one stray classification becomes a "missing topic" with a target and an action -
+// noise dressed as a work item. Same guard as getTopicsMap's MIN_POINTS_FOR_MAP.
+export const MIN_TRACES_PER_TOPIC = 2;
 
 // Lexical fallback bands. Deliberately NOT the cosine ones: Jaccard over content words runs on a
 // different scale, and reusing 0.75 there would report almost everything as uncovered.
@@ -85,11 +82,9 @@ const TARGET_K_RISK = 3;
 // Coverage at or above this counts the topic as covered for the breadth tile.
 const COVERED_THRESHOLD = 0.7;
 
-// monitor_classifications carries a traceId but no sessionId, so unique-session counts need the
-// one join in this module. It matters: 500 requests from 3 sessions is one customer stuck in a
-// retry loop, 500 from 400 sessions is real demand, and weighting a coverage target by raw
-// request count would over-invest in the first. A trace with no sessionId (SDK calls that never
-// set one) counts as its own session rather than being dropped - it IS a distinct interaction.
+// 500 requests from 3 sessions is one customer in a retry loop; 500 from 400 is real demand, and
+// sizing a target off raw request count would over-invest in the first. A trace with no sessionId
+// counts as its own session - it is still a distinct interaction.
 async function sessionsByTraceId(db: Db, traceIds: string[]): Promise<Map<string, string>> {
   const map = new Map<string, string>();
   if (traceIds.length === 0) {
@@ -126,20 +121,12 @@ export type TopicGroup = {
   words: Set<string>;
 };
 
-// Merge two intent labels into one topic when their trace centroids are this close.
-//
-// Calibrated against real classified traffic, and deliberately NOT curation.ts's 0.75: that one
-// compares two single query strings, this compares centroids of averaged input+output embeddings,
-// which run considerably higher. Measured on a real install:
-//
-//   0.909  "refund request"        vs "request a refund"          <- the same topic, must merge
-//   0.902  "reset password"        vs "reset forgotten password"  <- the same topic, must merge
-//   0.822  "order tracking"        vs "missing package"           <- DIFFERENT, must not merge
-//   0.813  "refund policy inquiry" vs "request a refund"          <- DIFFERENT (rules vs money back)
-//
-// 0.87 splits those populations with ~0.05 of margin on both sides. Reusing 0.75 here would have
-// merged order tracking with missing package, which are genuinely different questions with
-// genuinely different correct answers. Recalibrate if the embedding model changes.
+// Deliberately not curation.ts's 0.75: that compares two query strings, this compares centroids of
+// averaged input+output embeddings, which run higher. Measured on a real install - synonyms at
+// 0.909/0.902 ("refund request"/"request a refund", "reset password"/"reset forgotten password")
+// against distinct neighbours at 0.822/0.813 ("order tracking"/"missing package", "refund policy
+// inquiry"/"request a refund"). 0.87 splits them with ~0.05 either side; 0.75 would have merged
+// questions with different correct answers. Recalibrate if the embedding model changes.
 const TOPIC_MERGE_THRESHOLD = 0.87;
 
 // Group by normalized intent, keep the most common original casing as the display label. The
@@ -176,15 +163,12 @@ export function groupByIntent(rows: ClassificationRow[]): TopicGroup[] {
   return mergeSynonymousTopics(groups);
 }
 
-// The classifier is steered toward reusing existing labels but still coins near-duplicates, and on
-// real traffic that is not cosmetic: an install carrying both "refund request" and "request a
-// refund" reported one as covered and the other as MISSING, inventing a gap that did not exist and
-// splitting one topic's traffic share in half. Merging by centroid proximity is what stops the
-// coverage number being an artifact of how the labeller happened to phrase itself that day.
+// On real traffic an install carrying both "refund request" and "request a refund" reported one
+// covered and the other MISSING - one topic counted twice, half of it a phantom gap. Merging by
+// centroid stops coverage being an artifact of how the labeller phrased itself that day.
 //
-// Seeded greedily from the largest group, and every candidate is compared against the SEED's
-// centroid rather than the growing one - otherwise a chain of pairwise-similar topics (a~b, b~c)
-// collects into one blob even when a and c have nothing to do with each other.
+// Greedy from the largest group; candidates compare against the SEED's centroid, not the growing
+// one, so a chain (a~b, b~c) cannot collect into one blob when a and c are unrelated.
 export function mergeSynonymousTopics(groups: TopicGroup[]): TopicGroup[] {
   const bySize = [...groups].sort((a, b) => b.rows.length - a.rows.length);
   const consumed = new Set<TopicGroup>();
@@ -206,8 +190,12 @@ export function mergeSynonymousTopics(groups: TopicGroup[]): TopicGroup[] {
       if (cosine(seed.centroid, candidate.centroid) >= TOPIC_MERGE_THRESHOLD) {
         consumed.add(candidate);
         seed.aliases.push(candidate.topic);
-        seed.rows.push(...candidate.rows);
-        seed.embeddings.push(...candidate.embeddings);
+        for (const row of candidate.rows) {
+          seed.rows.push(row);
+        }
+        for (const embedding of candidate.embeddings) {
+          seed.embeddings.push(embedding);
+        }
         for (const word of candidate.words) {
           seed.words.add(word);
         }
@@ -236,9 +224,13 @@ function embeddingSimilarity(): Similarity {
   return {
     kind: "embedding",
     bands: SIMILARITY_BANDS,
-    toTopic: (item, group) => (item.embedding && group.centroid ? cosine(item.embedding, group.centroid) : -1),
+    // embeddingFull, not embedding: topic centroids and trace vectors are built from input+output,
+    // so the query-only vector would be a cross-space comparison and score systematically low.
+    toTopic: (item, group) => (item.embeddingFull && group.centroid ? cosine(item.embeddingFull, group.centroid) : -1),
     toTrace: (item, row) =>
-      item.embedding && Array.isArray(row.embedding) && row.embedding.length > 0 ? cosine(item.embedding, row.embedding) : -1,
+      item.embeddingFull && Array.isArray(row.embedding) && row.embedding.length > 0
+        ? cosine(item.embeddingFull, row.embedding)
+        : -1,
   };
 }
 
@@ -263,18 +255,19 @@ function lexicalSimilarity(): Similarity {
   };
 }
 
-// Facility-location: the average, over the topic's traces, of the best similarity any assigned
-// case achieves to that trace. Duplicated cases add nothing because the max is already satisfied,
-// so the metric cannot be inflated by generating near-copies - which matters, because generating
-// cases is the point of the feature. Rescaled from the related band up to the covered band so a
-// case sitting on a trace reads as 1 and an unrelated one as 0.
+// Facility-location: the average, over a topic's traces, of the best similarity any assigned case
+// reaches. A duplicate adds nothing because the max is already satisfied, so the metric cannot be
+// inflated by generating near-copies - which matters, since generating cases is the point.
+// Rescaled across the related..covered band so a case on top of a trace reads 1, an unrelated 0.
 function facilityLocation(assigned: DatasetCase[], group: TopicGroup, sim: Similarity): number | null {
-  if (assigned.length === 0) {
-    return 0;
-  }
   const usable = group.rows.filter(row => Array.isArray(row.embedding) && row.embedding.length > 0);
+  // Regime checked BEFORE the empty-case shortcut: an uncovered topic scores 0 either way, but
+  // returning a number here would label it "depth" on a run that measured no depth at all.
   if (sim.kind !== "embedding" || usable.length === 0) {
     return null;
+  }
+  if (assigned.length === 0) {
+    return 0;
   }
   const { covered, related } = sim.bands;
   let total = 0;
@@ -333,7 +326,7 @@ export async function getCoverage(
       insufficientData: true,
       trafficWeightedCoverage: 0,
       topicBreadth: { covered: 0, total: 0 },
-      riskWeightedCoverage: 0,
+      riskWeightedCoverage: null,
       presenceCoverage: 0,
       honestyDelta: 0,
       topics: [],
@@ -342,12 +335,17 @@ export async function getCoverage(
     };
   }
 
-  // Assign each case to its best-matching topic, or to none when nothing clears the related
-  // band. Argmax, not the softmax the plan specifies for Phase 1: with intent-string topics
-  // there are no real centroid boundaries for a soft assignment to be smoothing over yet.
+  // Argmax, not softmax: with intent-string topics there are no real centroid boundaries for a
+  // soft assignment to smooth over yet.
   const assignments = new Map<string, DatasetCase[]>();
   const offMapCases: CoverageResult["offMapCases"] = [];
   for (const item of cases) {
+    // An unembedded case (cap not yet reached, or a failed call) scores -1 against everything.
+    // Calling that "off map" would flag a good test as dead weight on first load; it is pending,
+    // and `caseEmbeddingsPending` already reports it.
+    if (sim.kind === "embedding" && !item.embeddingFull) {
+      continue;
+    }
     let bestGroup: TopicGroup | null = null;
     let bestScore = -1;
     for (const group of groups) {
@@ -398,13 +396,12 @@ export async function getCoverage(
     const risk = Math.min(1, issueRate * 0.7 + negativeSentimentRate * 0.3);
 
     const targetCases = Math.ceil(TARGET_BASE + TARGET_K_TRAFFIC * Math.sqrt(trafficShare) + TARGET_K_RISK * risk);
-    // Coverage is the facility-location value ALONE whenever embeddings allow it - never blended
-    // with the case count. Mixing the two would reintroduce exactly what this metric exists to
-    // prevent: six near-identical cases raise the count ratio while the max-similarity term is
-    // already satisfied, so any formula reading the count would report them as better coverage
-    // than one well-placed case. `targetCases` stays a guidance number (how many more to write,
-    // and the sizing shown in the panel), and becomes the measure only in the degraded path,
-    // where there is no geometry to measure depth with.
+    // Facility-location ALONE where geometry exists - never blended with the count, which would
+    // reintroduce the duplicate-inflation this metric exists to prevent. targetCases stays
+    // guidance, and becomes the measure only where there is no geometry.
+    // facilityLocation returns null for a topic whose traces carry no embeddings, even when the
+    // run as a whole is using them - so the basis is recorded per topic rather than inferred from
+    // the global flag, which would claim depth over a count.
     const depth = facilityLocation(assigned, group, sim);
     const coverage = depth === null ? Math.min(1, assigned.length / targetCases) : depth;
 
@@ -417,6 +414,7 @@ export async function getCoverage(
 
     return {
       topic: group.topic,
+      coverageBasis: depth === null ? "count" : "depth",
       aliases: group.aliases,
       state,
       trafficShare: Math.round(trafficShare * 1000) / 1000,
@@ -445,6 +443,9 @@ export async function getCoverage(
   };
 
   const trafficWeightedCoverage = weighted(t => t.trafficShare, t => t.coverage);
+  // A healthy install has zero risk everywhere, and `weighted` returns 0 for a zero denominator -
+  // which would render as 0% risk-weighted coverage, indistinguishable from testing nothing.
+  const totalRisk = topics.reduce((sum, t) => sum + t.risk, 0);
   // Presence: does the topic have any case at all. The crude number the honesty delta measures
   // the real one against.
   const presenceCoverage = weighted(t => t.trafficShare, t => (t.caseCount > 0 ? 1 : 0));
@@ -457,7 +458,7 @@ export async function getCoverage(
     insufficientData: false,
     trafficWeightedCoverage,
     topicBreadth: { covered: topics.filter(t => t.coverage >= COVERED_THRESHOLD).length, total: topics.length },
-    riskWeightedCoverage: weighted(t => t.risk, t => t.coverage),
+    riskWeightedCoverage: totalRisk === 0 ? null : weighted(t => t.risk, t => t.coverage),
     presenceCoverage,
     honestyDelta: Math.round((presenceCoverage - trafficWeightedCoverage) * 1000) / 1000,
     topics,

--- a/engine/src/core/insights/coverage.ts
+++ b/engine/src/core/insights/coverage.ts
@@ -4,7 +4,13 @@ import { listClassificationsSince, windowConfig, type ClassificationRow } from "
 import type { MonitoringWindow } from "../monitor/events.js";
 import { SIMILARITY_BANDS } from "../evaluate/curation.js";
 import { centroid, contentWords, cosine, normalizeText, overlap } from "../shared/vector.js";
-import { listDatasetCases, listDatasetSummaries, attachCaseEmbeddings, type DatasetCase } from "./cases.js";
+import {
+  listDatasetCases,
+  listDatasetRows,
+  datasetSummaries,
+  attachCaseEmbeddings,
+  type DatasetCase,
+} from "./cases.js";
 
 // The join between what production does (monitor_classifications) and what the datasets test.
 // Derived on read: there is no insight_topics table, and topics are the classifier's own `intent`
@@ -49,8 +55,12 @@ export type TopicCoverage = {
    * conclusion about whether to trust it.
    */
   caseDatasets: { id: string; name: string; count: number }[];
-  /** The closest assigned cases, best first - what this topic already tests, in its own words. */
-  sampleCases: { datasetId: string; query: string }[];
+  /**
+   * The closest assigned cases, best first, deduplicated by query text with the number of copies -
+   * what this topic already tests, in its own words. `count` is over every assigned case, not just
+   * the ones listed here.
+   */
+  sampleCases: { datasetId: string; query: string; count: number }[];
 };
 
 export type CoverageResult = {
@@ -354,6 +364,29 @@ function facilityLocation(assigned: DatasetCase[], group: TopicGroup, sim: Simil
 
 const SAMPLE_CASES = 6;
 
+// Deduped across EVERY assigned case, then truncated - not the other way round. Counting duplicates
+// inside a 6-case window would cap the count at 6 and hide exactly what the depth measure exists to
+// expose: twenty copies of one question is not twenty cases of coverage.
+function sampleCasesFor(
+  assigned: DatasetCase[],
+  scoreOf: (item: DatasetCase) => number
+): { datasetId: string; query: string; count: number }[] {
+  const byQuery = new Map<string, { datasetId: string; query: string; count: number; score: number }>();
+  for (const item of assigned) {
+    const entry = byQuery.get(item.query);
+    if (entry) {
+      entry.count++;
+      entry.score = Math.max(entry.score, scoreOf(item));
+    } else {
+      byQuery.set(item.query, { datasetId: item.datasetId, query: item.query, count: 1, score: scoreOf(item) });
+    }
+  }
+  return Array.from(byQuery.values())
+    .sort((a, b) => b.score - a.score || b.count - a.count)
+    .slice(0, SAMPLE_CASES)
+    .map(({ datasetId, query, count }) => ({ datasetId, query, count }));
+}
+
 // Grouped by dataset, biggest first, so "where does this coverage come from" is one glance.
 function caseDatasetsFor(assigned: DatasetCase[]): { id: string; name: string; count: number }[] {
   const byId = new Map<string, { id: string; name: string; count: number }>();
@@ -391,12 +424,18 @@ export async function getCoverage(
 
   const allGroups = groupByIntent(rows);
   const groups = allGroups.filter(g => g.rows.length >= MIN_TRACES_PER_TOPIC);
-  const cases = await listDatasetCases(db, options.datasetIds);
-  const { embedded, pending } = await attachCaseEmbeddings(db, cases);
+  // One read of the dataset table, used for both the analysed subset and the complete picker list.
+  const datasetRows = await listDatasetRows(db);
+  const cases = await listDatasetCases(db, options.datasetIds, datasetRows);
+  const { embedded, pending, canEmbed } = await attachCaseEmbeddings(db, cases);
+  // "Still warming" is only true when warming can actually happen. With no embeddings key nothing
+  // will ever be embedded, so reporting the cases as pending would tell every caller to come back
+  // for a number that is never going to change.
+  const provisional = pending > 0 && canEmbed;
 
   // Always the complete list, never just what the filter selected - this is what the filter's own
   // control is built from.
-  const datasets = await listDatasetSummaries(db);
+  const datasets = datasetSummaries(datasetRows);
 
   const anyTraceEmbeddings = groups.some(g => g.embeddings.length > 0);
   const sim = embedded && anyTraceEmbeddings ? embeddingSimilarity() : lexicalSimilarity();
@@ -419,7 +458,7 @@ export async function getCoverage(
       datasetIds,
       degraded: sim.kind !== "embedding",
       degradedReason,
-      provisional: pending > 0,
+      provisional,
       insufficientData: true,
       trafficWeightedCoverage: 0,
       topicBreadth: { covered: 0, total: 0 },
@@ -435,7 +474,10 @@ export async function getCoverage(
 
   // Argmax, not softmax: with intent-string topics there are no real centroid boundaries for a
   // soft assignment to smooth over yet.
+  // The score travels with the case: "which cases does this topic already have" is only useful if
+  // the closest ones are the ones shown, and the assignment loop is the only place the score exists.
   const assignments = new Map<string, DatasetCase[]>();
+  const assignedScore = new Map<DatasetCase, number>();
   const offMapCases: CoverageResult["offMapCases"] = [];
   for (const item of cases) {
     // An unembedded case (cap not yet reached, or a failed call) scores -1 against everything.
@@ -485,6 +527,7 @@ export async function getCoverage(
     const list = assignments.get(bestGroup.topic) ?? [];
     list.push(item);
     assignments.set(bestGroup.topic, list);
+    assignedScore.set(item, best.score);
   }
 
   const totalTraces = groups.reduce((sum, g) => sum + g.rows.length, 0);
@@ -558,7 +601,7 @@ export async function getCoverage(
       // Capped: a well-covered topic can carry twenty near-identical cases, and the reader needs
       // to recognise what is already tested, not to page through it. caseDatasets keeps the full
       // count honest above it.
-      sampleCases: assigned.slice(0, SAMPLE_CASES).map(item => ({ datasetId: item.datasetId, query: item.query })),
+      sampleCases: sampleCasesFor(assigned, item => assignedScore.get(item) ?? 0),
     };
   });
 
@@ -588,7 +631,7 @@ export async function getCoverage(
     datasetIds,
     degraded: sim.kind !== "embedding",
     degradedReason,
-    provisional: pending > 0,
+    provisional,
     insufficientData: false,
     trafficWeightedCoverage,
     topicBreadth: { covered: raw.filter(t => t.coverage >= COVERED_THRESHOLD).length, total: raw.length },

--- a/engine/src/core/insights/coverage.ts
+++ b/engine/src/core/insights/coverage.ts
@@ -3,7 +3,7 @@ import type { Db } from "../../storage/db.js";
 import { listClassificationsSince, windowConfig, type ClassificationRow } from "../monitor/topics.js";
 import type { MonitoringWindow } from "../monitor/events.js";
 import { SIMILARITY_BANDS } from "../evaluate/curation.js";
-import { centroid, contentWords, cosine, jaccard, normalizeText } from "../shared/vector.js";
+import { centroid, contentWords, cosine, normalizeText, overlap } from "../shared/vector.js";
 import { listDatasetCases, attachCaseEmbeddings, type DatasetCase } from "./cases.js";
 
 // The join between what production does (monitor_classifications) and what the datasets test.
@@ -50,6 +50,12 @@ export type CoverageResult = {
   datasetId: string | null;
   /** True when the numbers came from the lexical fallback rather than embeddings. */
   degraded: boolean;
+  /**
+   * Cases are still being embedded, so these numbers are a floor and will rise. Distinct from
+   * `degraded`, which is about which measure was used: a run can be perfectly non-degraded and
+   * still be reporting on a third of the dataset because the cache is 60 cases per request.
+   */
+  provisional: boolean;
   degradedReason: string | null;
   /** No classified traffic in the window - Topics is opt-in and sampled, so this is common. */
   insufficientData: boolean;
@@ -81,9 +87,10 @@ export type CoverageResult = {
 // noise dressed as a work item. Same guard as getTopicsMap's MIN_POINTS_FOR_MAP.
 export const MIN_TRACES_PER_TOPIC = 2;
 
-// Lexical fallback bands. Deliberately NOT the cosine ones: Jaccard over content words runs on a
-// different scale, and reusing 0.75 there would report almost everything as uncovered.
-const LEXICAL_BANDS = { covered: 0.5, related: 0.25 } as const;
+// Lexical bands, on the OVERLAP scale (see shared/vector.ts) - a case matches a topic when it
+// carries most of the label's words, regardless of how much else it says. Not the cosine bands:
+// a different measure needs its own calibration.
+const LEXICAL_BANDS = { covered: 1, related: 0.5 } as const;
 
 // Coverage target: a floor everything gets, plus traffic and risk. sqrt on traffic so a topic
 // carrying 40% of requests doesn't demand 40% of the test budget. Phase 1 adds the spread term
@@ -224,14 +231,33 @@ export function mergeSynonymousTopics(groups: TopicGroup[]): TopicGroup[] {
   return merged;
 }
 
+type Match = { score: number; matched: boolean; margin: number };
+
 type Similarity = {
   kind: "embedding" | "lexical";
   bands: { covered: number; related: number };
-  /** Case-to-topic score, used for assignment. */
-  toTopic(item: DatasetCase, group: TopicGroup): number;
+  /**
+   * Case-to-topic. Returns `margin` - how far above the related floor, on a 0-1 scale - so a topic
+   * matched by cosine and one matched lexically can still be ranked against each other. Needed
+   * because a topic whose own traces carry no embedding (the column is never backfilled) has no
+   * centroid, and scoring it -1 made it report "missing" on a run that measured everything else.
+   */
+  toTopic(item: DatasetCase, group: TopicGroup): Match;
   /** Case-to-single-trace score, used for the facility-location value. */
   toTrace(item: DatasetCase, row: ClassificationRow): number;
 };
+
+function matchOn(score: number, bands: { covered: number; related: number }): Match {
+  const span = bands.covered - bands.related;
+  return {
+    score,
+    matched: score >= bands.related,
+    margin: span <= 0 ? (score >= bands.related ? 1 : 0) : Math.max(0, Math.min(1, (score - bands.related) / span)),
+  };
+}
+
+const lexicalTopicMatch = (item: DatasetCase, group: TopicGroup): Match =>
+  matchOn(overlap(contentWords(item.query), group.words), LEXICAL_BANDS);
 
 function embeddingSimilarity(): Similarity {
   return {
@@ -239,7 +265,11 @@ function embeddingSimilarity(): Similarity {
     bands: SIMILARITY_BANDS,
     // embeddingFull, not embedding: topic centroids and trace vectors are built from input+output,
     // so the query-only vector would be a cross-space comparison and score systematically low.
-    toTopic: (item, group) => (item.embeddingFull && group.centroid ? cosine(item.embeddingFull, group.centroid) : -1),
+    // A topic with no centroid falls back to the label test rather than matching nothing.
+    toTopic: (item, group) =>
+      item.embeddingFull && group.centroid
+        ? matchOn(cosine(item.embeddingFull, group.centroid), SIMILARITY_BANDS)
+        : lexicalTopicMatch(item, group),
     toTrace: (item, row) =>
       item.embeddingFull && Array.isArray(row.embedding) && row.embedding.length > 0
         ? cosine(item.embeddingFull, row.embedding)
@@ -260,7 +290,7 @@ function lexicalSimilarity(): Similarity {
   return {
     kind: "lexical",
     bands: LEXICAL_BANDS,
-    toTopic: (item, group) => jaccard(words(item), group.words),
+    toTopic: (item, group) => matchOn(overlap(words(item), group.words), LEXICAL_BANDS),
     // No per-trace text is stored on a classification row, so the lexical regime has nothing
     // finer than the topic label to compare against. Coverage therefore degrades to the topic
     // score itself - which is exactly why this path is reported as degraded.
@@ -272,8 +302,16 @@ function lexicalSimilarity(): Similarity {
 // reaches. A duplicate adds nothing because the max is already satisfied, so the metric cannot be
 // inflated by generating near-copies - which matters, since generating cases is the point.
 // Rescaled across the related..covered band so a case on top of a trace reads 1, an unrelated 0.
+// traces x cases x dims, run synchronously per topic. Uncapped that is billions of operations on a
+// busy install, blocking the event loop for the whole engine - so the topic's traces are sampled,
+// the same guard getTopicsMap applies for the same reason. A mean over a sample of this size is
+// well within the rounding already applied to the result.
+const MAX_TRACES_PER_FACILITY_LOCATION = 300;
+
 function facilityLocation(assigned: DatasetCase[], group: TopicGroup, sim: Similarity): number | null {
-  const usable = group.rows.filter(row => Array.isArray(row.embedding) && row.embedding.length > 0);
+  const embedded = group.rows.filter(row => Array.isArray(row.embedding) && row.embedding.length > 0);
+  const step = Math.ceil(embedded.length / MAX_TRACES_PER_FACILITY_LOCATION);
+  const usable = step > 1 ? embedded.filter((_, i) => i % step === 0) : embedded;
   // Regime checked BEFORE the empty-case shortcut: an uncovered topic scores 0 either way, but
   // returning a number here would label it "depth" on a run that measured no depth at all.
   if (sim.kind !== "embedding" || usable.length === 0) {
@@ -336,12 +374,18 @@ export async function getCoverage(
 
   const anyTraceEmbeddings = groups.some(g => g.embeddings.length > 0);
   const sim = embedded && anyTraceEmbeddings ? embeddingSimilarity() : lexicalSimilarity();
+  // Ordered so the reason names the thing that is actually missing. With no cases at all there is
+  // nothing to embed, and blaming OPENAI_API_KEY on an install that has one is the kind of wrong
+  // explanation that sends someone hunting a configuration problem they do not have. This is the
+  // screen's common first view, since Topics is opt-in and sampled.
   const degradedReason =
     sim.kind === "embedding"
       ? null
-      : !embedded
-        ? "No dataset case embeddings are available yet - set OPENAI_API_KEY, or wait for the cache to warm."
-        : "No classified trace carries an embedding, so coverage falls back to label matching.";
+      : cases.length === 0
+        ? "No dataset cases to measure against yet."
+        : embedded
+          ? "No classified trace carries an embedding, so coverage falls back to label matching."
+          : "No dataset case embeddings are available yet - set OPENAI_API_KEY, or wait for the cache to warm.";
 
   if (groups.length === 0) {
     return {
@@ -349,6 +393,7 @@ export async function getCoverage(
       datasetId,
       degraded: sim.kind !== "embedding",
       degradedReason,
+      provisional: pending > 0,
       insufficientData: true,
       trafficWeightedCoverage: 0,
       topicBreadth: { covered: 0, total: 0 },
@@ -374,15 +419,16 @@ export async function getCoverage(
       continue;
     }
     let bestGroup: TopicGroup | null = null;
-    let bestScore = -1;
+    let best: Match | null = null;
     for (const group of groups) {
-      const score = sim.toTopic(item, group);
-      if (score > bestScore) {
-        bestScore = score;
+      const match = sim.toTopic(item, group);
+      // Ranked on margin, which is comparable across regimes; raw scores are not.
+      if (!best || match.margin > best.margin || (match.margin === best.margin && match.score > best.score)) {
+        best = match;
         bestGroup = group;
       }
     }
-    if (!bestGroup || bestScore < sim.bands.related) {
+    if (!bestGroup || !best?.matched) {
       // Off-map is only a real finding under embeddings. Lexical matching compares a case's words
       // against a topic LABEL, which most legitimate cases do not overlap - on real data that
       // produced 84 "dead test weight" entries that were nothing of the sort.
@@ -392,7 +438,7 @@ export async function getCoverage(
       // "Off map" has to mean no topic at all, not "no topic big enough to report". A case whose
       // topic exists but sits under MIN_TRACES_PER_TOPIC is covering real (if rare) traffic, and
       // listing it as dead test weight would be telling the user to delete a good test.
-      const matchesRareTopic = allGroups.some(group => sim.toTopic(item, group) >= sim.bands.related);
+      const matchesRareTopic = allGroups.some(group => sim.toTopic(item, group).matched);
       if (matchesRareTopic) {
         continue;
       }
@@ -400,7 +446,7 @@ export async function getCoverage(
         datasetId: item.datasetId,
         index: item.index,
         query: item.query,
-        bestSimilarity: Math.round(Math.max(0, bestScore) * 1000) / 1000,
+        bestSimilarity: Math.round(Math.max(0, best?.score ?? 0) * 1000) / 1000,
       });
       continue;
     }
@@ -505,6 +551,7 @@ export async function getCoverage(
     datasetId,
     degraded: sim.kind !== "embedding",
     degradedReason,
+    provisional: pending > 0,
     insufficientData: false,
     trafficWeightedCoverage,
     topicBreadth: { covered: raw.filter(t => t.coverage >= COVERED_THRESHOLD).length, total: raw.length },

--- a/engine/src/core/insights/coverage.ts
+++ b/engine/src/core/insights/coverage.ts
@@ -23,6 +23,8 @@ export type CoverageState = "covered" | "underrepresented" | "missing";
 
 export type TopicCoverage = {
   topic: string;
+  /** Other intent labels the classifier used for this same topic, merged in. */
+  aliases: string[];
   state: CoverageState;
   /** Share of classified traffic in the window, 0-1. */
   trafficShare: number;
@@ -116,11 +118,29 @@ async function sessionsByTraceId(db: Db, traceIds: string[]): Promise<Map<string
 
 export type TopicGroup = {
   topic: string;
+  /** Other intent labels merged into this topic - see mergeSynonymousTopics. */
+  aliases: string[];
   rows: ClassificationRow[];
   embeddings: number[][];
   centroid: number[] | null;
   words: Set<string>;
 };
+
+// Merge two intent labels into one topic when their trace centroids are this close.
+//
+// Calibrated against real classified traffic, and deliberately NOT curation.ts's 0.75: that one
+// compares two single query strings, this compares centroids of averaged input+output embeddings,
+// which run considerably higher. Measured on a real install:
+//
+//   0.909  "refund request"        vs "request a refund"          <- the same topic, must merge
+//   0.902  "reset password"        vs "reset forgotten password"  <- the same topic, must merge
+//   0.822  "order tracking"        vs "missing package"           <- DIFFERENT, must not merge
+//   0.813  "refund policy inquiry" vs "request a refund"          <- DIFFERENT (rules vs money back)
+//
+// 0.87 splits those populations with ~0.05 of margin on both sides. Reusing 0.75 here would have
+// merged order tracking with missing package, which are genuinely different questions with
+// genuinely different correct answers. Recalibrate if the embedding model changes.
+const TOPIC_MERGE_THRESHOLD = 0.87;
 
 // Group by normalized intent, keep the most common original casing as the display label. The
 // classifier is already steered toward reusing labels verbatim (see topics.ts's
@@ -139,19 +159,68 @@ export function groupByIntent(rows: ClassificationRow[]): TopicGroup[] {
     entry.rows.push(row);
     byKey.set(key, entry);
   }
-  return Array.from(byKey.values()).map(entry => {
+  const groups = Array.from(byKey.values()).map(entry => {
     const label = Array.from(entry.labels.entries()).sort((a, b) => b[1] - a[1])[0]![0];
     const embeddings = entry.rows
       .map(r => r.embedding)
       .filter((e): e is number[] => Array.isArray(e) && e.length > 0);
     return {
       topic: label,
+      aliases: [] as string[],
       rows: entry.rows,
       embeddings,
       centroid: centroid(embeddings),
       words: contentWords(label),
     };
   });
+  return mergeSynonymousTopics(groups);
+}
+
+// The classifier is steered toward reusing existing labels but still coins near-duplicates, and on
+// real traffic that is not cosmetic: an install carrying both "refund request" and "request a
+// refund" reported one as covered and the other as MISSING, inventing a gap that did not exist and
+// splitting one topic's traffic share in half. Merging by centroid proximity is what stops the
+// coverage number being an artifact of how the labeller happened to phrase itself that day.
+//
+// Seeded greedily from the largest group, and every candidate is compared against the SEED's
+// centroid rather than the growing one - otherwise a chain of pairwise-similar topics (a~b, b~c)
+// collects into one blob even when a and c have nothing to do with each other.
+export function mergeSynonymousTopics(groups: TopicGroup[]): TopicGroup[] {
+  const bySize = [...groups].sort((a, b) => b.rows.length - a.rows.length);
+  const consumed = new Set<TopicGroup>();
+  const merged: TopicGroup[] = [];
+
+  for (const seed of bySize) {
+    if (consumed.has(seed)) {
+      continue;
+    }
+    consumed.add(seed);
+    if (!seed.centroid) {
+      merged.push(seed);
+      continue;
+    }
+    for (const candidate of bySize) {
+      if (consumed.has(candidate) || !candidate.centroid) {
+        continue;
+      }
+      if (cosine(seed.centroid, candidate.centroid) >= TOPIC_MERGE_THRESHOLD) {
+        consumed.add(candidate);
+        seed.aliases.push(candidate.topic);
+        seed.rows.push(...candidate.rows);
+        seed.embeddings.push(...candidate.embeddings);
+        for (const word of candidate.words) {
+          seed.words.add(word);
+        }
+      }
+    }
+    // Recomputed only after absorbing everything, so the comparisons above all ran against the
+    // seed's original position. The label stays the seed's - it is the most common one.
+    if (seed.aliases.length > 0) {
+      seed.centroid = centroid(seed.embeddings) ?? seed.centroid;
+    }
+    merged.push(seed);
+  }
+  return merged;
 }
 
 type Similarity = {
@@ -348,6 +417,7 @@ export async function getCoverage(
 
     return {
       topic: group.topic,
+      aliases: group.aliases,
       state,
       trafficShare: Math.round(trafficShare * 1000) / 1000,
       traceCount: group.rows.length,

--- a/engine/src/core/insights/probe.ts
+++ b/engine/src/core/insights/probe.ts
@@ -5,17 +5,15 @@ import { SIMILARITY_BANDS } from "../evaluate/curation.js";
 import { computeEmbedding } from "../evaluate/judge.js";
 import { contentWords, cosine, jaccard } from "../shared/vector.js";
 import { listDatasetCases, attachCaseEmbeddings, type DatasetCase } from "./cases.js";
-import { groupByIntent } from "./coverage.js";
+import { groupByIntent, MIN_TRACES_PER_TOPIC } from "./coverage.js";
 
-// The probe: "does my dataset cover THIS?", asked in the words someone actually has the question
-// in. Coverage (coverage.ts) is a sweep over topics production already produced; this is the
-// inverse lookup, and it is the cheap half - one embedding for the query, cosine against the
-// cached case embeddings, no LLM in the verdict path.
+// "Does my dataset cover THIS?" - the inverse of coverage.ts's sweep, and the cheap half: one
+// embedding for the query, cosine against the cached case embeddings, no LLM in the verdict path.
 //
-// It deliberately answers TWO questions, not one, because the answer to "is it tested?" is
-// useless without "does anyone ask it?". A query with no coverage AND no traffic is not a hole in
-// the suite - reporting it as one would send a team writing tests for things nobody asks. That
-// case gets its own verdict, and it is the reason this file exists rather than a single cosine.
+// Answers TWO questions, not one. "Is it tested?" is useless without "does anyone ask it?": a
+// query with no coverage AND no traffic is not a hole in the suite, and reporting it as one would
+// send a team writing tests for things nobody asks. That case gets its own verdict, which is why
+// this is a file rather than a single cosine.
 
 export type ProbeVerdict = "covered" | "adjacent" | "gap" | "untested-and-unasked";
 
@@ -24,9 +22,8 @@ export type ProbeNearestCase = {
   datasetName: string;
   index: number;
   query: string;
-  // Always returned alongside the score: query-to-query similarity measures topical resemblance,
-  // NOT that the case asserts the same behavior. The human makes the final call, and cannot make
-  // it without seeing what the nearest case actually expects.
+  // Always returned with the score: similarity says the questions look alike, not that the case
+  // asserts the same behaviour. Nobody can judge that without seeing what it expects.
   expectedResults: string | null;
   similarity: number;
 };
@@ -47,8 +44,8 @@ export type ProbeResult = {
 
 const NEAREST_CASES = 3;
 const LEXICAL_BANDS = { covered: 0.5, related: 0.25 } as const;
-// Batch mode is a paste target (a PRD's user stories, a support macro export, a compliance
-// checklist), so the cap is generous but finite - one probe per line, each needing an embedding.
+// A paste target (PRD stories, a macro export, a compliance checklist) - generous but finite,
+// since each line costs an embedding.
 const MAX_BATCH = 50;
 
 type Scorer = {
@@ -96,8 +93,14 @@ async function loadContext(db: Db, window: MonitoringWindow, datasetId?: string)
   const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
   const [rows, cases] = await Promise.all([listClassificationsSince(db, since), listDatasetCases(db, datasetId)]);
   const { embedded } = await attachCaseEmbeddings(db, cases);
-  const groups = groupByIntent(rows);
-  return { cases, groups, totalTraces: rows.length, embeddedCases: embedded };
+  // Same floor the coverage sweep applies. Without it a single stray classification is enough to
+  // turn "nobody asks this" into a fabricated real gap - the one verdict the probe exists to avoid
+  // handing out.
+  const groups = groupByIntent(rows).filter(g => g.rows.length >= MIN_TRACES_PER_TOPIC);
+  // Denominator over the SAME filtered groups the sweep uses, not every classified row - otherwise
+  // one topic reports two different traffic shares depending on which screen you read it from.
+  const totalTraces = groups.reduce((sum, g) => sum + g.rows.length, 0);
+  return { cases, groups, totalTraces, embeddedCases: embedded };
 }
 
 async function scorerFor(query: string, ctx: ProbeContext): Promise<Scorer> {
@@ -106,6 +109,8 @@ async function scorerFor(query: string, ctx: ProbeContext): Promise<Scorer> {
     return {
       degraded: false,
       bands: SIMILARITY_BANDS,
+      // embedding (query only), not embeddingFull: this compares a typed query against a case's
+      // question, which is the pairing SIMILARITY_BANDS was calibrated on.
       score: item => (item.embedding ? cosine(queryEmbedding, item.embedding) : -1),
       topicScore: (_words, centroidVec) => (centroidVec ? cosine(queryEmbedding, centroidVec) : -1),
     };
@@ -192,11 +197,9 @@ export type ProbeBatchResult = {
   degraded: boolean;
 };
 
-// Batch mode is the pre-launch gate: paste what users will ask about a surface that hasn't
-// shipped, and get coverage against traffic that doesn't exist yet. It is the only answer here to
-// the cold-start problem - the topic map only knows the past, so a brand-new surface is invisible
-// to the sweep until it has already shipped and started failing. Context is loaded ONCE for the
-// whole batch; only the per-query embedding is per-query.
+// The pre-launch gate: coverage against traffic that does not exist yet, which is the only answer
+// here to the cold start - the sweep cannot see a surface that has not shipped. Context loads once
+// for the whole batch; only the embedding is per-query.
 export async function probeBatch(
   db: Db,
   input: { queries: string[]; window: MonitoringWindow; datasetId?: string }

--- a/engine/src/core/insights/probe.ts
+++ b/engine/src/core/insights/probe.ts
@@ -1,0 +1,224 @@
+import type { Db } from "../../storage/db.js";
+import { listClassificationsSince, windowConfig } from "../monitor/topics.js";
+import type { MonitoringWindow } from "../monitor/events.js";
+import { SIMILARITY_BANDS } from "../evaluate/curation.js";
+import { computeEmbedding } from "../evaluate/judge.js";
+import { contentWords, cosine, jaccard } from "../shared/vector.js";
+import { listDatasetCases, attachCaseEmbeddings, type DatasetCase } from "./cases.js";
+import { groupByIntent } from "./coverage.js";
+
+// The probe: "does my dataset cover THIS?", asked in the words someone actually has the question
+// in. Coverage (coverage.ts) is a sweep over topics production already produced; this is the
+// inverse lookup, and it is the cheap half - one embedding for the query, cosine against the
+// cached case embeddings, no LLM in the verdict path.
+//
+// It deliberately answers TWO questions, not one, because the answer to "is it tested?" is
+// useless without "does anyone ask it?". A query with no coverage AND no traffic is not a hole in
+// the suite - reporting it as one would send a team writing tests for things nobody asks. That
+// case gets its own verdict, and it is the reason this file exists rather than a single cosine.
+
+export type ProbeVerdict = "covered" | "adjacent" | "gap" | "untested-and-unasked";
+
+export type ProbeNearestCase = {
+  datasetId: string;
+  datasetName: string;
+  index: number;
+  query: string;
+  // Always returned alongside the score: query-to-query similarity measures topical resemblance,
+  // NOT that the case asserts the same behavior. The human makes the final call, and cannot make
+  // it without seeing what the nearest case actually expects.
+  expectedResults: string | null;
+  similarity: number;
+};
+
+export type ProbeResult = {
+  query: string;
+  verdict: ProbeVerdict;
+  /** Best case similarity, on whichever scale `degraded` implies. */
+  similarity: number;
+  bands: { covered: number; related: number };
+  degraded: boolean;
+  nearestCases: ProbeNearestCase[];
+  /** The production topic this query lands in, when one is close enough. */
+  topic: { topic: string; trafficShare: number; traceCount: number } | null;
+  /** Human-readable, and the thing the dashboard renders verbatim. */
+  explanation: string;
+};
+
+const NEAREST_CASES = 3;
+const LEXICAL_BANDS = { covered: 0.5, related: 0.25 } as const;
+// Batch mode is a paste target (a PRD's user stories, a support macro export, a compliance
+// checklist), so the cap is generous but finite - one probe per line, each needing an embedding.
+const MAX_BATCH = 50;
+
+type Scorer = {
+  degraded: boolean;
+  bands: { covered: number; related: number };
+  score(item: DatasetCase): number;
+  topicScore(words: Set<string>, centroidVec: number[] | null): number;
+};
+
+function explain(verdict: ProbeVerdict, nearest: ProbeNearestCase | null, topic: ProbeResult["topic"]): string {
+  switch (verdict) {
+    case "covered":
+      return (
+        `Effectively the same question as an existing case${nearest ? ` ("${nearest.query}")` : ""} - close enough that ` +
+        `adding it would be rejected as a duplicate. Check its expected result asserts what you meant.`
+      );
+    case "adjacent":
+      return (
+        `The nearest case asks something related but not this${nearest ? ` ("${nearest.query}")` : ""}. It sits in the ` +
+        `band measured for related-but-distinct questions, so it will not catch a regression specific to your query.`
+      );
+    case "gap":
+      return (
+        `Nothing in the dataset is close, and production does ask this` +
+        `${topic ? ` (topic "${topic.topic}", ${Math.round(topic.trafficShare * 100)}% of classified traffic)` : ""}. ` +
+        `This is a real gap.`
+      );
+    default:
+      return (
+        "Nothing in the dataset is close - but nothing in production resembles this either. It may be worth testing " +
+        "anyway, but this is not a gap in your coverage of real traffic."
+      );
+  }
+}
+
+type ProbeContext = {
+  cases: DatasetCase[];
+  groups: ReturnType<typeof groupByIntent>;
+  totalTraces: number;
+  embeddedCases: boolean;
+};
+
+async function loadContext(db: Db, window: MonitoringWindow, datasetId?: string): Promise<ProbeContext> {
+  const { days } = windowConfig(window);
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  const [rows, cases] = await Promise.all([listClassificationsSince(db, since), listDatasetCases(db, datasetId)]);
+  const { embedded } = await attachCaseEmbeddings(db, cases);
+  const groups = groupByIntent(rows);
+  return { cases, groups, totalTraces: rows.length, embeddedCases: embedded };
+}
+
+async function scorerFor(query: string, ctx: ProbeContext): Promise<Scorer> {
+  const queryEmbedding = ctx.embeddedCases ? await computeEmbedding(query) : null;
+  if (queryEmbedding) {
+    return {
+      degraded: false,
+      bands: SIMILARITY_BANDS,
+      score: item => (item.embedding ? cosine(queryEmbedding, item.embedding) : -1),
+      topicScore: (_words, centroidVec) => (centroidVec ? cosine(queryEmbedding, centroidVec) : -1),
+    };
+  }
+  const words = contentWords(query);
+  return {
+    degraded: true,
+    bands: LEXICAL_BANDS,
+    score: item => jaccard(words, contentWords(item.query)),
+    topicScore: topicWords => jaccard(words, topicWords),
+  };
+}
+
+function probeWith(query: string, ctx: ProbeContext, scorer: Scorer): ProbeResult {
+  const scored = ctx.cases
+    .map(item => ({ item, similarity: scorer.score(item) }))
+    .filter(entry => entry.similarity > 0)
+    .sort((a, b) => b.similarity - a.similarity)
+    .slice(0, NEAREST_CASES);
+
+  const nearestCases: ProbeNearestCase[] = scored.map(entry => ({
+    datasetId: entry.item.datasetId,
+    datasetName: entry.item.datasetName,
+    index: entry.item.index,
+    query: entry.item.query,
+    expectedResults: entry.item.expectedResults,
+    similarity: Math.round(entry.similarity * 1000) / 1000,
+  }));
+
+  const best = nearestCases[0]?.similarity ?? 0;
+
+  let topic: ProbeResult["topic"] = null;
+  let bestTopicScore = -1;
+  for (const group of ctx.groups) {
+    const score = scorer.topicScore(group.words, group.centroid);
+    if (score > bestTopicScore) {
+      bestTopicScore = score;
+      topic = {
+        topic: group.topic,
+        trafficShare: ctx.totalTraces === 0 ? 0 : Math.round((group.rows.length / ctx.totalTraces) * 1000) / 1000,
+        traceCount: group.rows.length,
+      };
+    }
+  }
+  // A topic the query doesn't actually belong to is worse than no topic: it would turn "nobody
+  // asks this" into a fabricated gap against an unrelated topic's traffic.
+  if (bestTopicScore < scorer.bands.related) {
+    topic = null;
+  }
+
+  const verdict: ProbeVerdict =
+    best >= scorer.bands.covered
+      ? "covered"
+      : best >= scorer.bands.related
+        ? "adjacent"
+        : topic
+          ? "gap"
+          : "untested-and-unasked";
+
+  return {
+    query,
+    verdict,
+    similarity: Math.round(best * 1000) / 1000,
+    bands: scorer.bands,
+    degraded: scorer.degraded,
+    nearestCases,
+    topic,
+    explanation: explain(verdict, nearestCases[0] ?? null, topic),
+  };
+}
+
+export async function probe(
+  db: Db,
+  input: { query: string; window: MonitoringWindow; datasetId?: string }
+): Promise<ProbeResult> {
+  const ctx = await loadContext(db, input.window, input.datasetId);
+  const scorer = await scorerFor(input.query, ctx);
+  return probeWith(input.query, ctx, scorer);
+}
+
+export type ProbeBatchResult = {
+  results: ProbeResult[];
+  rollup: { total: number; covered: number; adjacent: number; gap: number; untestedAndUnasked: number };
+  degraded: boolean;
+};
+
+// Batch mode is the pre-launch gate: paste what users will ask about a surface that hasn't
+// shipped, and get coverage against traffic that doesn't exist yet. It is the only answer here to
+// the cold-start problem - the topic map only knows the past, so a brand-new surface is invisible
+// to the sweep until it has already shipped and started failing. Context is loaded ONCE for the
+// whole batch; only the per-query embedding is per-query.
+export async function probeBatch(
+  db: Db,
+  input: { queries: string[]; window: MonitoringWindow; datasetId?: string }
+): Promise<ProbeBatchResult> {
+  const queries = input.queries.map(q => q.trim()).filter(Boolean).slice(0, MAX_BATCH);
+  const ctx = await loadContext(db, input.window, input.datasetId);
+
+  const results: ProbeResult[] = [];
+  for (const query of queries) {
+    const scorer = await scorerFor(query, ctx);
+    results.push(probeWith(query, ctx, scorer));
+  }
+
+  return {
+    results,
+    rollup: {
+      total: results.length,
+      covered: results.filter(r => r.verdict === "covered").length,
+      adjacent: results.filter(r => r.verdict === "adjacent").length,
+      gap: results.filter(r => r.verdict === "gap").length,
+      untestedAndUnasked: results.filter(r => r.verdict === "untested-and-unasked").length,
+    },
+    degraded: results.some(r => r.degraded),
+  };
+}

--- a/engine/src/core/insights/probe.ts
+++ b/engine/src/core/insights/probe.ts
@@ -3,7 +3,7 @@ import { listClassificationsSince, windowConfig } from "../monitor/topics.js";
 import type { MonitoringWindow } from "../monitor/events.js";
 import { SIMILARITY_BANDS } from "../evaluate/curation.js";
 import { computeEmbedding } from "../evaluate/judge.js";
-import { contentWords, cosine, jaccard } from "../shared/vector.js";
+import { contentWords, cosine, jaccard, overlap } from "../shared/vector.js";
 import { listDatasetCases, attachCaseEmbeddings, type DatasetCase } from "./cases.js";
 import { groupByIntent, MIN_TRACES_PER_TOPIC } from "./coverage.js";
 
@@ -55,13 +55,22 @@ type Scorer = {
   topicScore(words: Set<string>, centroidVec: number[] | null): number;
 };
 
-function explain(verdict: ProbeVerdict, nearest: ProbeNearestCase | null, topic: ProbeResult["topic"]): string {
+function explain(
+  verdict: ProbeVerdict,
+  nearest: ProbeNearestCase | null,
+  topic: ProbeResult["topic"],
+  degraded: boolean
+): string {
   switch (verdict) {
     case "covered":
-      return (
-        `Effectively the same question as an existing case${nearest ? ` ("${nearest.query}")` : ""} - close enough that ` +
-        `adding it would be rejected as a duplicate. Check its expected result asserts what you meant.`
-      );
+      // The duplicate claim is only true under embeddings: it IS addCaseToDataset's threshold.
+      // The lexical fallback is a different measure that the dedupe path does not implement, so
+      // saying it there would assert something the rest of the system would not honour.
+      return degraded
+        ? `Wording closely matches an existing case${nearest ? ` ("${nearest.query}")` : ""}, judged by shared words ` +
+          `rather than meaning. Check its expected result asserts what you meant.`
+        : `Effectively the same question as an existing case${nearest ? ` ("${nearest.query}")` : ""} - close enough ` +
+          `that adding it would be rejected as a duplicate. Check its expected result asserts what you meant.`;
     case "adjacent":
       return (
         `The nearest case asks something related but not this${nearest ? ` ("${nearest.query}")` : ""}. It sits in the ` +
@@ -105,6 +114,7 @@ async function loadContext(db: Db, window: MonitoringWindow, datasetId?: string)
 
 async function scorerFor(query: string, ctx: ProbeContext): Promise<Scorer> {
   const queryEmbedding = ctx.embeddedCases ? await computeEmbedding(query) : null;
+  const queryWords = contentWords(query);
   if (queryEmbedding) {
     return {
       degraded: false,
@@ -112,15 +122,20 @@ async function scorerFor(query: string, ctx: ProbeContext): Promise<Scorer> {
       // embedding (query only), not embeddingFull: this compares a typed query against a case's
       // question, which is the pairing SIMILARITY_BANDS was calibrated on.
       score: item => (item.embedding ? cosine(queryEmbedding, item.embedding) : -1),
-      topicScore: (_words, centroidVec) => (centroidVec ? cosine(queryEmbedding, centroidVec) : -1),
+      // A topic whose traces predate the embedding column has no centroid; scoring it -1 turned a
+      // real gap into "nobody asks this", which is the one verdict the probe must not hand out by
+      // accident. Falls back to the label test, normalized onto the same 0-1 decision.
+      topicScore: (words, centroidVec) =>
+        centroidVec ? cosine(queryEmbedding, centroidVec) : overlap(queryWords, words) >= 0.5 ? SIMILARITY_BANDS.related : 0,
     };
   }
-  const words = contentWords(query);
   return {
     degraded: true,
     bands: LEXICAL_BANDS,
-    score: item => jaccard(words, contentWords(item.query)),
-    topicScore: topicWords => jaccard(words, topicWords),
+    // Query against a case query: both are full sentences, so Jaccard is symmetric and fine here.
+    score: item => jaccard(queryWords, contentWords(item.query)),
+    // Query against a short topic LABEL: length-biased under Jaccard, so overlap instead.
+    topicScore: topicWords => overlap(queryWords, topicWords),
   };
 }
 
@@ -178,7 +193,7 @@ function probeWith(query: string, ctx: ProbeContext, scorer: Scorer): ProbeResul
     degraded: scorer.degraded,
     nearestCases,
     topic,
-    explanation: explain(verdict, nearestCases[0] ?? null, topic),
+    explanation: explain(verdict, nearestCases[0] ?? null, topic, scorer.degraded),
   };
 }
 

--- a/engine/src/core/insights/probe.ts
+++ b/engine/src/core/insights/probe.ts
@@ -97,10 +97,10 @@ type ProbeContext = {
   embeddedCases: boolean;
 };
 
-async function loadContext(db: Db, window: MonitoringWindow, datasetId?: string): Promise<ProbeContext> {
+async function loadContext(db: Db, window: MonitoringWindow, datasetIds?: string[]): Promise<ProbeContext> {
   const { days } = windowConfig(window);
   const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
-  const [rows, cases] = await Promise.all([listClassificationsSince(db, since), listDatasetCases(db, datasetId)]);
+  const [rows, cases] = await Promise.all([listClassificationsSince(db, since), listDatasetCases(db, datasetIds)]);
   const { embedded } = await attachCaseEmbeddings(db, cases);
   // Same floor the coverage sweep applies. Without it a single stray classification is enough to
   // turn "nobody asks this" into a fabricated real gap - the one verdict the probe exists to avoid
@@ -199,9 +199,9 @@ function probeWith(query: string, ctx: ProbeContext, scorer: Scorer): ProbeResul
 
 export async function probe(
   db: Db,
-  input: { query: string; window: MonitoringWindow; datasetId?: string }
+  input: { query: string; window: MonitoringWindow; datasetIds?: string[] }
 ): Promise<ProbeResult> {
-  const ctx = await loadContext(db, input.window, input.datasetId);
+  const ctx = await loadContext(db, input.window, input.datasetIds);
   const scorer = await scorerFor(input.query, ctx);
   return probeWith(input.query, ctx, scorer);
 }
@@ -217,10 +217,10 @@ export type ProbeBatchResult = {
 // for the whole batch; only the embedding is per-query.
 export async function probeBatch(
   db: Db,
-  input: { queries: string[]; window: MonitoringWindow; datasetId?: string }
+  input: { queries: string[]; window: MonitoringWindow; datasetIds?: string[] }
 ): Promise<ProbeBatchResult> {
   const queries = input.queries.map(q => q.trim()).filter(Boolean).slice(0, MAX_BATCH);
-  const ctx = await loadContext(db, input.window, input.datasetId);
+  const ctx = await loadContext(db, input.window, input.datasetIds);
 
   const results: ProbeResult[] = [];
   for (const query of queries) {

--- a/engine/src/core/monitor/topics.ts
+++ b/engine/src/core/monitor/topics.ts
@@ -182,7 +182,7 @@ export async function runClassification(
 // Same window/bucket idiom as events.ts's getOnlineEvaluatorRatings (windowConfig/listEventsSince
 // there are module-private, shaped for a different accumulator - copied here rather than shared,
 // matching how getOnlineEvaluatorRatings itself doesn't reuse events.ts's own bucketize()).
-function windowConfig(window: MonitoringWindow): { days: number; bucketHours: number } {
+export function windowConfig(window: MonitoringWindow): { days: number; bucketHours: number } {
   switch (window) {
     case "24h":
       return { days: 1, bucketHours: 1 };
@@ -194,7 +194,11 @@ function windowConfig(window: MonitoringWindow): { days: number; bucketHours: nu
   }
 }
 
-async function listClassificationsSince(db: Db, since: Date): Promise<ClassificationRow[]> {
+// Exported for core/insights/coverage.ts, which groups these same rows by intent to build its
+// Phase 0 topic list - the aggregations below (trend/top-intents/issue-breakdown/map) each
+// re-read the window for their own accumulator, and coverage is a fifth one of those, not a new
+// way of reading the table.
+export async function listClassificationsSince(db: Db, since: Date): Promise<ClassificationRow[]> {
   const cond = and(gte(db.schema.monitorClassifications.createdAt, since), eq(db.schema.monitorClassifications.projectId, db.projectId));
   const rows =
     db.kind === "sqlite"

--- a/engine/src/core/shared/vector.ts
+++ b/engine/src/core/shared/vector.ts
@@ -1,8 +1,6 @@
-// Cosine similarity over two embedding vectors, plus the small text helpers that go with it.
-// Extracted from core/evaluate/curation.ts (which still owns the *calibration* - see its
-// SIMILARITY_BANDS comment) once core/insights/ needed the same math: dedupe asks "is this case
-// already here?" and coverage asks "is this topic already tested?", which are the same question
-// pointed in different directions, and they must never answer it with two different formulas.
+// Cosine plus the text helpers that go with it. Extracted from curation.ts (which still owns the
+// calibration) once insights/ needed the same math: dedupe and coverage ask the same question in
+// different directions and must not answer it with two different formulas.
 
 export function cosine(a: number[], b: number[]): number {
   let dot = 0;
@@ -19,9 +17,8 @@ export function cosine(a: number[], b: number[]): number {
   return denom === 0 ? 0 : dot / denom;
 }
 
-// Element-wise mean, then unit-normalized: a topic's centroid. Vectors of differing length would
-// mean two embedding models got mixed in one table, so the shortest wins rather than padding
-// zeros (which would silently drag every centroid toward the origin).
+// Element-wise mean, unit-normalized. Differing lengths mean two embedding models got mixed, so
+// the shortest wins - padding zeros would drag every centroid toward the origin.
 export function centroid(vectors: number[][]): number[] | null {
   if (vectors.length === 0) {
     return null;
@@ -49,9 +46,8 @@ export function normalizeText(s: string): string {
   return s.toLowerCase().replace(/\s+/g, " ").trim();
 }
 
-// Content-word set for the lexical fallback (see core/insights/similarity.ts): stopwords and
-// 1-2 character tokens removed, so "how do I reset my password" and "password reset" overlap on
-// the words that carry the topic rather than on "how"/"my"/"do".
+// Content words for the lexical fallback: stopwords and short tokens dropped, so "how do I reset
+// my password" and "password reset" overlap on what carries the topic.
 const STOPWORDS = new Set([
   "the", "a", "an", "and", "or", "but", "if", "then", "than", "of", "to", "in", "on", "at", "for",
   "with", "by", "from", "is", "are", "was", "were", "be", "been", "being", "do", "does", "did",

--- a/engine/src/core/shared/vector.ts
+++ b/engine/src/core/shared/vector.ts
@@ -23,7 +23,9 @@ export function centroid(vectors: number[][]): number[] | null {
   if (vectors.length === 0) {
     return null;
   }
-  const dims = Math.min(...vectors.map(v => v.length));
+  // reduce, not Math.min(...spread): one argument per vector overflows the call stack somewhere
+  // around 10^5 traces in a topic, which 500s the endpoint on exactly the installs it is for.
+  const dims = vectors.reduce((min, v) => (v.length < min ? v.length : min), Infinity);
   if (dims === 0) {
     return null;
   }
@@ -63,6 +65,23 @@ export function contentWords(s: string): Set<string> {
       .split(/\s+/)
       .filter(w => w.length > 2 && !STOPWORDS.has(w))
   );
+}
+
+// Overlap (Szymkiewicz-Simpson) rather than Jaccard wherever the two sides differ in length -
+// notably a full case query against a 1-3 word topic label. Jaccard's union denominator grows with
+// the query, so a case containing EVERY word of the label scores 0.154 against it and gets dropped
+// as off-map. Measured, on "Order tracking" vs a real support question. Overlap scores that 1.0.
+export function overlap(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) {
+    return 0;
+  }
+  let shared = 0;
+  for (const token of a) {
+    if (b.has(token)) {
+      shared++;
+    }
+  }
+  return shared / Math.min(a.size, b.size);
 }
 
 export function jaccard(a: Set<string>, b: Set<string>): number {

--- a/engine/src/core/shared/vector.ts
+++ b/engine/src/core/shared/vector.ts
@@ -1,0 +1,83 @@
+// Cosine similarity over two embedding vectors, plus the small text helpers that go with it.
+// Extracted from core/evaluate/curation.ts (which still owns the *calibration* - see its
+// SIMILARITY_BANDS comment) once core/insights/ needed the same math: dedupe asks "is this case
+// already here?" and coverage asks "is this topic already tested?", which are the same question
+// pointed in different directions, and they must never answer it with two different formulas.
+
+export function cosine(a: number[], b: number[]): number {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < Math.min(a.length, b.length); i++) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    dot += x * y;
+    na += x * x;
+    nb += y * y;
+  }
+  const denom = Math.sqrt(na) * Math.sqrt(nb);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+// Element-wise mean, then unit-normalized: a topic's centroid. Vectors of differing length would
+// mean two embedding models got mixed in one table, so the shortest wins rather than padding
+// zeros (which would silently drag every centroid toward the origin).
+export function centroid(vectors: number[][]): number[] | null {
+  if (vectors.length === 0) {
+    return null;
+  }
+  const dims = Math.min(...vectors.map(v => v.length));
+  if (dims === 0) {
+    return null;
+  }
+  const sum = new Array<number>(dims).fill(0);
+  for (const vector of vectors) {
+    for (let i = 0; i < dims; i++) {
+      sum[i]! += vector[i] ?? 0;
+    }
+  }
+  let norm = 0;
+  for (let i = 0; i < dims; i++) {
+    sum[i]! /= vectors.length;
+    norm += sum[i]! * sum[i]!;
+  }
+  norm = Math.sqrt(norm);
+  return norm === 0 ? sum : sum.map(v => v / norm);
+}
+
+export function normalizeText(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+// Content-word set for the lexical fallback (see core/insights/similarity.ts): stopwords and
+// 1-2 character tokens removed, so "how do I reset my password" and "password reset" overlap on
+// the words that carry the topic rather than on "how"/"my"/"do".
+const STOPWORDS = new Set([
+  "the", "a", "an", "and", "or", "but", "if", "then", "than", "of", "to", "in", "on", "at", "for",
+  "with", "by", "from", "is", "are", "was", "were", "be", "been", "being", "do", "does", "did",
+  "how", "what", "when", "where", "why", "who", "which", "can", "could", "would", "should", "will",
+  "my", "me", "i", "you", "your", "it", "its", "this", "that", "these", "those", "there", "here",
+  "not", "no", "yes", "please", "help",
+]);
+
+export function contentWords(s: string): Set<string> {
+  return new Set(
+    normalizeText(s)
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter(w => w.length > 2 && !STOPWORDS.has(w))
+  );
+}
+
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) {
+    return 0;
+  }
+  let shared = 0;
+  for (const token of a) {
+    if (b.has(token)) {
+      shared++;
+    }
+  }
+  return shared / (a.size + b.size - shared);
+}

--- a/engine/src/routes/apiV1.ts
+++ b/engine/src/routes/apiV1.ts
@@ -11,6 +11,7 @@ import { outcomesRouter } from "./outcomes.js";
 import { feedbackRouter } from "./feedback.js";
 import { agentMonitoringDashboardRouter } from "./agentMonitoringDashboard.js";
 import { evaluateDashboardRouter } from "./evaluateDashboard.js";
+import { insightsRouter } from "./insights.js";
 import { otlpRouter } from "./otlp.js";
 import { exportRouter } from "./exportData.js";
 import { auditAuthTap, auditControlPlaneTap } from "./auditTap.js";
@@ -225,6 +226,7 @@ export function registerApiV1(app: Express, deps: ApiV1Deps): void {
   router.use("/admin", credentialLimit, adminRouter);
   router.use("/agent-monitoring", dataPlaneLimit, apiKey, agentMonitoringDashboardRouter);
   router.use("/evaluate", dataPlaneLimit, apiKey, evaluateDashboardRouter);
+  router.use("/insights", dataPlaneLimit, apiKey, insightsRouter);
   router.use("/otel", dataPlaneLimit, apiKey, otlpRouter);
   // Bulk NDJSON export for backup/migration (routes/exportData.ts) - data-plane like everything
   // else keyed by x-api-key; the key alone scopes what leaves the box.

--- a/engine/src/routes/insights.ts
+++ b/engine/src/routes/insights.ts
@@ -1,0 +1,64 @@
+import type { Request, Response } from "express";
+import { z } from "zod";
+import { asyncRouter } from "./asyncRouter.js";
+import { validateBody } from "./validateBody.js";
+import { scopedDb } from "../auth/apiKey.js";
+import { getCoverage } from "../core/insights/coverage.js";
+import { probe, probeBatch } from "../core/insights/probe.js";
+import type { MonitoringWindow } from "../core/monitor/events.js";
+
+// Insights: how well the evaluation datasets cover what production actually does. Read-only -
+// nothing here writes a dataset. A gap is reported, never filled: cases still land through the
+// existing preview -> human review -> append path in routes/evaluateDashboard.ts, which is what
+// keeps a coverage number from being inflated by rows nobody looked at.
+
+export const insightsRouter = asyncRouter();
+
+const WINDOWS: MonitoringWindow[] = ["24h", "7d", "30d"];
+
+function parseWindow(req: Request): MonitoringWindow {
+  const raw = String(req.query.window ?? "7d");
+  return (WINDOWS as string[]).includes(raw) ? (raw as MonitoringWindow) : "7d";
+}
+
+function datasetIdOf(req: Request): string | undefined {
+  const raw = req.query.datasetId;
+  return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+}
+
+// The sweep: three headline numbers, the topic list with its state, and the off-map cases.
+insightsRouter.get("/coverage", async (req: Request, res: Response) => {
+  res.status(200).json(await getCoverage(scopedDb(req), { window: parseWindow(req), datasetId: datasetIdOf(req) }));
+});
+
+const probeSchema = z
+  .object({
+    query: z.string().trim().min(1, "query is required"),
+    window: z.enum(["24h", "7d", "30d"]).optional(),
+    datasetId: z.string().trim().min(1).optional(),
+  })
+  .strip();
+
+// POST rather than GET despite being a read: the query is free text a user typed, and putting it
+// in a URL would leak it into access logs and browser history.
+insightsRouter.post("/probe", validateBody(probeSchema), async (req: Request, res: Response) => {
+  const body = req.body as z.infer<typeof probeSchema>;
+  res.status(200).json(
+    await probe(scopedDb(req), { query: body.query, window: body.window ?? "7d", datasetId: body.datasetId })
+  );
+});
+
+const probeBatchSchema = z
+  .object({
+    queries: z.array(z.string()).min(1, "queries must contain at least one entry").max(50),
+    window: z.enum(["24h", "7d", "30d"]).optional(),
+    datasetId: z.string().trim().min(1).optional(),
+  })
+  .strip();
+
+insightsRouter.post("/probe/batch", validateBody(probeBatchSchema), async (req: Request, res: Response) => {
+  const body = req.body as z.infer<typeof probeBatchSchema>;
+  res.status(200).json(
+    await probeBatch(scopedDb(req), { queries: body.queries, window: body.window ?? "7d", datasetId: body.datasetId })
+  );
+});

--- a/engine/src/routes/insights.ts
+++ b/engine/src/routes/insights.ts
@@ -25,17 +25,27 @@ function parseWindow(req: Request): MonitoringWindow {
   return (WINDOWS as string[]).includes(raw) ? (raw as MonitoringWindow) : "30d";
 }
 
-// Accepts a repeated or comma-separated `datasetId`, so the single-value form older callers send
-// keeps working and the UI's multi-select needs no second parameter.
+// Accepts `datasetId` or `datasetIds`, each repeated or comma-separated. Both spellings because the
+// response field is `datasetIds` and a client that mirrors the name it reads back would otherwise be
+// ignored in silence - answered project-wide with no error to say the scope was dropped.
 function datasetIdsOf(req: Request): string[] {
-  const raw = req.query.datasetId;
-  const values = Array.isArray(raw) ? raw : [raw];
-  return values
+  const raw = [req.query.datasetId, req.query.datasetIds];
+  return raw
+    .flatMap(value => (Array.isArray(value) ? value : [value]))
     .filter((value): value is string => typeof value === "string")
     .flatMap(value => value.split(","))
     .map(value => value.trim())
     .filter(Boolean);
 }
+
+// Same reasoning on the POST bodies: an older caller sending the single `datasetId` must not be
+// silently answered project-wide, which is the one wrong answer the probe exists to avoid.
+const datasetScope = {
+  datasetIds: z.array(z.string().trim().min(1)).optional(),
+  datasetId: z.string().trim().min(1).optional(),
+};
+const scopeOf = (body: { datasetIds?: string[]; datasetId?: string }): string[] | undefined =>
+  body.datasetIds?.length ? body.datasetIds : body.datasetId ? [body.datasetId] : undefined;
 
 // The sweep: three headline numbers, the topic list with its state, and the off-map cases.
 insightsRouter.get("/coverage", async (req: Request, res: Response) => {
@@ -46,7 +56,7 @@ const probeSchema = z
   .object({
     query: z.string().trim().min(1, "query is required"),
     window: z.enum(["24h", "7d", "30d"]).optional(),
-    datasetIds: z.array(z.string().trim().min(1)).optional(),
+    ...datasetScope,
   })
   .strip();
 
@@ -55,7 +65,7 @@ const probeSchema = z
 insightsRouter.post("/probe", validateBody(probeSchema), async (req: Request, res: Response) => {
   const body = req.body as z.infer<typeof probeSchema>;
   res.status(200).json(
-    await probe(scopedDb(req), { query: body.query, window: body.window ?? "30d", datasetIds: body.datasetIds })
+    await probe(scopedDb(req), { query: body.query, window: body.window ?? "30d", datasetIds: scopeOf(body) })
   );
 });
 
@@ -63,13 +73,13 @@ const probeBatchSchema = z
   .object({
     queries: z.array(z.string()).min(1, "queries must contain at least one entry").max(50),
     window: z.enum(["24h", "7d", "30d"]).optional(),
-    datasetIds: z.array(z.string().trim().min(1)).optional(),
+    ...datasetScope,
   })
   .strip();
 
 insightsRouter.post("/probe/batch", validateBody(probeBatchSchema), async (req: Request, res: Response) => {
   const body = req.body as z.infer<typeof probeBatchSchema>;
   res.status(200).json(
-    await probeBatch(scopedDb(req), { queries: body.queries, window: body.window ?? "30d", datasetIds: body.datasetIds })
+    await probeBatch(scopedDb(req), { queries: body.queries, window: body.window ?? "30d", datasetIds: scopeOf(body) })
   );
 });

--- a/engine/src/routes/insights.ts
+++ b/engine/src/routes/insights.ts
@@ -25,21 +25,28 @@ function parseWindow(req: Request): MonitoringWindow {
   return (WINDOWS as string[]).includes(raw) ? (raw as MonitoringWindow) : "30d";
 }
 
-function datasetIdOf(req: Request): string | undefined {
+// Accepts a repeated or comma-separated `datasetId`, so the single-value form older callers send
+// keeps working and the UI's multi-select needs no second parameter.
+function datasetIdsOf(req: Request): string[] {
   const raw = req.query.datasetId;
-  return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+  const values = Array.isArray(raw) ? raw : [raw];
+  return values
+    .filter((value): value is string => typeof value === "string")
+    .flatMap(value => value.split(","))
+    .map(value => value.trim())
+    .filter(Boolean);
 }
 
 // The sweep: three headline numbers, the topic list with its state, and the off-map cases.
 insightsRouter.get("/coverage", async (req: Request, res: Response) => {
-  res.status(200).json(await getCoverage(scopedDb(req), { window: parseWindow(req), datasetId: datasetIdOf(req) }));
+  res.status(200).json(await getCoverage(scopedDb(req), { window: parseWindow(req), datasetIds: datasetIdsOf(req) }));
 });
 
 const probeSchema = z
   .object({
     query: z.string().trim().min(1, "query is required"),
     window: z.enum(["24h", "7d", "30d"]).optional(),
-    datasetId: z.string().trim().min(1).optional(),
+    datasetIds: z.array(z.string().trim().min(1)).optional(),
   })
   .strip();
 
@@ -48,7 +55,7 @@ const probeSchema = z
 insightsRouter.post("/probe", validateBody(probeSchema), async (req: Request, res: Response) => {
   const body = req.body as z.infer<typeof probeSchema>;
   res.status(200).json(
-    await probe(scopedDb(req), { query: body.query, window: body.window ?? "30d", datasetId: body.datasetId })
+    await probe(scopedDb(req), { query: body.query, window: body.window ?? "30d", datasetIds: body.datasetIds })
   );
 });
 
@@ -56,13 +63,13 @@ const probeBatchSchema = z
   .object({
     queries: z.array(z.string()).min(1, "queries must contain at least one entry").max(50),
     window: z.enum(["24h", "7d", "30d"]).optional(),
-    datasetId: z.string().trim().min(1).optional(),
+    datasetIds: z.array(z.string().trim().min(1)).optional(),
   })
   .strip();
 
 insightsRouter.post("/probe/batch", validateBody(probeBatchSchema), async (req: Request, res: Response) => {
   const body = req.body as z.infer<typeof probeBatchSchema>;
   res.status(200).json(
-    await probeBatch(scopedDb(req), { queries: body.queries, window: body.window ?? "30d", datasetId: body.datasetId })
+    await probeBatch(scopedDb(req), { queries: body.queries, window: body.window ?? "30d", datasetIds: body.datasetIds })
   );
 });

--- a/engine/src/routes/insights.ts
+++ b/engine/src/routes/insights.ts
@@ -16,9 +16,13 @@ export const insightsRouter = asyncRouter();
 
 const WINDOWS: MonitoringWindow[] = ["24h", "7d", "30d"];
 
+// 30d, where the monitoring surfaces default to 7d. Those charts are about recent health, so a
+// short window is the point; coverage is accumulated test debt, and classification is sampled, so
+// a 7d window is routinely empty on an install whose 30d window is full - which reads as "no data"
+// rather than "look further back". Callers can still ask for 24h/7d explicitly.
 function parseWindow(req: Request): MonitoringWindow {
-  const raw = String(req.query.window ?? "7d");
-  return (WINDOWS as string[]).includes(raw) ? (raw as MonitoringWindow) : "7d";
+  const raw = String(req.query.window ?? "30d");
+  return (WINDOWS as string[]).includes(raw) ? (raw as MonitoringWindow) : "30d";
 }
 
 function datasetIdOf(req: Request): string | undefined {
@@ -44,7 +48,7 @@ const probeSchema = z
 insightsRouter.post("/probe", validateBody(probeSchema), async (req: Request, res: Response) => {
   const body = req.body as z.infer<typeof probeSchema>;
   res.status(200).json(
-    await probe(scopedDb(req), { query: body.query, window: body.window ?? "7d", datasetId: body.datasetId })
+    await probe(scopedDb(req), { query: body.query, window: body.window ?? "30d", datasetId: body.datasetId })
   );
 });
 
@@ -59,6 +63,6 @@ const probeBatchSchema = z
 insightsRouter.post("/probe/batch", validateBody(probeBatchSchema), async (req: Request, res: Response) => {
   const body = req.body as z.infer<typeof probeBatchSchema>;
   res.status(200).json(
-    await probeBatch(scopedDb(req), { queries: body.queries, window: body.window ?? "7d", datasetId: body.datasetId })
+    await probeBatch(scopedDb(req), { queries: body.queries, window: body.window ?? "30d", datasetId: body.datasetId })
   );
 });

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -667,6 +667,20 @@ function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean } {
 
     CREATE INDEX IF NOT EXISTS monitor_classifications_created_at ON monitor_classifications (created_at);
 
+    CREATE TABLE IF NOT EXISTS insight_case_embeddings (
+      id TEXT PRIMARY KEY,
+      project_id TEXT,
+      dataset_id TEXT NOT NULL,
+      case_key TEXT NOT NULL,
+      query TEXT NOT NULL,
+      embedding TEXT,
+      model TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS insight_case_embeddings_key ON insight_case_embeddings (project_id, dataset_id, case_key);
+
+
     CREATE TABLE IF NOT EXISTS monitor_online_evaluators (
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
@@ -1851,6 +1865,20 @@ async function bootstrapPostgres(pool: Pool): Promise<{ freshInstall: boolean }>
 
     CREATE INDEX IF NOT EXISTS monitor_classifications_created_at ON monitor_classifications (created_at);
 
+    CREATE TABLE IF NOT EXISTS insight_case_embeddings (
+      id TEXT PRIMARY KEY,
+      project_id TEXT,
+      dataset_id TEXT NOT NULL,
+      case_key TEXT NOT NULL,
+      query TEXT NOT NULL,
+      embedding JSONB,
+      model TEXT,
+      created_at TIMESTAMP NOT NULL
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS insight_case_embeddings_key ON insight_case_embeddings (project_id, dataset_id, case_key);
+
+
     CREATE TABLE IF NOT EXISTS monitor_online_evaluators (
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
@@ -2468,6 +2496,7 @@ const PROJECT_SCOPED_TABLES = [
   "monitor_signal_feedback",
   "monitor_events",
   "monitor_classifications",
+  "insight_case_embeddings",
   "monitor_online_evaluators",
   "prompts",
   "prompt_versions",

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -674,6 +674,7 @@ function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean } {
       case_key TEXT NOT NULL,
       query TEXT NOT NULL,
       embedding TEXT,
+      embedding_full TEXT,
       model TEXT,
       created_at INTEGER NOT NULL
     );
@@ -1872,6 +1873,7 @@ async function bootstrapPostgres(pool: Pool): Promise<{ freshInstall: boolean }>
       case_key TEXT NOT NULL,
       query TEXT NOT NULL,
       embedding JSONB,
+      embedding_full JSONB,
       model TEXT,
       created_at TIMESTAMP NOT NULL
     );

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -1073,6 +1073,11 @@ function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean } {
     // Topics "Map" view (core/monitor/topics.ts's getTopicsMap) - a JSON-encoded embedding vector
     // per classification, used for UMAP projection. Null for rows classified before this existed.
     ["monitor_classifications", "ALTER TABLE monitor_classifications ADD COLUMN embedding TEXT"],
+    // insight_case_embeddings gained a second vector after the table itself shipped on this
+    // branch. CREATE TABLE IF NOT EXISTS no-ops on an install that already has the table, so
+    // without this the column only appears on a fresh database - and every existing one 500s on
+    // GET /insights/coverage. CI never catches it because CI always starts empty.
+    ["insight_case_embeddings", "ALTER TABLE insight_case_embeddings ADD COLUMN embedding_full TEXT"],
     ["monitor_online_evaluators", "ALTER TABLE monitor_online_evaluators ADD COLUMN project_id TEXT"],
     ["prompts", "ALTER TABLE prompts ADD COLUMN project_id TEXT"],
     ["prompt_versions", "ALTER TABLE prompt_versions ADD COLUMN project_id TEXT"],
@@ -2246,6 +2251,7 @@ async function bootstrapPostgres(pool: Pool): Promise<{ freshInstall: boolean }>
     ALTER TABLE monitor_events ADD COLUMN IF NOT EXISTS project_id TEXT;
     ALTER TABLE monitor_classifications ADD COLUMN IF NOT EXISTS project_id TEXT;
     ALTER TABLE monitor_classifications ADD COLUMN IF NOT EXISTS embedding JSONB;
+    ALTER TABLE insight_case_embeddings ADD COLUMN IF NOT EXISTS embedding_full JSONB;
     ALTER TABLE monitor_online_evaluators ADD COLUMN IF NOT EXISTS project_id TEXT;
     ALTER TABLE prompts ADD COLUMN IF NOT EXISTS project_id TEXT;
     ALTER TABLE prompt_versions ADD COLUMN IF NOT EXISTS project_id TEXT;

--- a/engine/src/storage/schema.pg.ts
+++ b/engine/src/storage/schema.pg.ts
@@ -322,6 +322,19 @@ export const monitorClassifications = pgTable("monitor_classifications", {
   embedding: jsonb("embedding"),
 });
 
+
+// See schema.sqlite.ts's insightCaseEmbeddings for the full comment.
+export const insightCaseEmbeddings = pgTable("insight_case_embeddings", {
+  id: text("id").primaryKey(),
+  projectId: text("project_id"),
+  datasetId: text("dataset_id").notNull(),
+  caseKey: text("case_key").notNull(),
+  query: text("query").notNull(),
+  embedding: jsonb("embedding"),
+  model: text("model"),
+  createdAt: timestamp("created_at", { mode: "date" }).notNull(),
+});
+
 // See schema.sqlite.ts's monitorOnlineEvaluators for the full comment.
 export const monitorOnlineEvaluators = pgTable("monitor_online_evaluators", {
   id: text("id").primaryKey(),
@@ -676,6 +689,7 @@ export type PgSchema = {
   monitorSignals: typeof monitorSignals;
   monitorEvents: typeof monitorEvents;
   monitorClassifications: typeof monitorClassifications;
+  insightCaseEmbeddings: typeof insightCaseEmbeddings;
   monitorOnlineEvaluators: typeof monitorOnlineEvaluators;
   customEvaluators: typeof customEvaluators;
   agentConnectors: typeof agentConnectors;

--- a/engine/src/storage/schema.pg.ts
+++ b/engine/src/storage/schema.pg.ts
@@ -331,6 +331,7 @@ export const insightCaseEmbeddings = pgTable("insight_case_embeddings", {
   caseKey: text("case_key").notNull(),
   query: text("query").notNull(),
   embedding: jsonb("embedding"),
+  embeddingFull: jsonb("embedding_full"),
   model: text("model"),
   createdAt: timestamp("created_at", { mode: "date" }).notNull(),
 });

--- a/engine/src/storage/schema.sqlite.ts
+++ b/engine/src/storage/schema.sqlite.ts
@@ -495,8 +495,8 @@ export const monitorClassifications = sqliteTable("monitor_classifications", {
 // a case re-embeds it because its hash changes, while reordering or inserting cases costs nothing,
 // which a positional key would get exactly backwards. Rows are never invalidated, only orphaned:
 // an edited case leaves its old row behind, harmless and reused if the text ever comes back.
-// Null `embedding` is a REMEMBERED FAILURE (no OPENAI_API_KEY, or the embeddings call failed), so
-// coverage degrades to the lexical fallback without re-attempting a doomed call on every request.
+// A row is only written once BOTH vectors are computed - a failed call is never cached, since it
+// cannot be told apart from a missing key and would exclude the case forever.
 export const insightCaseEmbeddings = sqliteTable("insight_case_embeddings", {
   id: text("id").primaryKey(),
   projectId: text("project_id"),
@@ -506,8 +506,12 @@ export const insightCaseEmbeddings = sqliteTable("insight_case_embeddings", {
   // The query text itself, denormalized so a probe result can name the nearest case without
   // re-reading and re-walking every dataset's questions JSON.
   query: text("query").notNull(),
-  // JSON-encoded number[] (text-embedding-3-small), or null - see the note above.
+  // JSON-encoded number[] (text-embedding-3-small). Two of them, in two different spaces:
+  // `embedding` is the query alone (compared against a probe's typed query), `embedding_full` is
+  // query + expected result (compared against trace embeddings, which are input + output). See
+  // core/insights/cases.ts.
   embedding: text("embedding", { mode: "json" }),
+  embeddingFull: text("embedding_full", { mode: "json" }),
   model: text("model"),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
 });

--- a/engine/src/storage/schema.sqlite.ts
+++ b/engine/src/storage/schema.sqlite.ts
@@ -490,6 +490,28 @@ export const monitorClassifications = sqliteTable("monitor_classifications", {
   embedding: text("embedding", { mode: "json" }),
 });
 
+// core/insights/: one cached embedding per distinct dataset case query. Keyed by a content hash
+// of the query text, not by the case's position in the dataset's `questions` JSON array - editing
+// a case re-embeds it because its hash changes, while reordering or inserting cases costs nothing,
+// which a positional key would get exactly backwards. Rows are never invalidated, only orphaned:
+// an edited case leaves its old row behind, harmless and reused if the text ever comes back.
+// Null `embedding` is a REMEMBERED FAILURE (no OPENAI_API_KEY, or the embeddings call failed), so
+// coverage degrades to the lexical fallback without re-attempting a doomed call on every request.
+export const insightCaseEmbeddings = sqliteTable("insight_case_embeddings", {
+  id: text("id").primaryKey(),
+  projectId: text("project_id"),
+  datasetId: text("dataset_id").notNull(),
+  // sha256 of the normalized query text - see core/insights/coverage.ts's caseKey().
+  caseKey: text("case_key").notNull(),
+  // The query text itself, denormalized so a probe result can name the nearest case without
+  // re-reading and re-walking every dataset's questions JSON.
+  query: text("query").notNull(),
+  // JSON-encoded number[] (text-embedding-3-small), or null - see the note above.
+  embedding: text("embedding", { mode: "json" }),
+  model: text("model"),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+});
+
 // The ONLINE PROFILE of an LLM Judge Scorer (core/monitor/judgeScorers.ts): routing/threshold
 // state only - sampleRate/scopeMode/agentIds mirror monitor_patterns' routing fields (see
 // core/monitor/routing.ts). The rubric (criteria/judge prompt/judge model) and the scorer's
@@ -1020,6 +1042,7 @@ export type SqliteSchema = {
   monitorSignals: typeof monitorSignals;
   monitorEvents: typeof monitorEvents;
   monitorClassifications: typeof monitorClassifications;
+  insightCaseEmbeddings: typeof insightCaseEmbeddings;
   monitorOnlineEvaluators: typeof monitorOnlineEvaluators;
   customEvaluators: typeof customEvaluators;
   agentConnectors: typeof agentConnectors;

--- a/engine/src/test/contract.integration.test.ts
+++ b/engine/src/test/contract.integration.test.ts
@@ -1,6 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { startEngine, postJson, type TestEngine } from "./server.js";
 import {
+  insightsCoverageResponseSchema,
+  insightsProbeBatchResponseSchema,
+  insightsProbeResponseSchema,
   judgeScorersResponseSchema,
   monitoringDefaultsPutResponseSchema,
   monitorMetricsResponseSchema,
@@ -107,6 +110,40 @@ describe("wire contract", () => {
     expect(res.status).toBe(200);
     const parsed = judgeScorersResponseSchema.parse(res.body);
     expect(parsed.judgeScorers.length).toBeGreaterThan(0);
+  });
+
+  it("GET /insights/coverage matches the contract with no classified traffic", async () => {
+    // Topics is opt-in and sampled, so an install with nothing classified yet is the COMMON
+    // first view of this screen - it has to be a clean, parseable empty state rather than a 500.
+    const res = await api("/insights/coverage?window=7d");
+    expect(res.status).toBe(200);
+    const parsed = insightsCoverageResponseSchema.parse(res.body);
+    expect(parsed.insufficientData).toBe(true);
+    expect(parsed.topics).toEqual([]);
+  });
+
+  it("POST /insights/probe matches the contract and validates its body", async () => {
+    const res = await api("/insights/probe", postJson({ query: "how do I reset my password" }));
+    expect(res.status).toBe(200);
+    const parsed = insightsProbeResponseSchema.parse(res.body);
+    // No dataset case is anywhere near it and production has never been classified, so the only
+    // honest answer is the one that does not manufacture a gap.
+    expect(parsed.verdict).toBe("untested-and-unasked");
+    expect(parsed.explanation).toContain("not a gap");
+
+    const empty = await api("/insights/probe", postJson({ query: "   " }));
+    expect(empty.status).toBe(400);
+  });
+
+  it("POST /insights/probe/batch matches the contract", async () => {
+    const res = await api("/insights/probe/batch", postJson({ queries: ["close my account", "refund status"] }));
+    expect(res.status).toBe(200);
+    const parsed = insightsProbeBatchResponseSchema.parse(res.body);
+    expect(parsed.rollup.total).toBe(2);
+    expect(parsed.results).toHaveLength(2);
+
+    const none = await api("/insights/probe/batch", postJson({ queries: [] }));
+    expect(none.status).toBe(400);
   });
 
   it("GET /openapi.json publishes every contract entry", async () => {

--- a/engine/src/test/embeddingBatch.test.ts
+++ b/engine/src/test/embeddingBatch.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { embedBatched, type EmbeddingClient } from "../core/evaluate/judge.js";
+
+// Batching turns ~120 serialized round trips into one. What makes that safe rather than merely fast
+// is failure isolation: the embeddings API rejects an ENTIRE request when any single input exceeds
+// the model's token limit, and the caller caches nothing from a failure and rebuilds the same batch
+// next time - so a batch that fails as a unit does not lose one case, it blocks every case behind it
+// forever. These pin that it splits instead.
+
+/** A client that rejects any request containing `poison`, the way an over-long input does. */
+const clientRejecting = (poison: string) => {
+  const calls: string[][] = [];
+  const client: EmbeddingClient = {
+    embeddings: {
+      create: async ({ input }) => {
+        calls.push(input);
+        if (input.includes(poison)) {
+          throw new Error("400 - requested too many tokens");
+        }
+        return { data: input.map((text, index) => ({ index, embedding: [text.length, 0] })) };
+      },
+    },
+  };
+  return { client, calls };
+};
+
+describe("embedBatched", () => {
+  it("isolates the one input the API rejects and keeps the rest", async () => {
+    const { client, calls } = clientRejecting("bad");
+
+    const result = await embedBatched(client, ["a", "b", "bad", "c"]);
+
+    expect(result.map(vector => vector === null)).toEqual([false, false, true, false]);
+    // The whole batch is attempted first - splitting is the fallback, not the default.
+    expect(calls[0]).toEqual(["a", "b", "bad", "c"]);
+    expect(calls.length).toBeGreaterThan(1);
+  });
+
+  it("finds the offender in a logarithmic number of requests, not a linear one", async () => {
+    const { client, calls } = clientRejecting("bad");
+    const texts = Array.from({ length: 32 }, (_, index) => (index === 19 ? "bad" : `t${index}`));
+
+    const result = await embedBatched(client, texts);
+
+    expect(result[19]).toBeNull();
+    expect(result.filter(vector => vector === null)).toHaveLength(1);
+    // Halving: ~2·log2(32) requests, nowhere near one per input.
+    expect(calls.length).toBeLessThan(16);
+  });
+
+  it("sends exactly one request when nothing fails", async () => {
+    const { client, calls } = clientRejecting("nothing-matches");
+
+    const result = await embedBatched(client, ["a", "b", "c"]);
+
+    expect(calls).toEqual([["a", "b", "c"]]);
+    expect(result.every(vector => vector !== null)).toBe(true);
+  });
+
+  it("keeps every slot aligned with its input, including blanks", async () => {
+    const { client, calls } = clientRejecting("nothing-matches");
+
+    const result = await embedBatched(client, ["alpha", "   ", "be"]);
+
+    expect(calls).toEqual([["alpha", "be"]]);
+    expect(result).toEqual([[5, 0], null, [2, 0]]);
+  });
+
+  it("maps vectors by the response's own index rather than by position", async () => {
+    const client: EmbeddingClient = {
+      embeddings: {
+        create: async ({ input }) => ({
+          data: input.map((_, index) => ({ index, embedding: [index] })).reverse(),
+        }),
+      },
+    };
+
+    expect(await embedBatched(client, ["x", "y", "z"])).toEqual([[0], [1], [2]]);
+  });
+
+  it("nulls only the input that cannot be embedded at all", async () => {
+    const client: EmbeddingClient = {
+      embeddings: {
+        create: async () => {
+          throw new Error("500");
+        },
+      },
+    };
+
+    expect(await embedBatched(client, ["a", "b"])).toEqual([null, null]);
+  });
+});

--- a/engine/src/test/insights.integration.test.ts
+++ b/engine/src/test/insights.integration.test.ts
@@ -106,9 +106,12 @@ async function cacheCaseEmbedding(datasetId: string, query: string, angle: numbe
     id: nanoid(),
     projectId: db.projectId,
     datasetId,
-    caseKey: caseKeyFor(query),
+    caseKey: caseKeyFor(query, `expected for ${query}`),
     query,
+    // Two vectors in two spaces. Seeded to the same angle here so the geometry stays readable;
+    // what matters is that coverage reads embeddingFull and the probe reads embedding.
     embedding: unit(angle),
+    embeddingFull: unit(angle),
     model: "test-injected",
     createdAt: new Date(),
   });
@@ -276,6 +279,63 @@ describe("synonymous intent labels", () => {
   });
 });
 
+describe("degradation and pending work are reported honestly", () => {
+  it("does not report an unembedded case as dead test weight", async () => {
+    const scoped = test.scoped(await test.newProject("Pending"));
+    const saved = db;
+    db = scoped;
+    try {
+      for (let i = 0; i < 4; i++) {
+        await classify({ intent: "refund request", angle: SAME });
+      }
+      // TWO cases, only one with cached vectors. The embedded one puts the run in embedding mode;
+      // the other scores -1 against everything. Calling that "off map" would tell a team to delete
+      // a perfectly good test on its first load, before the cache had finished warming.
+      const created = (await createDataset(db, {
+        name: "half-embedded",
+        questions: [
+          { main_question: { query: "I want a refund", expectedResults: "expected for I want a refund" }, follow_up_questions: [] },
+          { main_question: { query: "not yet embedded", expectedResults: "expected for not yet embedded" }, follow_up_questions: [] },
+        ],
+      })) as { _id: string };
+      await cacheCaseEmbedding(created._id, "I want a refund", SAME);
+
+      const result = await getCoverage(db, { window: "7d", datasetId: created._id });
+      expect(result.degraded).toBe(false);
+      expect(result.caseEmbeddingsPending).toBe(1);
+      expect(result.offMapCases.map(c => c.query)).not.toContain("not yet embedded");
+    } finally {
+      db = saved;
+    }
+  });
+
+  it("says per topic which measure produced the number", async () => {
+    const result = await getCoverage(db, { window: "7d", datasetId: await newDataset("basis", [{ query: "how do I reset my password", angle: SAME }]) });
+    // The global degraded flag cannot answer this: facilityLocation returns null for a topic whose
+    // own traces carry no embeddings even while the run is using them.
+    for (const topic of result.topics) {
+      expect(["depth", "count"]).toContain(topic.coverageBasis);
+    }
+  });
+
+  it("returns null risk-weighted coverage when nothing carries risk, not zero", async () => {
+    const scoped = test.scoped(await test.newProject("NoRisk"));
+    const saved = db;
+    db = scoped;
+    try {
+      // Every topic healthy. 0% here would be indistinguishable from testing nothing at all.
+      for (let i = 0; i < 4; i++) {
+        await classify({ intent: "happy path", angle: SAME, issueType: "none", sentiment: "positive" });
+      }
+      const result = await getCoverage(db, { window: "7d", datasetId: await newDataset("healthy", [{ query: "all good", angle: SAME }]) });
+      expect(result.riskWeightedCoverage).toBeNull();
+      expect(result.trafficWeightedCoverage).toBeGreaterThan(0);
+    } finally {
+      db = saved;
+    }
+  });
+});
+
 describe("the probe", () => {
   let datasetId: string;
 
@@ -332,6 +392,24 @@ describe("the probe", () => {
     expect(result.degraded).toBe(true);
     expect(result.bands.covered).toBeLessThan(SIMILARITY_BANDS.covered);
     expect(result.nearestCases.length).toBeGreaterThan(0);
+  });
+
+  it("will not call a single stray classification a real gap", async () => {
+    const scoped = test.scoped(await test.newProject("Stray"));
+    const saved = db;
+    db = scoped;
+    try {
+      // ONE classification. Below the floor the coverage sweep applies, so it is not a topic - and
+      // treating it as one would fabricate a gap out of a single trace.
+      await classify({ intent: "one-off question", angle: UNRELATED });
+      registerQuery("something nobody really asks", UNRELATED);
+      const dsId = await newDataset("stray-suite", [{ query: "unrelated case", angle: SAME }]);
+      const result = await probe(db, { query: "something nobody really asks", datasetId: dsId, window: "7d" });
+      expect(result.verdict).toBe("untested-and-unasked");
+      expect(result.topic).toBeNull();
+    } finally {
+      db = saved;
+    }
   });
 
   it("returns the bands it judged with, so a raw score is never shown alone", async () => {

--- a/engine/src/test/insights.integration.test.ts
+++ b/engine/src/test/insights.integration.test.ts
@@ -170,7 +170,7 @@ describe("coverage over production topics", () => {
   });
 
   it("reports a covered topic and a missing one, and ranks by traffic", async () => {
-    const result = await getCoverage(db, { window: "7d", datasetId });
+    const result = await getCoverage(db, { window: "7d", datasetIds: [datasetId] });
     expect(result.insufficientData).toBe(false);
     expect(result.degraded).toBe(false);
 
@@ -188,7 +188,7 @@ describe("coverage over production topics", () => {
   });
 
   it("counts unique sessions, not raw request volume", async () => {
-    const result = await getCoverage(db, { window: "7d", datasetId });
+    const result = await getCoverage(db, { window: "7d", datasetIds: [datasetId] });
     const reset = result.topics.find(t => t.topic === "password reset")!;
     // 8 traces, 8 distinct session ids. The retry-loop case is the next test.
     expect(reset.traceCount).toBe(8);
@@ -196,7 +196,7 @@ describe("coverage over production topics", () => {
   });
 
   it("weights risk toward observed issues rather than sentiment alone", async () => {
-    const result = await getCoverage(db, { window: "7d", datasetId });
+    const result = await getCoverage(db, { window: "7d", datasetIds: [datasetId] });
     const closure = result.topics.find(t => t.topic === "account closure")!;
     expect(closure.riskComponents.issueRate).toBe(1);
     expect(closure.riskComponents.negativeSentimentRate).toBe(1);
@@ -207,7 +207,7 @@ describe("coverage over production topics", () => {
   });
 
   it("does not let duplicate cases inflate coverage", async () => {
-    const before = (await getCoverage(db, { window: "7d", datasetId })).topics.find(t => t.topic === "password reset")!;
+    const before = (await getCoverage(db, { window: "7d", datasetIds: [datasetId] })).topics.find(t => t.topic === "password reset")!;
     const padded = await newDataset(
       "padded",
       // Six near-identical cases, all sitting on the same point as the traffic. A count-based
@@ -215,7 +215,7 @@ describe("coverage over production topics", () => {
       // facility-location value is already satisfied, so it must not.
       Array.from({ length: 6 }, (_, i) => ({ query: `please reset my password variant ${i}`, angle: SAME }))
     );
-    const after = (await getCoverage(db, { window: "7d", datasetId: padded })).topics.find(t => t.topic === "password reset")!;
+    const after = (await getCoverage(db, { window: "7d", datasetIds: [padded] })).topics.find(t => t.topic === "password reset")!;
     expect(after.caseCount).toBe(6);
     // Three times the cases, not one point of extra coverage - the max-similarity term was
     // already satisfied by the first one.
@@ -223,7 +223,7 @@ describe("coverage over production topics", () => {
   });
 
   it("scales the target with traffic and risk instead of using a flat number", async () => {
-    const result = await getCoverage(db, { window: "7d", datasetId });
+    const result = await getCoverage(db, { window: "7d", datasetIds: [datasetId] });
     const reset = result.topics.find(t => t.topic === "password reset")!;
     const closure = result.topics.find(t => t.topic === "account closure")!;
     expect(reset.targetCases).toBeGreaterThan(2);
@@ -232,14 +232,14 @@ describe("coverage over production topics", () => {
   });
 
   it("reports an honesty delta between case presence and real depth", async () => {
-    const result = await getCoverage(db, { window: "7d", datasetId });
+    const result = await getCoverage(db, { window: "7d", datasetIds: [datasetId] });
     expect(result.presenceCoverage).toBeGreaterThanOrEqual(result.trafficWeightedCoverage);
     expect(result.honestyDelta).toBeCloseTo(result.presenceCoverage - result.trafficWeightedCoverage, 3);
   });
 
   it("flags cases that match no production topic as off-map", async () => {
     const orphan = await newDataset("orphan", [{ query: "can I pay in martian dollars", angle: 2.6 }]);
-    const result = await getCoverage(db, { window: "7d", datasetId: orphan });
+    const result = await getCoverage(db, { window: "7d", datasetIds: [orphan] });
     expect(result.offMapCases).toHaveLength(1);
     expect(result.offMapCases[0]!.query).toBe("can I pay in martian dollars");
   });
@@ -263,7 +263,7 @@ describe("synonymous intent labels", () => {
         await classify({ intent: "dispute a charge", angle: 0.55 });
       }
       const dsId = await newDataset("merge-suite", [{ query: "I want a refund", angle: SAME }]);
-      const result = await getCoverage(db, { window: "7d", datasetId: dsId });
+      const result = await getCoverage(db, { window: "7d", datasetIds: [dsId] });
 
       const labels = result.topics.map(t => t.topic);
       expect(labels).toContain("refund request");
@@ -302,7 +302,7 @@ describe("degradation and pending work are reported honestly", () => {
       })) as { _id: string };
       await cacheCaseEmbedding(created._id, "I want a refund", SAME);
 
-      const result = await getCoverage(db, { window: "7d", datasetId: created._id });
+      const result = await getCoverage(db, { window: "7d", datasetIds: [created._id] });
       expect(result.degraded).toBe(false);
       expect(result.caseEmbeddingsPending).toBe(1);
       expect(result.offMapCases.map(c => c.query)).not.toContain("not yet embedded");
@@ -312,7 +312,7 @@ describe("degradation and pending work are reported honestly", () => {
   });
 
   it("says per topic which measure produced the number", async () => {
-    const result = await getCoverage(db, { window: "7d", datasetId: await newDataset("basis", [{ query: "how do I reset my password", angle: SAME }]) });
+    const result = await getCoverage(db, { window: "7d", datasetIds: [await newDataset("basis", [{ query: "how do I reset my password", angle: SAME }])] });
     // The global degraded flag cannot answer this: facilityLocation returns null for a topic whose
     // own traces carry no embeddings even while the run is using them.
     for (const topic of result.topics) {
@@ -329,7 +329,7 @@ describe("degradation and pending work are reported honestly", () => {
       for (let i = 0; i < 4; i++) {
         await classify({ intent: "happy path", angle: SAME, issueType: "none", sentiment: "positive" });
       }
-      const result = await getCoverage(db, { window: "7d", datasetId: await newDataset("healthy", [{ query: "all good", angle: SAME }]) });
+      const result = await getCoverage(db, { window: "7d", datasetIds: [await newDataset("healthy", [{ query: "all good", angle: SAME }])] });
       expect(result.riskWeightedCoverage).toBeNull();
       expect(result.trafficWeightedCoverage).toBeGreaterThan(0);
     } finally {
@@ -361,7 +361,7 @@ describe("provisional results do not read as verdicts", () => {
       // its case exists and is in the queue, so "curate production traces" is wrong advice.
       await cacheCaseEmbedding(created._id, "I want a refund", SAME);
 
-      const result = await getCoverage(db, { window: "7d", datasetId: created._id });
+      const result = await getCoverage(db, { window: "7d", datasetIds: [created._id] });
       const tracking = result.topics.find(t => t.topic === "order tracking")!;
       expect(result.caseEmbeddingsPending).toBe(1);
       expect(tracking.suggestedAction).toContain("still being indexed");
@@ -412,7 +412,7 @@ describe("provisional results do not read as verdicts", () => {
         await classify({ intent: "vpn issue", angle: UNRELATED });
       }
       const dsId = await newDataset("tail", [{ query: "I want a refund", angle: SAME }]);
-      const result = await getCoverage(db, { window: "7d", datasetId: dsId });
+      const result = await getCoverage(db, { window: "7d", datasetIds: [dsId] });
       // The uncovered tail must hold the number below a clean 1.
       expect(result.trafficWeightedCoverage).toBeLessThan(1);
       expect(result.trafficWeightedCoverage).toBeGreaterThan(0.9);
@@ -438,7 +438,7 @@ describe("telling someone what to do first", () => {
       for (let i = 0; i < 10; i++) {
         await classify({ intent: "account closure", angle: UNRELATED, issueType: "refusal", sentiment: "negative" });
       }
-      const result = await getCoverage(db, { window: "7d", datasetId: await newDataset("empty-ish", [{ query: "unrelated", angle: 2.6 }]) });
+      const result = await getCoverage(db, { window: "7d", datasetIds: [await newDataset("empty-ish", [{ query: "unrelated", angle: 2.6 }])] });
 
       const greeting = result.topics.find(t => t.topic === "general greeting")!;
       const closure = result.topics.find(t => t.topic === "account closure")!;
@@ -461,7 +461,7 @@ describe("telling someone what to do first", () => {
       for (let i = 0; i < 2; i++) {
         await classify({ intent: "exotic edge case", angle: UNRELATED, issueType: "refusal", sentiment: "negative" });
       }
-      const result = await getCoverage(db, { window: "7d", datasetId: await newDataset("none", [{ query: "unrelated", angle: 2.6 }]) });
+      const result = await getCoverage(db, { window: "7d", datasetIds: [await newDataset("none", [{ query: "unrelated", angle: 2.6 }])] });
       const tracking = result.topics.find(t => t.topic === "order tracking")!;
       const exotic = result.topics.find(t => t.topic === "exotic edge case")!;
       expect(tracking.priority).toBeGreaterThan(exotic.priority);
@@ -471,20 +471,28 @@ describe("telling someone what to do first", () => {
   });
 
   it("gives a covered topic no priority, however busy it is", async () => {
-    const result = await getCoverage(db, { window: "7d", datasetId: await newDataset("covered", [{ query: "how do I reset my password", angle: SAME }]) });
+    const result = await getCoverage(db, { window: "7d", datasetIds: [await newDataset("covered", [{ query: "how do I reset my password", angle: SAME }])] });
     for (const t of result.topics.filter(t => t.state === "covered")) {
       expect(t.priority).toBeLessThan(0.05);
     }
   });
 
-  it("names the datasets the number was computed over", async () => {
+  it("lists every dataset even while filtered to one, and echoes the filter", async () => {
     const dsId = await newDataset("named-suite", [{ query: "how do I reset my password", angle: SAME }]);
-    const result = await getCoverage(db, { window: "7d", datasetId: dsId });
-    // A project-wide figure silently mixes every dataset in the project; without this nobody can
-    // tell whether a gap belongs to the suite they care about.
-    expect(result.datasets.map(d => d.id)).toEqual([dsId]);
-    expect(result.datasets[0]!.name).toBe("named-suite");
-    expect(result.datasets[0]!.caseCount).toBe(1);
+    const other = await newDataset("other-suite", [{ query: "close my account", angle: UNRELATED }]);
+    const result = await getCoverage(db, { window: "7d", datasetIds: [dsId] });
+
+    // A project-wide figure silently mixes every dataset, so the filter has to exist - but the
+    // list it is drawn from must NOT narrow with it. Returning only the selected dataset left the
+    // UI's picker with one option the moment it was used, which is a filter nobody can undo.
+    const ids = result.datasets.map(d => d.id);
+    expect(ids).toContain(dsId);
+    expect(ids).toContain(other);
+    const named = result.datasets.find(d => d.id === dsId)!;
+    expect(named.name).toBe("named-suite");
+    expect(named.caseCount).toBe(1);
+    // The scope itself comes back on the response, so a caller can tell what it was answered for.
+    expect(result.datasetIds).toEqual([dsId]);
   });
 });
 
@@ -547,7 +555,7 @@ describe("label matching does not punish long cases", () => {
       await cacheCaseEmbedding(created._id, "how do I reset my password", SAME);
       await cacheCaseEmbedding(created._id, "billing dispute over a duplicate charge", UNRELATED);
 
-      const result = await getCoverage(db, { window: "7d", datasetId: created._id });
+      const result = await getCoverage(db, { window: "7d", datasetIds: [created._id] });
       const billing = result.topics.find(t => t.topic === "billing dispute")!;
       expect(result.degraded).toBe(false);
       expect(billing.caseCount).toBe(1);
@@ -574,7 +582,7 @@ describe("label matching does not punish long cases", () => {
       })) as { _id: string };
       await cacheCaseEmbedding(created._id, "I want a refund", SAME);
 
-      const result = await getCoverage(db, { window: "7d", datasetId: created._id });
+      const result = await getCoverage(db, { window: "7d", datasetIds: [created._id] });
       // degraded is about WHICH measure ran; provisional is about how much of the dataset it saw.
       // A cold cache on a big dataset reports a near-zero number that is a floor, not a verdict.
       expect(result.degraded).toBe(false);
@@ -617,7 +625,7 @@ describe("the probe", () => {
   });
 
   it("calls a paraphrase covered, and names the case it matched", async () => {
-    const result = await probe(db, { query: "I need to reset my password", datasetId, window: "7d" });
+    const result = await probe(db, { query: "I need to reset my password", datasetIds: [datasetId], window: "7d" });
     expect(result.verdict).toBe("covered");
     expect(result.similarity).toBeGreaterThanOrEqual(SIMILARITY_BANDS.covered);
     expect(result.nearestCases[0]!.query).toBe("how do I reset my password");
@@ -629,19 +637,19 @@ describe("the probe", () => {
   it("distinguishes a real gap from a question nobody asks", async () => {
     // Both are uncovered. Only one is a gap - and conflating them is what would send a team
     // writing tests for traffic that does not exist.
-    const real = await probe(db, { query: "close my account", datasetId, window: "7d" });
+    const real = await probe(db, { query: "close my account", datasetIds: [datasetId], window: "7d" });
     expect(real.verdict).toBe("gap");
     expect(real.topic!.topic).toBe("account closure");
     expect(real.explanation).toContain("real gap");
 
-    const hypothetical = await probe(db, { query: "unrelated to anything on file", datasetId, window: "7d" });
+    const hypothetical = await probe(db, { query: "unrelated to anything on file", datasetIds: [datasetId], window: "7d" });
     expect(hypothetical.verdict).toBe("untested-and-unasked");
     expect(hypothetical.topic).toBeNull();
     expect(hypothetical.explanation).toContain("not a gap");
   });
 
   it("refuses to call a related-but-distinct question covered", async () => {
-    const result = await probe(db, { query: "my password reset link expired, what now", datasetId, window: "7d" });
+    const result = await probe(db, { query: "my password reset link expired, what now", datasetIds: [datasetId], window: "7d" });
     expect(result.verdict).toBe("adjacent");
     expect(result.similarity).toBeGreaterThanOrEqual(SIMILARITY_BANDS.related);
     expect(result.similarity).toBeLessThan(SIMILARITY_BANDS.covered);
@@ -653,7 +661,7 @@ describe("the probe", () => {
   it("degrades to lexical matching, and says so, when the query cannot be embedded", async () => {
     // Never registered, so the mocked embedder returns null exactly as a missing OPENAI_API_KEY
     // would. The verdict still comes back - on a different, clearly-labelled scale.
-    const result = await probe(db, { query: "reset password", datasetId, window: "7d" });
+    const result = await probe(db, { query: "reset password", datasetIds: [datasetId], window: "7d" });
     expect(result.degraded).toBe(true);
     expect(result.bands.covered).toBeLessThan(SIMILARITY_BANDS.covered);
     expect(result.nearestCases.length).toBeGreaterThan(0);
@@ -669,7 +677,7 @@ describe("the probe", () => {
       await classify({ intent: "one-off question", angle: UNRELATED });
       registerQuery("something nobody really asks", UNRELATED);
       const dsId = await newDataset("stray-suite", [{ query: "unrelated case", angle: SAME }]);
-      const result = await probe(db, { query: "something nobody really asks", datasetId: dsId, window: "7d" });
+      const result = await probe(db, { query: "something nobody really asks", datasetIds: [dsId], window: "7d" });
       expect(result.verdict).toBe("untested-and-unasked");
       expect(result.topic).toBeNull();
     } finally {
@@ -678,14 +686,14 @@ describe("the probe", () => {
   });
 
   it("returns the bands it judged with, so a raw score is never shown alone", async () => {
-    const result = await probe(db, { query: "how do I reset my password", datasetId, window: "7d" });
+    const result = await probe(db, { query: "how do I reset my password", datasetIds: [datasetId], window: "7d" });
     expect(result.bands).toEqual({ covered: SIMILARITY_BANDS.covered, related: SIMILARITY_BANDS.related });
   });
 
   it("rolls a batch up into a pre-launch verdict", async () => {
     const result = await probeBatch(db, {
       queries: ["how do I reset my password", "close my account", "  ", "something with no bearing on this suite"],
-      datasetId,
+      datasetIds: [datasetId],
       window: "7d",
     });
     // The blank line is dropped rather than probed.

--- a/engine/src/test/insights.integration.test.ts
+++ b/engine/src/test/insights.integration.test.ts
@@ -18,13 +18,26 @@ import { SIMILARITY_BANDS } from "../core/evaluate/curation.js";
 // be pre-seeded into the cache the way case embeddings can. Registered text returns its injected
 // vector; anything unregistered returns null, which is precisely what a missing OPENAI_API_KEY
 // does - so the degraded lexical path stays exercised rather than mocked away.
-const { registered } = vi.hoisted(() => ({ registered: new Map<string, number[]>() }));
+const { registered, canEmbed } = vi.hoisted(() => ({
+  registered: new Map<string, number[]>(),
+  // Whether an embeddings key is configured. It is the difference between "warming, come back" and
+  // "this will never change", which is the whole of what `provisional` now means.
+  canEmbed: { current: false },
+}));
 
 vi.mock("../core/evaluate/judge.js", async importOriginal => {
   const actual = await importOriginal<typeof import("../core/evaluate/judge.js")>();
   const one = (text: string): number[] | null => registered.get(text.trim()) ?? null;
-  return { ...actual, computeEmbedding: async (text: string) => one(text), computeEmbeddings: async (texts: string[]) => texts.map(one) };
+  return {
+    ...actual,
+    embeddingsAvailable: async () => canEmbed.current,
+    computeEmbedding: async (text: string) => one(text),
+    computeEmbeddings: async (texts: string[]) => texts.map(one),
+  };
 });
+
+// The batching itself is unit-tested against a fake client below, where a request can be made to
+// fail the way the real API fails - the integration mock above cannot express that.
 
 let test: TestDb;
 let db: Db;
@@ -565,7 +578,7 @@ describe("label matching does not punish long cases", () => {
     }
   });
 
-  it("marks a run provisional while cases are still being embedded", async () => {
+  it("marks a run provisional only while the missing cases can still be embedded", async () => {
     const scoped = test.scoped(await test.newProject("Provisional"));
     const saved = db;
     db = scoped;
@@ -582,12 +595,23 @@ describe("label matching does not punish long cases", () => {
       })) as { _id: string };
       await cacheCaseEmbedding(created._id, "I want a refund", SAME);
 
-      const result = await getCoverage(db, { window: "7d", datasetIds: [created._id] });
+      canEmbed.current = true;
+      const warming = await getCoverage(db, { window: "7d", datasetIds: [created._id] });
       // degraded is about WHICH measure ran; provisional is about how much of the dataset it saw.
       // A cold cache on a big dataset reports a near-zero number that is a floor, not a verdict.
-      expect(result.degraded).toBe(false);
-      expect(result.provisional).toBe(true);
+      expect(warming.degraded).toBe(false);
+      expect(warming.provisional).toBe(true);
+      expect(warming.caseEmbeddingsPending).toBe(1);
+
+      // Same shortfall, no key to close it. "Still indexing" would be a promise the engine cannot
+      // keep, and a caller that polls on it would poll forever - so the shortfall is still reported
+      // through caseEmbeddingsPending, but the run is not called provisional.
+      canEmbed.current = false;
+      const stuck = await getCoverage(db, { window: "7d", datasetIds: [created._id] });
+      expect(stuck.provisional).toBe(false);
+      expect(stuck.caseEmbeddingsPending).toBe(1);
     } finally {
+      canEmbed.current = false;
       db = saved;
     }
   });

--- a/engine/src/test/insights.integration.test.ts
+++ b/engine/src/test/insights.integration.test.ts
@@ -54,7 +54,8 @@ async function insertRow(handle: Db, table: unknown, values: Record<string, unkn
 
 async function classify(opts: {
   intent: string;
-  angle: number;
+  /** null writes a row with no embedding - the un-backfilled case. */
+  angle: number | null;
   sessionId?: string | null;
   issueType?: string;
   sentiment?: string;
@@ -95,7 +96,7 @@ async function classify(opts: {
     issueType: opts.issueType ?? "none",
     createdAt: new Date(),
     projectId: db.projectId,
-    embedding: unit(opts.angle),
+    embedding: opts.angle === null ? null : unit(opts.angle),
   });
 }
 
@@ -483,6 +484,119 @@ describe("telling someone what to do first", () => {
     expect(result.datasets.map(d => d.id)).toEqual([dsId]);
     expect(result.datasets[0]!.name).toBe("named-suite");
     expect(result.datasets[0]!.caseCount).toBe(1);
+  });
+});
+
+describe("label matching does not punish long cases", () => {
+  it("assigns a wordy case to a topic whose every label word it contains", async () => {
+    const scoped = test.scoped(await test.newProject("Wordy"));
+    const saved = db;
+    db = scoped;
+    try {
+      for (let i = 0; i < 4; i++) {
+        await classify({ intent: "Order tracking", angle: SAME });
+      }
+      // No cached vectors, so this runs on the label test. The case carries BOTH label words and
+      // a lot else; under Jaccard the union denominator scored that 0.154 - below the floor - so
+      // it was dropped as off-map and the topic reported "missing" with cases sitting right there.
+      await createDataset(db, {
+        name: "wordy",
+        questions: [
+          {
+            main_question: {
+              query:
+                "Where is my order? It has been five days since the shipping confirmation and tracking has not updated at all.",
+              expectedResults: "Looks up the order and explains the tracking status.",
+            },
+            follow_up_questions: [],
+          },
+        ],
+      });
+      const result = await getCoverage(db, { window: "7d" });
+      const tracking = result.topics.find(t => t.topic === "Order tracking")!;
+      expect(result.degraded).toBe(true);
+      expect(tracking.caseCount).toBe(1);
+      expect(tracking.state).not.toBe("missing");
+    } finally {
+      db = saved;
+    }
+  });
+
+  it("still assigns cases to a topic whose traces predate the embedding column", async () => {
+    const scoped = test.scoped(await test.newProject("NoCentroid"));
+    const saved = db;
+    db = scoped;
+    try {
+      // One topic embedded, one not. monitor_classifications.embedding is never backfilled, so a
+      // mixed install is the normal case after an upgrade - and a topic with no centroid used to
+      // match nothing at all, reporting "missing" with its cases sitting right there.
+      for (let i = 0; i < 4; i++) {
+        await classify({ intent: "password reset", angle: SAME });
+        await classify({ intent: "billing dispute", angle: null });
+      }
+      const created = (await createDataset(db, {
+        name: "mixed",
+        questions: [
+          // expectedResults must match what cacheCaseEmbedding hashes - the cache key covers both
+          // the query and the expected text, so an edit to either re-embeds the case.
+          { main_question: { query: "how do I reset my password", expectedResults: "expected for how do I reset my password" }, follow_up_questions: [] },
+          { main_question: { query: "billing dispute over a duplicate charge", expectedResults: "expected for billing dispute over a duplicate charge" }, follow_up_questions: [] },
+        ],
+      })) as { _id: string };
+      await cacheCaseEmbedding(created._id, "how do I reset my password", SAME);
+      await cacheCaseEmbedding(created._id, "billing dispute over a duplicate charge", UNRELATED);
+
+      const result = await getCoverage(db, { window: "7d", datasetId: created._id });
+      const billing = result.topics.find(t => t.topic === "billing dispute")!;
+      expect(result.degraded).toBe(false);
+      expect(billing.caseCount).toBe(1);
+      expect(billing.state).not.toBe("missing");
+    } finally {
+      db = saved;
+    }
+  });
+
+  it("marks a run provisional while cases are still being embedded", async () => {
+    const scoped = test.scoped(await test.newProject("Provisional"));
+    const saved = db;
+    db = scoped;
+    try {
+      for (let i = 0; i < 4; i++) {
+        await classify({ intent: "refund request", angle: SAME });
+      }
+      const created = (await createDataset(db, {
+        name: "half",
+        questions: [
+          { main_question: { query: "I want a refund", expectedResults: "expected for I want a refund" }, follow_up_questions: [] },
+          { main_question: { query: "not yet embedded", expectedResults: "expected for not yet embedded" }, follow_up_questions: [] },
+        ],
+      })) as { _id: string };
+      await cacheCaseEmbedding(created._id, "I want a refund", SAME);
+
+      const result = await getCoverage(db, { window: "7d", datasetId: created._id });
+      // degraded is about WHICH measure ran; provisional is about how much of the dataset it saw.
+      // A cold cache on a big dataset reports a near-zero number that is a floor, not a verdict.
+      expect(result.degraded).toBe(false);
+      expect(result.provisional).toBe(true);
+    } finally {
+      db = saved;
+    }
+  });
+
+  it("does not blame a missing key when there are simply no cases", async () => {
+    const scoped = test.scoped(await test.newProject("NoCases"));
+    const saved = db;
+    db = scoped;
+    try {
+      for (let i = 0; i < 4; i++) {
+        await classify({ intent: "refund request", angle: SAME });
+      }
+      const result = await getCoverage(db, { window: "7d" });
+      expect(result.degradedReason).toBe("No dataset cases to measure against yet.");
+      expect(result.degradedReason).not.toContain("OPENAI_API_KEY");
+    } finally {
+      db = saved;
+    }
   });
 });
 

--- a/engine/src/test/insights.integration.test.ts
+++ b/engine/src/test/insights.integration.test.ts
@@ -336,6 +336,90 @@ describe("degradation and pending work are reported honestly", () => {
   });
 });
 
+describe("provisional results do not read as verdicts", () => {
+  it("does not tell you to write a case for a topic whose cases are still indexing", async () => {
+    const scoped = test.scoped(await test.newProject("Indexing"));
+    const saved = db;
+    db = scoped;
+    try {
+      for (let i = 0; i < 4; i++) {
+        await classify({ intent: "refund request", angle: SAME });
+      }
+      for (let i = 0; i < 4; i++) {
+        await classify({ intent: "order tracking", angle: UNRELATED });
+      }
+      const created = (await createDataset(db, {
+        name: "indexing",
+        questions: [
+          { main_question: { query: "I want a refund", expectedResults: "expected for I want a refund" }, follow_up_questions: [] },
+          { main_question: { query: "where is my order", expectedResults: "expected for where is my order" }, follow_up_questions: [] },
+        ],
+      })) as { _id: string };
+      // Only the refund case is indexed. Order tracking therefore has no assigned case yet - but
+      // its case exists and is in the queue, so "curate production traces" is wrong advice.
+      await cacheCaseEmbedding(created._id, "I want a refund", SAME);
+
+      const result = await getCoverage(db, { window: "7d", datasetId: created._id });
+      const tracking = result.topics.find(t => t.topic === "order tracking")!;
+      expect(result.caseEmbeddingsPending).toBe(1);
+      expect(tracking.suggestedAction).toContain("still being indexed");
+      expect(tracking.suggestedAction).not.toContain("Curate the production traces");
+    } finally {
+      db = saved;
+    }
+  });
+
+  it("does not report off-map cases when it is only matching labels", async () => {
+    const scoped = test.scoped(await test.newProject("LexicalOffMap"));
+    const saved = db;
+    db = scoped;
+    try {
+      for (let i = 0; i < 4; i++) {
+        await classify({ intent: "refund request", angle: SAME });
+      }
+      // No cached vectors anywhere, so this runs lexically. Jaccard compares a case's words to a
+      // topic LABEL, which most legitimate cases miss - reporting those as dead test weight was
+      // producing dozens of false "delete this test" entries on real data.
+      await createDataset(db, {
+        name: "lexical",
+        questions: [
+          { main_question: { query: "please issue my money back for order 12345", expectedResults: "issues it" }, follow_up_questions: [] },
+        ],
+      });
+      const result = await getCoverage(db, { window: "7d" });
+      expect(result.degraded).toBe(true);
+      expect(result.offMapCases).toHaveLength(0);
+    } finally {
+      db = saved;
+    }
+  });
+
+  // NOTE: this asserts the tail counts at all, NOT that the unrounded-weight fix works. Rounding
+  // to 3dp only zeroes a weight below 0.0005 of traffic, which needs >4000 classified traces to
+  // reproduce - too slow to seed here. The fix is reasoned, not covered at realistic scale.
+  it("keeps a small traffic tail counting toward the headline number", async () => {
+    const scoped = test.scoped(await test.newProject("Tail"));
+    const saved = db;
+    db = scoped;
+    try {
+      // One dominant topic plus an uncovered tail.
+      for (let i = 0; i < 60; i++) {
+        await classify({ intent: "refund request", angle: SAME });
+      }
+      for (let i = 0; i < 2; i++) {
+        await classify({ intent: "vpn issue", angle: UNRELATED });
+      }
+      const dsId = await newDataset("tail", [{ query: "I want a refund", angle: SAME }]);
+      const result = await getCoverage(db, { window: "7d", datasetId: dsId });
+      // The uncovered tail must hold the number below a clean 1.
+      expect(result.trafficWeightedCoverage).toBeLessThan(1);
+      expect(result.trafficWeightedCoverage).toBeGreaterThan(0.9);
+    } finally {
+      db = saved;
+    }
+  });
+});
+
 describe("the probe", () => {
   let datasetId: string;
 

--- a/engine/src/test/insights.integration.test.ts
+++ b/engine/src/test/insights.integration.test.ts
@@ -1,0 +1,318 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { nanoid } from "nanoid";
+import { openTestDb, type TestDb } from "./dbHarness.js";
+import type { Db } from "../storage/db.js";
+import { getCoverage } from "../core/insights/coverage.js";
+import { probe, probeBatch } from "../core/insights/probe.js";
+import { caseKeyFor } from "../core/insights/cases.js";
+import { createDataset } from "../core/evaluate/datasets.js";
+import { SIMILARITY_BANDS } from "../core/evaluate/curation.js";
+
+// Coverage and the probe are pure functions of two tables nobody can populate through a route in
+// a test: classifying a trace needs an LLM key, and so does embedding a case. Both are driven
+// directly here, with EMBEDDINGS INJECTED rather than computed - deterministic vectors on a unit
+// circle, whose cosines are exactly cos(angle difference), so every assertion about a band
+// boundary is arithmetic rather than a guess about what an embedding model will do that day.
+
+// The one seam these tests need: probing embeds the QUERY, which is the only vector that cannot
+// be pre-seeded into the cache the way case embeddings can. Registered text returns its injected
+// vector; anything unregistered returns null, which is precisely what a missing OPENAI_API_KEY
+// does - so the degraded lexical path stays exercised rather than mocked away.
+const { registered } = vi.hoisted(() => ({ registered: new Map<string, number[]>() }));
+
+vi.mock("../core/evaluate/judge.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../core/evaluate/judge.js")>();
+  return { ...actual, computeEmbedding: async (text: string) => registered.get(text.trim()) ?? null };
+});
+
+let test: TestDb;
+let db: Db;
+
+// A unit vector at `angle` radians, padded into a 4-dimensional space so nothing depends on
+// dimensionality. cosine(unit(a), unit(b)) === cos(a - b).
+const unit = (angle: number): number[] => [Math.cos(angle), Math.sin(angle), 0, 0];
+
+/** Makes `text` embeddable by the mocked embedder above, at the given angle. */
+const registerQuery = (text: string, angle: number): void => {
+  registered.set(text, unit(angle));
+};
+
+// Angles chosen against the real calibration: 0 vs 0.35 rad is cos ~= 0.94 (covered, >= 0.75),
+// 0 vs 1.0 rad is cos ~= 0.54 (adjacent, between 0.56 and 0.75 after clamping - see the explicit
+// assertions below), 0 vs 1.4 rad is cos ~= 0.17 (nothing in common).
+const SAME = 0;
+const NEAR = 0.35;
+const UNRELATED = 1.4;
+
+async function insertRow(handle: Db, table: unknown, values: Record<string, unknown>): Promise<void> {
+  if (handle.kind === "sqlite") {
+    await handle.db.insert(table as Parameters<typeof handle.db.insert>[0]).values(values as never);
+  } else {
+    await handle.db.insert(table as Parameters<typeof handle.db.insert>[0]).values(values as never);
+  }
+}
+
+async function classify(opts: {
+  intent: string;
+  angle: number;
+  sessionId?: string | null;
+  issueType?: string;
+  sentiment?: string;
+}): Promise<void> {
+  const traceId = nanoid();
+  await insertRow(db, db.schema.traces, {
+    id: traceId,
+    name: "insights-agent",
+    input: "q",
+    output: "a",
+    error: null,
+    latencyMs: 10,
+    framework: null,
+    model: null,
+    toolCalls: null,
+    metadata: null,
+    sessionId: opts.sessionId ?? null,
+    performanceSummary: null,
+    inputTokens: null,
+    outputTokens: null,
+    cacheReadTokens: null,
+    cacheWriteTokens: null,
+    spanKind: null,
+    source: null,
+    spanId: null,
+    parentSpanId: null,
+    startedAt: null,
+    createdAt: new Date(),
+    agentId: null,
+    projectId: db.projectId,
+  });
+  await insertRow(db, db.schema.monitorClassifications, {
+    id: nanoid(),
+    traceId,
+    agentId: null,
+    intent: opts.intent,
+    sentiment: opts.sentiment ?? "neutral",
+    issueType: opts.issueType ?? "none",
+    createdAt: new Date(),
+    projectId: db.projectId,
+    embedding: unit(opts.angle),
+  });
+}
+
+// Pre-seeds the embedding cache so nothing in these tests calls out to an embeddings API. This is
+// exactly the row attachCaseEmbeddings would have written.
+async function cacheCaseEmbedding(datasetId: string, query: string, angle: number): Promise<void> {
+  await insertRow(db, db.schema.insightCaseEmbeddings, {
+    id: nanoid(),
+    projectId: db.projectId,
+    datasetId,
+    caseKey: caseKeyFor(query),
+    query,
+    embedding: unit(angle),
+    model: "test-injected",
+    createdAt: new Date(),
+  });
+}
+
+async function newDataset(name: string, queries: { query: string; angle: number }[]): Promise<string> {
+  const created = (await createDataset(db, {
+    name,
+    questions: queries.map(q => ({
+      main_question: { query: q.query, expectedResults: `expected for ${q.query}` },
+      follow_up_questions: [],
+    })),
+  })) as { _id: string };
+  for (const q of queries) {
+    await cacheCaseEmbedding(created._id, q.query, q.angle);
+  }
+  return created._id;
+}
+
+beforeAll(async () => {
+  test = await openTestDb();
+  db = test.scoped(await test.newProject("Insights"));
+}, 60_000);
+
+afterAll(async () => {
+  await test?.close();
+});
+
+describe("the similarity calibration is shared, not copied", () => {
+  it("uses the same threshold coverage claims and dedupe rejection are built on", () => {
+    // The property the feature is sold on: "covered" means addCaseToDataset would reject the
+    // query as a duplicate. If these ever diverge, one of the two is lying to the user.
+    expect(SIMILARITY_BANDS.covered).toBe(0.75);
+    expect(SIMILARITY_BANDS.related).toBeLessThan(SIMILARITY_BANDS.covered);
+  });
+});
+
+describe("coverage over production topics", () => {
+  let datasetId: string;
+
+  beforeAll(async () => {
+    // "password reset": lots of traffic, and a case sitting right on it.
+    for (let i = 0; i < 8; i++) {
+      await classify({ intent: "password reset", angle: SAME, sessionId: `sess-${i}` });
+    }
+    // "account closure": real traffic, failing, and nothing near it in any dataset.
+    for (let i = 0; i < 4; i++) {
+      await classify({ intent: "account closure", angle: UNRELATED, sessionId: `close-${i}`, issueType: "refusal", sentiment: "negative" });
+    }
+    datasetId = await newDataset("suite", [
+      { query: "how do I reset my password", angle: SAME },
+      { query: "reset password link expired", angle: NEAR },
+    ]);
+  });
+
+  it("reports a covered topic and a missing one, and ranks by traffic", async () => {
+    const result = await getCoverage(db, { window: "7d", datasetId });
+    expect(result.insufficientData).toBe(false);
+    expect(result.degraded).toBe(false);
+
+    const topics = Object.fromEntries(result.topics.map(t => [t.topic, t]));
+    expect(topics["password reset"]!.state).toBe("covered");
+    expect(topics["password reset"]!.caseCount).toBe(2);
+    // Its target is higher than the two cases it has, and it is still covered: depth, not count,
+    // is what the verdict is made of. The target is guidance for what to write next.
+    expect(topics["password reset"]!.targetCases).toBeGreaterThan(2);
+    expect(topics["account closure"]!.state).toBe("missing");
+    expect(topics["account closure"]!.caseCount).toBe(0);
+    expect(topics["account closure"]!.coverage).toBe(0);
+    // Busiest topic first - the detail panel reads top-down.
+    expect(result.topics[0]!.topic).toBe("password reset");
+  });
+
+  it("counts unique sessions, not raw request volume", async () => {
+    const result = await getCoverage(db, { window: "7d", datasetId });
+    const reset = result.topics.find(t => t.topic === "password reset")!;
+    // 8 traces, 8 distinct session ids. The retry-loop case is the next test.
+    expect(reset.traceCount).toBe(8);
+    expect(reset.uniqueSessions).toBe(8);
+  });
+
+  it("weights risk toward observed issues rather than sentiment alone", async () => {
+    const result = await getCoverage(db, { window: "7d", datasetId });
+    const closure = result.topics.find(t => t.topic === "account closure")!;
+    expect(closure.riskComponents.issueRate).toBe(1);
+    expect(closure.riskComponents.negativeSentimentRate).toBe(1);
+    expect(closure.risk).toBeGreaterThan(0.9);
+    // A failing, untested topic must drag the risk-weighted number below the traffic-weighted
+    // one. That gap is the headline finding - "you test what is common, not what is dangerous".
+    expect(result.riskWeightedCoverage).toBeLessThan(result.trafficWeightedCoverage);
+  });
+
+  it("does not let duplicate cases inflate coverage", async () => {
+    const before = (await getCoverage(db, { window: "7d", datasetId })).topics.find(t => t.topic === "password reset")!;
+    const padded = await newDataset(
+      "padded",
+      // Six near-identical cases, all sitting on the same point as the traffic. A count-based
+      // metric would read this as far better covered than the two-case dataset; the
+      // facility-location value is already satisfied, so it must not.
+      Array.from({ length: 6 }, (_, i) => ({ query: `please reset my password variant ${i}`, angle: SAME }))
+    );
+    const after = (await getCoverage(db, { window: "7d", datasetId: padded })).topics.find(t => t.topic === "password reset")!;
+    expect(after.caseCount).toBe(6);
+    // Three times the cases, not one point of extra coverage - the max-similarity term was
+    // already satisfied by the first one.
+    expect(after.coverage).toBeLessThanOrEqual(before.coverage + 0.001);
+  });
+
+  it("scales the target with traffic and risk instead of using a flat number", async () => {
+    const result = await getCoverage(db, { window: "7d", datasetId });
+    const reset = result.topics.find(t => t.topic === "password reset")!;
+    const closure = result.topics.find(t => t.topic === "account closure")!;
+    expect(reset.targetCases).toBeGreaterThan(2);
+    // Lower traffic but far higher risk, so its target is not simply proportional to volume.
+    expect(closure.targetCases).toBeGreaterThan(2);
+  });
+
+  it("reports an honesty delta between case presence and real depth", async () => {
+    const result = await getCoverage(db, { window: "7d", datasetId });
+    expect(result.presenceCoverage).toBeGreaterThanOrEqual(result.trafficWeightedCoverage);
+    expect(result.honestyDelta).toBeCloseTo(result.presenceCoverage - result.trafficWeightedCoverage, 3);
+  });
+
+  it("flags cases that match no production topic as off-map", async () => {
+    const orphan = await newDataset("orphan", [{ query: "can I pay in martian dollars", angle: 2.6 }]);
+    const result = await getCoverage(db, { window: "7d", datasetId: orphan });
+    expect(result.offMapCases).toHaveLength(1);
+    expect(result.offMapCases[0]!.query).toBe("can I pay in martian dollars");
+  });
+});
+
+describe("the probe", () => {
+  let datasetId: string;
+
+  beforeAll(async () => {
+    datasetId = await newDataset("probe-suite", [{ query: "how do I reset my password", angle: SAME }]);
+    registerQuery("I need to reset my password", NEAR);
+    registerQuery("how do I reset my password", SAME);
+    registerQuery("close my account", UNRELATED);
+    registerQuery("unrelated to anything on file", 2.9);
+    registerQuery("something with no bearing on this suite", 2.9);
+    // cos(0.75) ~= 0.73: inside the related band, below the covered one. The case that must not
+    // be reported as tested.
+    registerQuery("my password reset link expired, what now", 0.75);
+  });
+
+  it("calls a paraphrase covered, and names the case it matched", async () => {
+    const result = await probe(db, { query: "I need to reset my password", datasetId, window: "7d" });
+    expect(result.verdict).toBe("covered");
+    expect(result.similarity).toBeGreaterThanOrEqual(SIMILARITY_BANDS.covered);
+    expect(result.nearestCases[0]!.query).toBe("how do I reset my password");
+    // Never a bare score: the expected answer comes back so a human can see whether the case
+    // actually asserts what they meant.
+    expect(result.nearestCases[0]!.expectedResults).toContain("expected for");
+  });
+
+  it("distinguishes a real gap from a question nobody asks", async () => {
+    // Both are uncovered. Only one is a gap - and conflating them is what would send a team
+    // writing tests for traffic that does not exist.
+    const real = await probe(db, { query: "close my account", datasetId, window: "7d" });
+    expect(real.verdict).toBe("gap");
+    expect(real.topic!.topic).toBe("account closure");
+    expect(real.explanation).toContain("real gap");
+
+    const hypothetical = await probe(db, { query: "unrelated to anything on file", datasetId, window: "7d" });
+    expect(hypothetical.verdict).toBe("untested-and-unasked");
+    expect(hypothetical.topic).toBeNull();
+    expect(hypothetical.explanation).toContain("not a gap");
+  });
+
+  it("refuses to call a related-but-distinct question covered", async () => {
+    const result = await probe(db, { query: "my password reset link expired, what now", datasetId, window: "7d" });
+    expect(result.verdict).toBe("adjacent");
+    expect(result.similarity).toBeGreaterThanOrEqual(SIMILARITY_BANDS.related);
+    expect(result.similarity).toBeLessThan(SIMILARITY_BANDS.covered);
+    // The wording has to say the existing case will not catch this, or a reader sees a high-ish
+    // number next to a familiar case and assumes they are covered.
+    expect(result.explanation).toContain("not this");
+  });
+
+  it("degrades to lexical matching, and says so, when the query cannot be embedded", async () => {
+    // Never registered, so the mocked embedder returns null exactly as a missing OPENAI_API_KEY
+    // would. The verdict still comes back - on a different, clearly-labelled scale.
+    const result = await probe(db, { query: "reset password", datasetId, window: "7d" });
+    expect(result.degraded).toBe(true);
+    expect(result.bands.covered).toBeLessThan(SIMILARITY_BANDS.covered);
+    expect(result.nearestCases.length).toBeGreaterThan(0);
+  });
+
+  it("returns the bands it judged with, so a raw score is never shown alone", async () => {
+    const result = await probe(db, { query: "how do I reset my password", datasetId, window: "7d" });
+    expect(result.bands).toEqual({ covered: SIMILARITY_BANDS.covered, related: SIMILARITY_BANDS.related });
+  });
+
+  it("rolls a batch up into a pre-launch verdict", async () => {
+    const result = await probeBatch(db, {
+      queries: ["how do I reset my password", "close my account", "  ", "something with no bearing on this suite"],
+      datasetId,
+      window: "7d",
+    });
+    // The blank line is dropped rather than probed.
+    expect(result.rollup.total).toBe(3);
+    expect(result.rollup.covered).toBe(1);
+    expect(result.rollup.gap).toBe(1);
+    expect(result.rollup.untestedAndUnasked).toBe(1);
+  });
+});

--- a/engine/src/test/insights.integration.test.ts
+++ b/engine/src/test/insights.integration.test.ts
@@ -22,7 +22,8 @@ const { registered } = vi.hoisted(() => ({ registered: new Map<string, number[]>
 
 vi.mock("../core/evaluate/judge.js", async importOriginal => {
   const actual = await importOriginal<typeof import("../core/evaluate/judge.js")>();
-  return { ...actual, computeEmbedding: async (text: string) => registered.get(text.trim()) ?? null };
+  const one = (text: string): number[] | null => registered.get(text.trim()) ?? null;
+  return { ...actual, computeEmbedding: async (text: string) => one(text), computeEmbeddings: async (texts: string[]) => texts.map(one) };
 });
 
 let test: TestDb;

--- a/engine/src/test/insights.integration.test.ts
+++ b/engine/src/test/insights.integration.test.ts
@@ -240,6 +240,42 @@ describe("coverage over production topics", () => {
   });
 });
 
+describe("synonymous intent labels", () => {
+  it("merges labels the classifier phrased differently, and keeps related-but-distinct ones apart", async () => {
+    const db2 = test.scoped(await test.newProject("Merge"));
+    const saved = db;
+    db = db2;
+    try {
+      // Same angle = same centroid: the classifier coined two labels for one topic. Measured on
+      // real traffic these land at ~0.90, well above the merge threshold.
+      for (let i = 0; i < 5; i++) {
+        await classify({ intent: "refund request", angle: SAME });
+        await classify({ intent: "request a refund", angle: SAME + 0.05 });
+      }
+      // Related but genuinely different - cos(0.55) ~= 0.85, just under the threshold, which is
+      // the case the calibration exists to protect ("order tracking" vs "missing package").
+      for (let i = 0; i < 5; i++) {
+        await classify({ intent: "dispute a charge", angle: 0.55 });
+      }
+      const dsId = await newDataset("merge-suite", [{ query: "I want a refund", angle: SAME }]);
+      const result = await getCoverage(db, { window: "7d", datasetId: dsId });
+
+      const labels = result.topics.map(t => t.topic);
+      expect(labels).toContain("refund request");
+      // Merged away, not reported as its own missing topic - the bug this exists to prevent.
+      expect(labels).not.toContain("request a refund");
+      const refunds = result.topics.find(t => t.topic === "refund request")!;
+      expect(refunds.aliases).toContain("request a refund");
+      expect(refunds.traceCount).toBe(10);
+
+      // Still its own topic: merging it would hide a genuinely different question.
+      expect(labels).toContain("dispute a charge");
+    } finally {
+      db = saved;
+    }
+  });
+});
+
 describe("the probe", () => {
   let datasetId: string;
 

--- a/engine/src/test/insights.integration.test.ts
+++ b/engine/src/test/insights.integration.test.ts
@@ -420,6 +420,72 @@ describe("provisional results do not read as verdicts", () => {
   });
 });
 
+describe("telling someone what to do first", () => {
+  it("ranks a dangerous rarely-asked gap above a harmless common one", async () => {
+    const scoped = test.scoped(await test.newProject("Priority"));
+    const saved = db;
+    db = scoped;
+    try {
+      // Proportions taken from a real install: the busiest topic runs ~21% of traffic and the
+      // dangerous one ~10%. Common and harmless, untested:
+      for (let i = 0; i < 21; i++) {
+        await classify({ intent: "general greeting", angle: SAME });
+      }
+      // Half its traffic, but failing. Sorting by traffic alone buries it - and it is exactly the
+      // case the headline traffic-vs-risk gap exists to surface.
+      for (let i = 0; i < 10; i++) {
+        await classify({ intent: "account closure", angle: UNRELATED, issueType: "refusal", sentiment: "negative" });
+      }
+      const result = await getCoverage(db, { window: "7d", datasetId: await newDataset("empty-ish", [{ query: "unrelated", angle: 2.6 }]) });
+
+      const greeting = result.topics.find(t => t.topic === "general greeting")!;
+      const closure = result.topics.find(t => t.topic === "account closure")!;
+      expect(greeting.trafficShare).toBeGreaterThan(closure.trafficShare);
+      expect(closure.priority).toBeGreaterThan(greeting.priority);
+    } finally {
+      db = saved;
+    }
+  });
+
+  it("gives a topic nobody asks about no priority, however dangerous it looks", async () => {
+    const scoped = test.scoped(await test.newProject("RareRisk"));
+    const saved = db;
+    db = scoped;
+    try {
+      for (let i = 0; i < 200; i++) {
+        await classify({ intent: "order tracking", angle: SAME });
+      }
+      // 2 traces in 202. Failing, untested - and still not where the next hour goes.
+      for (let i = 0; i < 2; i++) {
+        await classify({ intent: "exotic edge case", angle: UNRELATED, issueType: "refusal", sentiment: "negative" });
+      }
+      const result = await getCoverage(db, { window: "7d", datasetId: await newDataset("none", [{ query: "unrelated", angle: 2.6 }]) });
+      const tracking = result.topics.find(t => t.topic === "order tracking")!;
+      const exotic = result.topics.find(t => t.topic === "exotic edge case")!;
+      expect(tracking.priority).toBeGreaterThan(exotic.priority);
+    } finally {
+      db = saved;
+    }
+  });
+
+  it("gives a covered topic no priority, however busy it is", async () => {
+    const result = await getCoverage(db, { window: "7d", datasetId: await newDataset("covered", [{ query: "how do I reset my password", angle: SAME }]) });
+    for (const t of result.topics.filter(t => t.state === "covered")) {
+      expect(t.priority).toBeLessThan(0.05);
+    }
+  });
+
+  it("names the datasets the number was computed over", async () => {
+    const dsId = await newDataset("named-suite", [{ query: "how do I reset my password", angle: SAME }]);
+    const result = await getCoverage(db, { window: "7d", datasetId: dsId });
+    // A project-wide figure silently mixes every dataset in the project; without this nobody can
+    // tell whether a gap belongs to the suite they care about.
+    expect(result.datasets.map(d => d.id)).toEqual([dsId]);
+    expect(result.datasets[0]!.name).toBe("named-suite");
+    expect(result.datasets[0]!.caseCount).toBe(1);
+  });
+});
+
 describe("the probe", () => {
   let datasetId: string;
 

--- a/engine/src/test/projectSettings.integration.test.ts
+++ b/engine/src/test/projectSettings.integration.test.ts
@@ -104,11 +104,18 @@ describe("project monitoring settings", () => {
     });
     expect(updated.status, JSON.stringify(updated.body)).toBeLessThan(300);
 
+    // Asserted on the FIELD, not a substring of the serialized body: the response carries the
+    // project's randomly generated apiKey, and a key containing "1234" anywhere in its hex failed
+    // this as a settings leak. Seen in CI - agtx_local_...a8ec1234e5a5... - roughly 1 run in 1600.
+    type SettingsBody = { monitoringDefaults: { latencyThresholdMs: number } };
     const afterA = await engine.json("/api/v1/agent-monitoring/settings", { apiKey: a.apiKey });
-    expect(JSON.stringify(afterA.body)).toContain("1234");
+    expect((afterA.body as SettingsBody).monitoringDefaults.latencyThresholdMs).toBe(1234);
 
     const afterB = await engine.json("/api/v1/agent-monitoring/settings", { apiKey: b.apiKey });
-    expect(JSON.stringify(afterB.body), "one project's settings leaked into another").not.toContain("1234");
+    expect(
+      (afterB.body as SettingsBody).monitoringDefaults.latencyThresholdMs,
+      "one project's settings leaked into another"
+    ).not.toBe(1234);
   });
 
   it("reports latency as a KPI metric from the traces themselves - no scorer involved", async () => {


### PR DESCRIPTION
> **Note:** this PR opened as a docs-only change (the plan document) and its description said so. The branch has since grown the whole implementation, engine side. Rewritten below to describe what it actually contains.

## What this changes, and why

Topics knew what production was asked about and Evaluate knew what the datasets tested, and the two had never been introduced. Nobody could answer "does our suite look anything like our traffic?", so dataset quality was a feeling. This adds the join.

**`GET /insights/coverage`** groups the window's `monitor_classifications` by intent, assigns every dataset case to a topic, and reports traffic-weighted coverage, topic breadth, and risk-weighted coverage. The gap between the first and third is the finding worth having — it says you test what is common rather than what is dangerous.

**Coverage is a facility-location value, not a case count.** The average, over the topic's real traces, of the best similarity any assigned case reaches to that trace. A duplicate adds nothing because the maximum is already satisfied, so the anti-gaming property falls out of the formula rather than needing a rule. This matters because the whole point of finding gaps is to then generate cases, and any count-based number is inflated by generating near-copies of one you already have.

That distinction was not theoretical. The first implementation took `min(countRatio, depth)`, which reads plausibly and quietly reintroduces the flaw — the duplicate-inflation test failed with `expected 0.857 to be less than or equal to 0.287`. The count term was doing the talking. `targetCases` (scaled by traffic and observed risk, `sqrt` on traffic so a topic carrying 40% of requests does not demand 40% of the test budget) survives as guidance for what to write next, and becomes the measure only where there is no geometry to measure depth with.

**Per-topic `priority`, so the response says which gap to work first.** Sorting by traffic alone leaves the reader doing the traffic-vs-risk arithmetic this feature exists to do for them — on real data the traffic-ordered list leads with a topic at 21% of traffic that is *already covered*, while the highest-value job is `Order tracking`: 12.7% of traffic, 48% of it failing, zero cases. `priority = (1 - coverage) * trafficShare * (1 + 3 * risk)`. Risk **amplifies** exposure rather than substituting for it: adding them would rank a 0.1%-of-traffic topic above a 20% one, and a topic nobody asks is worth nothing to test however dangerous it sounds. The first attempt used addition and a test caught it.

**The response names the datasets it was computed over.** The endpoint always accepted `datasetId`, but a project-wide figure silently mixes every dataset in the project — 49 on the install this was checked against — and no gap could be traced to the suite it belongs to. Now the caller can see what went in, and the dashboard can filter.

**`POST /insights/probe`** is the inverse lookup and the cheap half: one embedding for the query, cosine against the cached case embeddings, no LLM in the verdict path. `POST /insights/probe/batch` takes a pasted list — a launch spec, a support macro export — which is the only answer here to the cold-start problem, since the topic map only knows traffic that has already happened.

Its bands are not new constants. `SIMILARITY_BANDS` is exported from `core/evaluate/curation.ts`, which already carries the measured calibration for `text-embedding-3-small`, so the probe's "covered" verdict is *defined* as "`addCaseToDataset` would reject this query as a duplicate" and the two features cannot drift apart.

The probe answers two questions rather than one, deliberately. "Is it tested?" is useless without "does anyone ask it?", because a query with no coverage **and** no traffic is not a hole in the suite, and reporting it as one would send a team writing tests for traffic that does not exist. That case gets its own verdict (`untested-and-unasked`). Likewise the nearest case's `expectedResults` always comes back beside the score: query similarity measures topical resemblance, not that the case asserts the same behaviour.

**Two embeddings per case**, because there are two comparisons in two different spaces: `embedding` (the query alone, compared against a typed query by the probe) and `embedding_full` (query + expected result, compared against TRACE embeddings, which `monitor/topics.ts` builds from `input + output`). Scoring one against the other is a cross-space comparison that reads systematically low — cases fall off the map and covered topics report missing.

**Topic merging, pulled forward from a later phase.** Running against a real install made this non-optional. That install carried both `Refund request` (7 cases, covered) and `Request a refund` (0 cases, **missing**) — one topic reported twice, half of it inventing a gap that did not exist, its traffic share split between the two. Same for `Reset Password` / `Reset forgotten password`. `mergeSynonymousTopics` merges intent labels whose trace centroids are close, using embeddings **already stored** on `monitor_classifications`, so it needs no new API calls and works with no LLM key at all.

The 0.87 threshold is deliberately not curation.ts's 0.75 — that one compares two query strings, this compares centroids of averaged input+output embeddings, which run much higher. Measured on that install:

| pair | cosine | verdict |
|---|---|---|
| refund request / request a refund | 0.909 | must merge |
| reset password / reset forgotten password | 0.902 | must merge |
| order tracking / missing package | 0.822 | must **not** |
| refund policy inquiry / request a refund | 0.813 | must **not** |

0.87 splits those with ~0.05 either side; 0.75 would have merged questions with different correct answers. Candidates compare against the seed centroid, not the growing one, so pairwise-similar chains cannot collect into one blob.

**The window defaults to 30d** where the monitoring surfaces default to 7d. Those are about recent health; this is accumulated test debt measured against a *sampled* classifier, and on that install every classified trace was older than seven days — the screen read "nothing classified yet" while the 30d window was full.

**Nothing here writes a dataset.** Gaps are reported; cases still land through the existing preview → human review → append path, which is what keeps a coverage number from being inflated by rows nobody looked at.

Everything degrades rather than failing: without an embeddings key both fall back to Jaccard over content words, on their own thresholds, with `degraded: true` and a reason on every response.

Also included: `docs/insights-topic-coverage-plan.md`, the design document this was built from, reconciled with what actually shipped.

The dashboard side is [AgentX-eval-front#31](https://github.com/AgentX-ai/AgentX-eval-front/pull/31), same branch name. This one should merge first — that tab reads endpoints that do not exist without it.

## Review rounds

Three review passes landed after the first implementation, plus a pass asking what a developer and a buyer would actually do with the screen. Recorded because several changed behaviour, not just structure:

**Round 1** — seven findings, three of which compounded to push the headline number toward zero on a real install, all masked by a test harness that injected vectors into one shared space: the cross-space embedding bug above; unembedded cases (60/request cap) reported as dead test weight, so first load of a 200-case dataset flagged 140 good tests; transient embedding failures cached as permanent nulls, so adding a key later never recovered them; `SIMILARITY_BANDS.related` set to the *ceiling* of the measured related band rather than its floor; coverage basis claimed globally when it varies per topic; `riskWeightedCoverage` reporting 0 for a healthy install, indistinguishable from testing nothing; and the probe missing the `MIN_TRACES_PER_TOPIC` floor, so one stray classification fabricated a gap.

**Round 2** — reviewing those fixes: the empty-case shortcut ran before the regime check, labelling an uncovered topic "depth" on a run that measured none; the probe's traffic-share denominator disagreed with the sweep's, so one topic reported two different shares depending on the screen.

**Round 3** — an incomplete fix from round 1. Excluding unembedded cases from off-map stopped them reading as dead weight, but they still counted toward no topic, so a topic whose only cases were queued reported "missing" with the advice *"curate the production traces in this topic"* — telling someone to write a case that already exists. Also: off-map is no longer reported at all under lexical matching (it produced 84 false "dead test weight" entries on real data — an artifact of the fallback, not a finding), the headline numbers now weight off unrounded values, and `deleteDataset` cleans up its cached embeddings, which nothing previously deleted.

**Usefulness pass** — produced `priority` and the dataset provenance above, and found the upgrade bug below.

## An upgrade bug worth calling out

Adding `embedding_full` to the `CREATE TABLE IF NOT EXISTS` block does nothing on an install that already has the table, so every existing install 500s on `GET /insights/coverage` with `no such column: embedding_full`. It is now an additive column migration in both dialects, which is what that mechanism is for.

CI could not catch this — CI always starts from an empty database. It took running the engine against a database that already existed.

## How it was verified

**Unit** — `src/test/insights.integration.test.ts` (26 tests) drives the core against a real database with embeddings **injected** rather than computed: unit vectors at chosen angles, whose cosines are exactly `cos(Δangle)`, so every band-boundary assertion is arithmetic instead of a guess about what an embedding model returns today.

Every behavioural fix from the review rounds is **checked both ways** — the test fails against the unfixed code and passes against the fix. That was done for duplicate inflation, unembedded-case handling, the null risk-weighted number, the probe's topic floor, pending-aware advice, and lexical off-map suppression.

**Contract** — `src/test/contract.integration.test.ts` drives the three new endpoints live against the real engine, including the empty state, which is the common first view of this screen since Topics is opt-in and sampled.

**Postgres** — CI's `engine on Postgres` job passes, exercising the new table and its added column on the real dialect.

**Against real data** — booted the engine against a real install's database (340 classified traces, 54 datasets). The probe returns a real gap for "I want to cancel my subscription today" (naming the `Cancel subscription` topic at 11% of traffic) while returning not-covered-and-not-asked for "can I pay my invoice in martian dollars". The merging, the window default, the priority ranking and the upgrade bug all came out of those runs, not the test suite.

**Full suite** — 659 passed, 37 skipped. `yarn typecheck` and `yarn lint` clean.

### Not verified

- **The non-degraded similarity path end-to-end.** No `OPENAI_API_KEY` was available, so the real-data runs exercised the labelled lexical fallback throughout. The cosine path is covered by the injected-embedding unit tests but has not been run against a live embeddings API — and since the cross-space bug was fixed after those runs, the real-data figures quoted here were produced by the fallback, not the corrected cosine path.
- **The unrounded-weighting fix.** Correct by reasoning, but not covered by a discriminating test: rounding to 3dp only zeroes a weight below 0.0005 of traffic, which needs >4000 classified traces to reproduce. The test that would have implied otherwise is labelled with what it actually checks.

## Also in this branch, unrelated to the feature

One commit fixes a pre-existing flaky test that turned this branch's CI red. `projectSettings.integration.test.ts` set `latencyThresholdMs: 1234` on one project, then asserted the *other* project's whole serialized settings body did not contain the substring `"1234"`. That body carries the project's randomly generated API key, and CI drew `agtx_local_5b5a9d5d2987e8d0fbe1acc6a22a5ba8ec1234e5a5c48fe0`. Roughly one run in 1600 by the hex arithmetic, so it would keep recurring on anyone's branch. Now asserted on the field itself. Happy to split it out if you would rather it landed separately.

## Known gaps, deliberately not in this PR

Asking what someone would actually do with this screen turned up three things it does not answer, all larger than a follow-up commit:

- **No trend.** Add six cases and the number moves, but nothing records where it moved from. Snapshotting the three figures per run is the cheapest remaining win.
- **No click-through from a gap to the traces behind it.** The suggested action says "curate the production traces in this topic" and offers no way to reach them — the flywheel is not built.
- **Coverage is per project, not per agent.** Open question #1 in the plan document, still unresolved.

## Checklist

- [x] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [x] `yarn workspace @agentx/engine test` passes
- [x] Changed a response shape covered by `src/contract/wire.ts`? Updated in the same commits — three new entries, plus `aliases`, `coverageBasis`, `priority`, `datasets`, and `riskWeightedCoverage` becoming nullable
- [x] New or changed mutating route? Both probe routes validate with `validateBody(schema)`; they are new, so there was no `routeBodyValidation.test.ts` entry to delete
- [x] Schema change? One new table (`insight_case_embeddings`) created via `CREATE TABLE IF NOT EXISTS` in both dialect bootstraps, **and** its later `embedding_full` column added through `columnMigrations` (sqlite) plus the `ADD COLUMN IF NOT EXISTS` block (pg) — see the upgrade bug above, where relying on the CREATE alone broke every pre-existing install. No existing column or id touched
- [x] New setting? None added