### PR TITLE
docs: drop the stale analyze_run/get_report known gap from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,8 +430,9 @@ receiver verified against both protobuf and JSON payloads. The dashboard covers 
 self-host surface: Observe (live traces and sessions, with end-user feedback chips), Monitor
 (signals triage plus the KPI cards - scores, latency, spans, cost, tokens, the platform mix,
 and tool executions with the error rate overlaid), Review and Scorers (human labels; pattern,
-online, and custom evaluators, trace- and session-scoped), Topics, Evaluate (runs, datasets
-curated straight from production traffic, standalone evaluator configs, version history,
+online, and custom evaluators, trace- and session-scoped, composable into weighted scorer
+groups), Topics, Evaluate (runs, datasets curated straight from production traffic, standalone
+evaluator configs, version history,
 per-case run comparison, Model Portability, and Playground), Insights (Suggestions and Dataset
 coverage, with the Prompts and Tools & MCPs registries - validated proposals and
 unregistered-tool surfacing - reached from the sidebar's Manage section), CI Gates (recorded
@@ -445,7 +446,9 @@ map, Model Comparison, and Judge Calibration against reported outcomes and end-u
   fundamentally tied to AgentX's native agent config-branching system, which self-host doesn't
   have. The version-comparison and Prompt Registry features are the self-host analogs.
 - Guardrail hasn't been started.
-- Evaluate's async whole-run analysis (`analyze_run`/`get_report`) is out of scope for now.
+- The SDK's `list_models` call isn't served on the `custom-agent-evaluations` router yet; every
+  other `EvaluationsClient` path, including whole-run analysis (`analyze_run`/
+  `get_analysis_status`/`get_report`, synchronous here rather than queued), is.
 
 See [CHANGELOG.md](CHANGELOG.md) for the detailed, narrative build/verification history behind
 every feature above.


### PR DESCRIPTION
Whole-run analysis has been served on the SDK's custom-agent-evaluations router since "Serve whole-run analysis on the SDK's routes" (8aa475c), with integration tests keeping the three paths mounted, but the Project status section still listed it as out of scope. Replace that bullet with the one EvaluationsClient path that genuinely isn't ported (list_models), and note scorer groups in the Scorers summary now that they have shipped.


Claude-Session: https://claude.ai/code/session_01WdJpK3TN17GwP7n59rq1vR

<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
