### PR TITLE
Relicense the engine repo from Apache-2.0 to Elastic License 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -964,3 +964,20 @@ pay my invoice in martian dollars" comes back not-covered-and-not-asked rather t
 gap. The nearest-case panel earned its place there: for the cancellation query the closest case is
 about being charged AFTER cancelling, a billing dispute rather than how to cancel, which the
 similarity score alone would never have revealed.
+
+## License change: Apache-2.0 -> Elastic License 2.0
+
+The engine repo moved from Apache-2.0 to the Elastic License 2.0 (ELv2). Rationale: the
+self-host tier exists to let companies adopt Governance commercially and grow into the hosted
+tiers, so blanket noncommercial terms were never on the table - but nothing in Apache-2.0
+prevented a third party from reselling the engine as their own managed service. ELv2 forbids
+exactly that (plus license-key tampering, which matters once enterprise features gate on keys)
+while keeping every internal commercial use free. ELv2 over BSL 1.1 because it is a fixed,
+widely-cleared text with no self-drafted "competitive use" clause to argue about and no
+per-release change-date bookkeeping.
+
+Scope: this repo's future releases only. Previously tagged versions remain Apache-2.0. The
+Python SDK stays permissively licensed (it ships inside customer applications). The vendored
+OpenTelemetry proto schema keeps its upstream Apache-2.0 notice. Applied to LICENSE, the README
+badge and License section, CONTRIBUTING's contribution terms, and the workspace package.json
+license fields (SPDX id `Elastic-2.0`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,5 +77,5 @@ Please do not open a public issue for a vulnerability. See [SECURITY.md](SECURIT
 
 ## License
 
-By contributing you agree that your contributions are licensed under Apache-2.0, matching
+By contributing you agree that your contributions are licensed under the Elastic License 2.0, matching
 [LICENSE](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,190 +1,93 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Elastic License 2.0
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+URL: https://www.elastic.co/licensing/elastic-license
 
-   1. Definitions.
+## Acceptance
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+By using the software, you agree to all of the terms and conditions below.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+## Copyright License
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+## Limitations
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+## Patents
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+## Notices
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+## No Other Rights
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+These terms do not imply any licenses other than those expressly granted in
+these terms.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+## Termination
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+## No Liability
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+## Definitions
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+**you** refers to the individual or entity agreeing to these terms.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
+**control** means ownership of substantially all the assets of an entity, or the
+power to direct its management and policies by vote, contract, or otherwise.
+Control can be direct or indirect.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+**your licenses** are all the licenses granted to you for the software under
+these terms.
 
-   END OF TERMS AND CONDITIONS
+**use** means anything you do with the software requiring one of your licenses.
 
-   Copyright 2026 AgentX
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+**trademark** means trademarks, service marks, and similar rights.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AgentX Trace & Eval
 
 [![Release](https://img.shields.io/github/v/release/AgentX-ai/AgentX-trace-eval)](https://github.com/AgentX-ai/AgentX-trace-eval/releases/latest)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
+[![License](https://img.shields.io/badge/license-Elastic--2.0-blue)](LICENSE)
 
 A portable, self-hostable build of AgentX's Governance layer - **Trace**, **Evaluate**, and
 **Monitor** for AI agents - as a single local install. No account, no multi-tenant billing, bring
@@ -404,4 +404,13 @@ Vulnerabilities go to [SECURITY.md](SECURITY.md), privately, rather than to a pu
 
 ## License
 
-Apache-2.0 (see [LICENSE](LICENSE)).
+[Elastic License 2.0](LICENSE) (ELv2). In practice: use it freely - self-host it at work,
+modify it, embed it in your stack, run it commercially. The only things you may not do are
+offer it to third parties as a hosted/managed service, or tamper with license-key-protected
+functionality. Versions released before this change remain Apache-2.0 under their original
+tags.
+
+The [AgentX Python SDK](https://github.com/AgentX-ai/AgentX-Python) stays permissively
+licensed - restrictions here apply to the engine, never to code embedded in your application.
+The vendored OpenTelemetry proto schema (`engine/src/otel/protoSchema.ts`) remains Apache-2.0
+per its upstream license.

--- a/packages/agentx-eval/package.json
+++ b/packages/agentx-eval/package.json
@@ -2,7 +2,7 @@
   "name": "@agentx/eval",
   "version": "0.1.0",
   "description": "Minimal TypeScript client for the AgentX self-host engine's evaluation CI surface: datasets, runs, batched result submission, finalize, CI gate, and pairwise comparison. Zero runtime dependencies (Node 18+ global fetch).",
-  "license": "Apache-2.0",
+  "license": "Elastic-2.0",
   "private": false,
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/judge-core/package.json
+++ b/packages/judge-core/package.json
@@ -2,7 +2,7 @@
   "name": "@agentx/judge-core",
   "version": "0.1.16",
   "description": "LLM-as-judge prompt template + multi-provider (OpenAI/Anthropic) scoring call, shared between AgentX-web-api and AgentX-trace-eval's engine so the two don't maintain separate copies.",
-  "license": "Apache-2.0",
+  "license": "Elastic-2.0",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
Free for every internal and commercial use, including self-hosting at work; the only prohibitions are offering the software to third parties as a hosted or managed service and circumventing license-key functionality. ELv2 over BSL 1.1: a fixed, widely-cleared text with no self-drafted competitive-use clause and no per-release change-date bookkeeping.

Scope: future releases of this repo only. Previously tagged versions remain Apache-2.0. The Python SDK stays Apache-2.0 (it ships inside customer applications), and the vendored OpenTelemetry proto schema keeps its upstream Apache-2.0 notice. Contributors are on board with the change.

<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
