### PR TITLE
docs: make the CI-check table actually predict CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,18 +32,26 @@ prediction rather than a hopeful one.
 | --- | --- |
 | `yarn typecheck` | strict TypeScript across both workspaces |
 | `yarn workspace @agentx/engine lint` | async discipline the compiler cannot see, see `engine/eslint.config.mjs` |
+| `yarn workspace @agentx/judge-core test` | the shared judge prompt/scoring logic |
 | `yarn workspace @agentx/engine test` | the integration-first suite, on SQLite |
 | `yarn workspace @agentx/engine test:coverage` | the same suite behind the coverage floors |
-| `cd cli && gofmt -l . && go vet ./... && go test -race ./...` | the Go CLI |
+| `yarn workspace @agentx/eval typecheck && yarn workspace @agentx/eval build && yarn workspace @agentx/eval test` | the CI SDK's stub-server pin on the `/custom-agent-evaluations` wire contract |
+| `cd cli && test -z "$(gofmt -l .)" && go vet ./... && go test -race ./...` | the Go CLI |
 | `shellcheck install.sh build.sh scripts/*.sh` | the scripts users pipe into bash |
+
+The `test -z` around gofmt is not decoration: `gofmt -l` names the files it objects to on stdout
+and exits 0 either way, so a bare `gofmt -l . && ...` prints the complaint, runs on, and reports
+success, while the workflow's own emptiness check fails the build. Same check, so the local run
+predicts CI.
 
 CI additionally runs the engine suite a second time against real Postgres and ClickHouse
 services, and smoke tests the `bun build --compile` binary that releases actually ship. To
 reproduce the Postgres run locally, point `AGENTX_TEST_DB_URL` at a superuser connection string
 (and `AGENTX_TEST_CLICKHOUSE_URL` at a ClickHouse server for the telemetry-store suites); the
 suites create and drop their own throwaway databases, and skip entirely when the variables are
-unset. CI's typecheck also covers the `@agentx/eval` workspace, which the root `yarn typecheck`
-does not.
+unset. The root `yarn typecheck` and `yarn test` both skip the `@agentx/eval` workspace, which is
+why its row above spells the three commands out: they are the only local cover a change under
+`packages/agentx-eval/` gets before CI runs them.
 
 ## Tests
 


### PR DESCRIPTION
CONTRIBUTING promises "the same commands the workflow runs, so a local pass is a real prediction rather than a hopeful one". Three ways it wasn't.

- The gofmt chain could not fail. `gofmt -l` names offending files on stdout and exits 0 either way, so `cd cli && gofmt -l . && go vet ./... && go test -race ./...` prints the complaint, runs straight on, and reports success; the workflow's Format step wraps the same call in an explicit emptiness check and fails the build. A contributor following this file saw green locally and red in CI, on the one check whose whole appeal is that it costs nothing. Now `test -z "$(gofmt -l .)"`, which is the workflow's check. Verified both directions: with a deliberately unformatted file in cli/, the old chain exits 0 and the new one exits 1; on the tree as it stands the new chain passes.

- `yarn workspace @agentx/judge-core test` was missing. Root `yarn test` runs it, but this table never sends you to root `yarn test`, so following the table alone skipped judge-core's 37 cases.

- The @agentx/eval workspace was a footnote saying CI typechecks it. CI also builds and tests it, and the root `yarn typecheck` and `yarn test` skip it entirely, so a change under packages/agentx-eval/ had no local cover at all. Its three commands now have a row, spelled out rather than folded into a root script that does not include them.

Documentation only, no behaviour change. Every row verified by running it on a clean checkout: judge-core 37 passed, @agentx/eval typecheck + build + 15 passed, and the Go chain green across cli/ and cli/cmd under -race.


Claude-Session: https://claude.ai/code/session_01A1ofMuxFZrPeVM9ULnakFE

<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
