### PR TITLE
group scorer bug fix

### DIFF
--- a/engine/src/core/evaluate/playground.ts
+++ b/engine/src/core/evaluate/playground.ts
@@ -135,6 +135,10 @@ export type PlaygroundRunInput = {
   // own rubric/judge model. Unlike the primary judge these are not gated on `expected` - with no
   // reference the judge simply scores reference-free, same as the online dry-runs.
   additionalScorerIds?: string[];
+  // Grade the cell with a Scorer group instead of judgeCriteria: the group's 0-10 aggregate
+  // fills `rating`, member verdicts land in judgeScorerResults/codeScorerResults - the same
+  // contract group-graded dataset runs have (runs.ts). Wins over judgeCriteria when both come.
+  scorerGroupId?: string;
   // Per-model overrides from Playground's "Model settings" - see callModelWithTools's `options`
   // param. Both omitted preserves today's exact defaults.
   maxTokens?: number;
@@ -358,9 +362,41 @@ export async function runPlayground(db: Db, input: PlaygroundRunInput): Promise<
 
     let rating: number | null = null;
     let justification: string | null = null;
+    let groupMemberJudges: PlaygroundJudgeScorerResult[] | undefined;
+    let groupMemberChecks: CodeScorerResult[] | undefined;
+    if (input.scorerGroupId) {
+      // Group grading: the group IS the recipe - judgeCriteria is not consulted, and unlike the
+      // primary judge below the group is NOT gated on `expected` (patterns/code members and
+      // reference-free judges all score without one, same as live scoring).
+      const { getScorerGroup, computeGroupScore, describeGroupScore } = await import("../monitor/scorerGroups.js");
+      const group = await getScorerGroup(db, input.scorerGroupId);
+      if (group) {
+        const groupResult = await computeGroupScore(db, group, {
+          input: input.query,
+          output: completion.text,
+          expected: input.expected,
+          toolCalls: completion.toolCalls.length > 0 ? completion.toolCalls : undefined,
+        });
+        rating = groupResult.score;
+        justification = describeGroupScore(groupResult, groupResult.members);
+        groupMemberJudges = groupResult.members
+          .filter(m => m.kind === "judge")
+          .map(m => ({
+            scorerId: m.refId,
+            name: m.name,
+            rating: m.goodness === null ? null : Math.round(m.goodness * 100) / 10,
+            justification: m.error ?? m.detail,
+          }));
+        groupMemberChecks = groupResult.members
+          .filter(m => m.kind !== "judge")
+          .map(m => ({ name: m.name, score: m.goodness, reasoning: m.error ? undefined : m.detail, error: m.error }));
+      } else {
+        justification = "Scorer group no longer exists.";
+      }
+    }
     // Only score when there's a ground truth to compare against - a question with no
     // expectedResults still runs and shows output, it just never blocks on a judge call.
-    if (input.expected) {
+    if (!input.scorerGroupId && input.expected) {
       try {
         const scored = await scoreAgainstCriteria(
           {
@@ -392,7 +428,7 @@ export async function runPlayground(db: Db, input: PlaygroundRunInput): Promise<
       input.onlineEvaluatorIds && input.onlineEvaluatorIds.length > 0
         ? await runPlaygroundOnlineEvaluatorChecks(db, input.onlineEvaluatorIds, { input: input.query, output: completion.text })
         : undefined;
-    const judgeScorerResults =
+    const additionalJudgeResults =
       input.additionalScorerIds && input.additionalScorerIds.length > 0
         ? await runPlaygroundJudgeScorerChecks(db, input.additionalScorerIds, {
             input: input.query,
@@ -401,13 +437,17 @@ export async function runPlayground(db: Db, input: PlaygroundRunInput): Promise<
             judgeGuideline: input.judgeGuideline,
           })
         : undefined;
+    const judgeScorerResults =
+      groupMemberJudges || additionalJudgeResults
+        ? [...(groupMemberJudges ?? []), ...(additionalJudgeResults ?? [])]
+        : undefined;
 
     // Code scorers run AFTER the judges (same ordering as runs.ts's scoreOneResult) so a scorer
     // can read the verdicts via `scores` and combine them into a custom final score. Playground
     // has no similarity metrics, so those slots are null. Not gated on `expected`, and each
     // scorer still isolates its own failure into { score: null, error }.
     const enabledCodeScorers = (input.codeScorers ?? []).filter(s => s.enabled);
-    const codeScorerResults =
+    const attachedCheckResults =
       enabledCodeScorers.length > 0
         ? await Promise.all(
             enabledCodeScorers.map(scorer =>
@@ -429,6 +469,10 @@ export async function runPlayground(db: Db, input: PlaygroundRunInput): Promise<
               })
             )
           )
+        : undefined;
+    const codeScorerResults =
+      groupMemberChecks || attachedCheckResults
+        ? [...(groupMemberChecks ?? []), ...(attachedCheckResults ?? [])]
         : undefined;
 
     return {

--- a/engine/src/core/evaluate/playgroundProfiles.ts
+++ b/engine/src/core/evaluate/playgroundProfiles.ts
@@ -28,6 +28,7 @@ export type PlaygroundProfileConfig = {
   models: { ids: string[]; settings?: Record<string, { maxTokens?: string; temperature?: string }> };
   scorers: {
     evaluationSettingsId?: string | null;
+    scorerGroupId?: string | null;
     patternIds: string[];
     onlineEvaluatorIds: string[];
     additionalScorerIds?: string[];

--- a/engine/src/core/monitor/onlineEvaluators.ts
+++ b/engine/src/core/monitor/onlineEvaluators.ts
@@ -319,7 +319,8 @@ type ScorableTrace = { input?: unknown; output?: unknown; metadata?: unknown };
 // single process; multi-replica drift is bounded at one burst per replica.
 const onlineJudgeSpend = new Map<string, { day: string; count: number }>();
 let onlineJudgeReservationChain: Promise<void> = Promise.resolve();
-async function reserveOnlineJudgeCall(db: Db): Promise<boolean> {
+// Exported for scorerGroups.ts: group judge members draw from the same online judge budget.
+export async function reserveOnlineJudgeCall(db: Db): Promise<boolean> {
   const cap = Number(process.env.AGENTX_QUOTA_ONLINE_JUDGE_CALLS_PER_DAY || 0);
   if (!Number.isFinite(cap) || cap <= 0) return true;
   let granted = false;

--- a/engine/src/core/monitor/scorerGroups.ts
+++ b/engine/src/core/monitor/scorerGroups.ts
@@ -11,6 +11,9 @@ import { runScriptScorer, loadScorerSpans } from "./scriptScorer.js";
 import { passesSampleRate } from "./routing.js";
 import { recordEvent } from "./events.js";
 import { upsertSignal } from "./signals.js";
+import { getProfileRow } from "./profiles.js";
+import { notifyWebhooks, extractWebhookUrls } from "./webhooks.js";
+import { reserveOnlineJudgeCall } from "./onlineEvaluators.js";
 import { logger } from "../../log.js";
 
 // A Scorer group: several scorers of ANY kind - LLM judges, patterns (templates included), and
@@ -397,10 +400,26 @@ export async function runScorerGroupsOnline(
   if (groups.length === 0) return;
   const inputText = typeof trace.input === "string" ? trace.input : JSON.stringify(trace.input ?? "");
   const outputText = typeof trace.output === "string" ? trace.output : JSON.stringify(trace.output ?? "");
+  // Same webhook fan-out low online-evaluator scores get - a below-threshold group score is a
+  // failure detection, and it pages the same channels.
+  const alertProfile = ctx.agentId ? await getProfileRow(db, ctx.agentId) : null;
 
   for (const group of groups) {
     const online = group.online!;
     if (!passesSampleRate(online.sampleRate)) continue;
+    // Judge members are real LLM spend at the sample rate, so they draw from the SAME online
+    // judge budget evaluators reserve from (reserveOnlineJudgeCall) - one slot per judge member,
+    // taken up front. A refused reservation skips the whole group for this trace: a partial
+    // panel would score the group on a different recipe than the one configured.
+    const judgeMemberCount = group.members.filter(m => m.kind === "judge").length;
+    let budgetOk = true;
+    for (let i = 0; i < judgeMemberCount; i++) {
+      if (!(await reserveOnlineJudgeCall(db))) {
+        budgetOk = false;
+        break;
+      }
+    }
+    if (!budgetOk) return;
     try {
       const result = await computeGroupScore(db, group, {
         input: inputText,
@@ -427,6 +446,13 @@ export async function runScorerGroupsOnline(
           { agentId: ctx.agentId, traceId: ctx.traceId, evidence: { input: trace.input, output: trace.output } }
         );
         signalId = signal._id;
+        notifyWebhooks(extractWebhookUrls(alertProfile?.channels), {
+          summary,
+          severity: online.severity,
+          patternKey: `scorer-group:${group.id}`,
+          agentId: ctx.agentId,
+          rootCause: group.name,
+        });
       }
 
       await recordEvent(db, {

--- a/engine/src/routes/evaluateDashboard.ts
+++ b/engine/src/routes/evaluateDashboard.ts
@@ -72,6 +72,7 @@ import {
   updateToolSchemaMeta,
 } from "../core/evaluate/toolSchemas.js";
 import { runPlayground, extractPlaygroundTools, callPlaygroundTool } from "../core/evaluate/playground.js";
+import { getScorerGroup } from "../core/monitor/scorerGroups.js";
 import { runConversationSimulation } from "../core/evaluate/simulation.js";
 import { generateSyntheticCases } from "../core/evaluate/synthesize.js";
 import { loadMcpTools } from "../core/evaluate/mcp.js";
@@ -435,6 +436,7 @@ const profileConfigSchema = z.object({
   }),
   scorers: z.object({
     evaluationSettingsId: z.string().max(200).nullable().optional(),
+    scorerGroupId: z.string().max(200).nullable().optional(),
     patternIds: z.array(z.string().max(200)).max(200),
     // Legacy dashboards stored online-profile ids here; current ones store judge scorer ids in
     // additionalScorerIds. Both survive the round trip.
@@ -681,6 +683,7 @@ evaluateDashboardRouter.post("/playground/run", async (req: Request, res: Respon
     patternIds: extractIds(body.patternIds),
     onlineEvaluatorIds: extractIds(body.onlineEvaluatorIds),
     additionalScorerIds: extractIds(body.additionalScorerIds),
+    scorerGroupId: typeof body.scorerGroupId === "string" && body.scorerGroupId ? body.scorerGroupId : undefined,
     maxTokens: typeof body.maxTokens === "number" ? body.maxTokens : undefined,
     temperature: typeof body.temperature === "number" ? body.temperature : undefined,
   });
@@ -1504,11 +1507,13 @@ function toResultWire(r: RunResultRow, evaluationSettingsQuestions: unknown, dat
 // liveStatistics.averageRating, not results.length, and a rating of exactly 0 (e.g. an errored
 // result) must not be treated as "no rating yet" (0 !== null).
 async function toEvaluateWire(db: Db, run: FullRunRow, includeResults: boolean) {
-  const [dataset, evaluationSettings, results, analysisRow] = await Promise.all([
+  const scorerGroupId = (run as { scorerGroupId?: string | null }).scorerGroupId ?? null;
+  const [dataset, evaluationSettings, results, analysisRow, scorerGroup] = await Promise.all([
     getDataset(db, run.datasetId),
     getMergedEvaluationSettings(db, run.evaluationSettingsId ?? run.datasetId),
     getRunResults(db, run.id),
     getEvaluationAnalysisRow(db, run.id),
+    scorerGroupId ? getScorerGroup(db, scorerGroupId) : Promise.resolve(null),
   ]);
   const rated = results.filter(r => r.rating != null).map(r => r.rating as number);
   const averageRating = rated.length ? rated.reduce((a, b) => a + b, 0) / rated.length : null;
@@ -1529,8 +1534,8 @@ async function toEvaluateWire(db: Db, run: FullRunRow, includeResults: boolean) 
     additionalAgg.size > 0
       ? [
           {
-            scorerId: run.evaluationSettingsId ?? null,
-            name: "Primary scorer",
+            scorerId: run.evaluationSettingsId ?? scorerGroup?.id ?? null,
+            name: scorerGroup ? `${scorerGroup.name} (group)` : "Primary scorer",
             primary: true,
             averageRating: averageRating != null ? Math.round(averageRating * 100) / 100 : null,
             scored: rated.length,
@@ -1548,6 +1553,10 @@ async function toEvaluateWire(db: Db, run: FullRunRow, includeResults: boolean) 
   return {
     scorerBreakdown,
     _id: run.id,
+    // Group-graded runs: name the group so the Evaluate list's Scorers column doesn't claim
+    // the dataset's own twin config graded the run.
+    scorerGroupId: scorerGroup?.id ?? null,
+    scorerGroupName: scorerGroup?.name ?? null,
     evaluationSettings: evaluationSettings ?? undefined,
     datasetId: dataset ? { _id: dataset._id, name: dataset.name, description: dataset.description } : run.datasetId,
     results: includeResults ? results.map(r => toResultWire(r, evaluationSettings?.questions, dataset?.questions)) : [],

--- a/engine/src/test/scorerGroups.integration.test.ts
+++ b/engine/src/test/scorerGroups.integration.test.ts
@@ -23,6 +23,18 @@ beforeAll(async () => {
     req.on("end", () => {
       const rating = raw.includes("HARSHMARK") ? 2 : 8;
       res.setHeader("content-type", "application/json");
+      // Judges arrive via the Responses API (judge-core); the Playground's model completion
+      // uses chat completions - serve whichever shape the path asks for.
+      if ((req.url ?? "").includes("/chat/completions")) {
+        res.end(
+          JSON.stringify({
+            id: "chat_stub",
+            choices: [{ message: { role: "assistant", content: "stub answer" } }],
+            usage: { prompt_tokens: 5, completion_tokens: 5 },
+          })
+        );
+        return;
+      }
       res.end(
         JSON.stringify({
           id: "resp_stub",
@@ -173,6 +185,22 @@ describe("scorer groups", () => {
     };
     expect(detail.scorerGroupId).toBe(groupId);
     expect(detail.scorerBreakdown[0]).toMatchObject({ name: "Blend group (group)", primary: true });
+
+    // A group MEMBER is gate-able by name ("fail the run if the Harsh judge is low, whatever
+    // the blend says") - and an unknown member is still a hard 400.
+    const memberGate = (await api(`/custom-agent-evaluations/runs/${runId}/gate?failUnder=5&scorer=Harsh judge`))
+      .body as { passed: boolean; gatedScorer: { name: string } | null; averageRating: number | null };
+    expect(memberGate.gatedScorer?.name).toBe("Harsh judge");
+    expect(memberGate.averageRating).toBe(2);
+    expect(memberGate.passed).toBe(false);
+    expect((await api(`/custom-agent-evaluations/runs/${runId}/gate?failUnder=5&scorer=Nope`)).status).toBe(400);
+
+    // The dashboard list wire names the group (Evaluate page's Scorers column).
+    const listed = (await api("/evaluate/list?limit=20")).body as {
+      evaluations: Array<{ scorerGroupId?: string | null; scorerGroupName?: string | null }>;
+    };
+    const listedRun = listed.evaluations.find(e => e.scorerGroupId === groupId);
+    expect(listedRun?.scorerGroupName).toBe("Blend group");
   });
 
   it("a must-pass gate zeroes the group score when its member fails", async () => {
@@ -213,6 +241,41 @@ describe("scorer groups", () => {
     expect(scored.rating).toBe(0);
     expect(scored.justification).toContain("Gated to 0");
   });
+
+  it("grades a Playground cell with a group: aggregate rating + member verdicts", async () => {
+    const kindId = await makeJudge("PG kind", "KINDMARK"); // stub rates 8
+    const patternId = await makePattern("PG sorry", "sorry");
+    const group = await api(
+      "/agent-monitoring/scorer-groups",
+      postJson({
+        name: "PG group",
+        members: [
+          { kind: "judge", refId: kindId, weight: 1 },
+          { kind: "pattern", refId: patternId, weight: 1 },
+        ],
+      })
+    );
+    const groupId = (group.body as { scorerGroup: { _id: string } }).scorerGroup._id;
+
+    const run = await api(
+      "/evaluate/playground/run",
+      postJson({ model: "stub-judge-g", messages: [], query: "hi?", scorerGroupId: groupId })
+    );
+    expect(run.status).toBe(200);
+    const body = run.body as {
+      rating: number | null;
+      justification: string | null;
+      judgeScorerResults?: Array<{ name: string; rating: number | null }>;
+      codeScorerResults?: Array<{ name: string; score: number | null }>;
+    };
+    // Stub answer contains no "sorry": judge 8 (0.8) + clean pattern (1.0) -> 0.9 -> 9.0.
+    expect(body.rating).toBeCloseTo(9, 5);
+    expect(body.justification).toContain("Weighted blend");
+    expect(body.judgeScorerResults).toEqual([
+      expect.objectContaining({ name: "PG kind", rating: 8 }),
+    ]);
+    expect(body.codeScorerResults).toEqual([expect.objectContaining({ name: "PG sorry", score: 1 })]);
+  }, 90_000);
 
   it("scores live traffic and raises a Signal below the group threshold", async () => {
     const harshId = await makeJudge("Live harsh", "HARSHMARK"); // rates 2


### PR DESCRIPTION
<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
