### PR TITLE
group scorer with session + dataset map

### DIFF
--- a/engine/src/core/evaluate/playgroundRuns.ts
+++ b/engine/src/core/evaluate/playgroundRuns.ts
@@ -86,14 +86,24 @@ export async function createPlaygroundRun(
 // A run that's already been pruned out from under an in-progress grid (rare - only possible if
 // someone runs 50+ grids without ever reloading the page in one sitting) no-ops rather than
 // throwing: the in-flight run just stops persisting further, it never breaks the UI mid-run.
-export async function updatePlaygroundRunResults(db: Db, id: string, results: unknown): Promise<void> {
+export async function updatePlaygroundRunResults(db: Db, id: string, results: unknown): Promise<boolean> {
   const row = { results, updatedAt: new Date() };
   const cond = and(eq(db.schema.playgroundRuns.id, id), eq(db.schema.playgroundRuns.projectId, db.projectId));
+  // Existence-checked so the route can 404 - PATCHing a deleted/foreign id used to answer
+  // {ok:true} while writing nothing.
+  const existing =
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.playgroundRuns).where(cond).all()[0]
+      : (await db.db.select().from(db.schema.playgroundRuns).where(cond))[0];
+  if (!existing) {
+    return false;
+  }
   if (db.kind === "sqlite") {
     await db.db.update(db.schema.playgroundRuns).set(row).where(cond);
   } else {
     await db.db.update(db.schema.playgroundRuns).set(row).where(cond);
   }
+  return true;
 }
 
 // Every playground_runs row that reviewed a given prompt - the read side of gatherPlaygroundExamples

--- a/engine/src/core/evaluate/runs.ts
+++ b/engine/src/core/evaluate/runs.ts
@@ -825,8 +825,8 @@ export async function computeLiveStatistics(db: Db, runId: string) {
   const rated = results.filter(r => r.rating != null).map(r => r.rating as number);
   return {
     averageRating: rated.length ? rated.reduce((a, b) => a + b, 0) / rated.length : null,
-    minRating: rated.length ? Math.min(...rated) : null,
-    maxRating: rated.length ? Math.max(...rated) : null,
+    minRating: rated.length ? rated.reduce((a, b) => (b < a ? b : a)) : null,
+    maxRating: rated.length ? rated.reduce((a, b) => (b > a ? b : a)) : null,
     ratedCount: rated.length,
     // A run with 30 judge-skipped rows used to be indistinguishable on the wire from a run with
     // 30 fewer cases. skipped = judge could not score (failure/no reference); failed = the
@@ -1083,8 +1083,8 @@ export async function getRun(db: Db, runId: string) {
     averageRating,
     liveStatistics: {
       averageRating,
-      minRating: rated.length ? Math.min(...rated) : null,
-      maxRating: rated.length ? Math.max(...rated) : null,
+      minRating: rated.length ? rated.reduce((a, b) => (b < a ? b : a)) : null,
+      maxRating: rated.length ? rated.reduce((a, b) => (b > a ? b : a)) : null,
       ratedCount: rated.length,
       skippedCount: (results as { status?: string | null }[]).filter(r => r.status === "skipped").length,
       failedCount: (results as { status?: string | null }[]).filter(r => r.status === "failed").length,

--- a/engine/src/core/insights/coverage.ts
+++ b/engine/src/core/insights/coverage.ts
@@ -261,7 +261,7 @@ export function mergeSynonymousTopics(groups: TopicGroup[]): TopicGroup[] {
 
 type Match = { score: number; matched: boolean; margin: number };
 
-type Similarity = {
+export type Similarity = {
   kind: "embedding" | "lexical";
   bands: { covered: number; related: number };
   /**
@@ -287,7 +287,7 @@ function matchOn(score: number, bands: { covered: number; related: number }): Ma
 const lexicalTopicMatch = (item: DatasetCase, group: TopicGroup): Match =>
   matchOn(overlap(contentWords(item.query), group.words), LEXICAL_BANDS);
 
-function embeddingSimilarity(): Similarity {
+export function embeddingSimilarity(): Similarity {
   return {
     kind: "embedding",
     bands: SIMILARITY_BANDS,

--- a/engine/src/core/insights/coverageMap.ts
+++ b/engine/src/core/insights/coverageMap.ts
@@ -1,0 +1,219 @@
+import { UMAP } from "umap-js";
+import type { Db } from "../../storage/db.js";
+import { resolveRange, type MonitoringRange, type MonitoringWindow } from "../monitor/events.js";
+import { listClassificationsSince, type ClassificationRow } from "../monitor/topics.js";
+import { listDatasetRows, listDatasetCases, attachCaseEmbeddings, type DatasetCase } from "./cases.js";
+import { traceStoreFor } from "../trace/store/index.js";
+import { computeEmbeddings } from "../evaluate/judge.js";
+import { and, eq } from "drizzle-orm";
+import { groupByIntent, embeddingSimilarity, MIN_TRACES_PER_TOPIC, type TopicGroup } from "./coverage.js";
+
+// The coverage MAP: production traces and dataset cases projected into ONE picture, so "does my
+// suite cover what production actually asks" is visible as overlapping clouds rather than only a
+// table of numbers.
+//
+// The projection runs in QUESTION space: a trace's input-only embedding against a case's
+// query-only embedding, so an identical question from both sources lands in the same spot. The
+// interaction space coverage matches topics in (input+output vs query+expected) is the wrong
+// geometry for this picture - it separates identical questions whenever the actual answer
+// differs from the expected one, which is exactly when a reader would call the map broken.
+// Historical classification rows predate the input-only column, so a bounded batch is embedded
+// lazily per request and persisted; the remainder is reported as traceEmbeddingsPending.
+//
+// One JOINT UMAP fit, one endpoint: coordinates from two separate fits are not comparable, so
+// the production-only topics map cannot simply be overlaid with a second one.
+
+// Same caps/floors as the topics map (topics.ts): below the floor UMAP draws an arbitrary shape,
+// and the per-source cap keeps a long-running install's request bounded.
+const MAX_POINTS_PER_SOURCE = 300;
+const MIN_POINTS_FOR_MAP = 10;
+// Historical rows lacking input_embedding, embedded per map request - bounded like the case
+// cache's own warming so one request never turns into hundreds of embedding calls.
+const MAX_TRACE_BACKFILL_PER_REQUEST = 100;
+
+export type CoverageMapPoint = {
+  x: number;
+  y: number;
+  source: "production" | "dataset";
+  // The classification intent (production) or the coverage-matched topic (dataset);
+  // "unmatched" for a case no topic claimed.
+  topic: string;
+  query: string;
+  traceId?: string | null;
+  datasetId?: string;
+  caseIndex?: number;
+};
+
+export type CoverageMapTopic = { topic: string; productionCount: number; datasetCount: number };
+
+export type CoverageMapResult = {
+  window: MonitoringWindow | "custom";
+  datasetIds: string[];
+  insufficientData: boolean;
+  degradedReason: string | null;
+  // Cases not yet embedded (cache warming) - absent from the map, reported so the UI can say so.
+  caseEmbeddingsPending: number;
+  // Historical traces whose question-space embedding is still backfilling - same treatment.
+  traceEmbeddingsPending: number;
+  points: CoverageMapPoint[];
+  topics: CoverageMapTopic[];
+};
+
+export async function getCoverageMap(
+  db: Db,
+  options: { window: MonitoringRange; datasetIds?: string[] }
+): Promise<CoverageMapResult> {
+  const { sinceMs, untilMs, windowLabel } = resolveRange(options.window);
+  const datasetIds = options.datasetIds ?? [];
+  const empty = (degradedReason: string | null, pending = 0, tracePending = 0): CoverageMapResult => ({
+    window: windowLabel,
+    datasetIds,
+    insufficientData: true,
+    degradedReason,
+    caseEmbeddingsPending: pending,
+    traceEmbeddingsPending: tracePending,
+    points: [],
+    topics: [],
+  });
+
+  const allRows = await listClassificationsSince(db, new Date(sinceMs), new Date(untilMs));
+  const candidates = allRows
+    .filter(r => r.traceId)
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+    .slice(0, MAX_POINTS_PER_SOURCE);
+
+  // Question-space vectors: input_embedding when stored, else a bounded lazy backfill embedding
+  // the trace's input text now and persisting it for every later request.
+  const traceTexts = await traceStoreFor(db).getByIds(
+    candidates.map(r => r.traceId).filter((id): id is string => !!id)
+  );
+  const inputTextOf = (row: ClassificationRow): string => {
+    const input = row.traceId ? traceTexts.get(row.traceId)?.input : undefined;
+    if (typeof input === "string") return input;
+    if (input && typeof input === "object" && typeof (input as { query?: unknown }).query === "string") {
+      return (input as { query: string }).query;
+    }
+    return input ? JSON.stringify(input) : "";
+  };
+
+  const missing = candidates
+    .filter(r => !Array.isArray(r.inputEmbedding) || r.inputEmbedding.length === 0)
+    .filter(r => inputTextOf(r).trim().length > 0)
+    .slice(0, MAX_TRACE_BACKFILL_PER_REQUEST);
+  if (missing.length > 0) {
+    const vectors = await computeEmbeddings(missing.map(r => inputTextOf(r)));
+    for (let i = 0; i < missing.length; i++) {
+      const vector = vectors[i];
+      if (!vector) continue;
+      missing[i]!.inputEmbedding = vector;
+      const cond = and(
+        eq(db.schema.monitorClassifications.id, missing[i]!.id),
+        eq(db.schema.monitorClassifications.projectId, db.projectId)
+      );
+      if (db.kind === "sqlite") {
+        db.db.update(db.schema.monitorClassifications).set({ inputEmbedding: vector }).where(cond).run();
+      } else {
+        await db.db.update(db.schema.monitorClassifications).set({ inputEmbedding: vector }).where(cond);
+      }
+    }
+  }
+
+  const traceRows = candidates.filter(
+    (r): r is ClassificationRow & { inputEmbedding: number[] } =>
+      Array.isArray(r.inputEmbedding) && r.inputEmbedding.length > 0
+  );
+  const tracePending = candidates.length - traceRows.length;
+
+  const datasetRows = await listDatasetRows(db);
+  const cases = await listDatasetCases(db, options.datasetIds, datasetRows);
+  const { pending } = await attachCaseEmbeddings(db, cases);
+  // Query-only embeddings - the same question space the trace side projects in.
+  const embeddedCases = cases
+    .filter((c): c is DatasetCase & { embedding: number[] } => Array.isArray(c.embedding))
+    .slice(0, MAX_POINTS_PER_SOURCE);
+
+  // Unlike the coverage table, the map has no lexical fallback - positions ARE similarities, and
+  // there is no honest place to draw a point whose similarity was never measured.
+  if (traceRows.length === 0) {
+    return empty("No classified production traffic carries an embedding in this window.", pending, tracePending);
+  }
+  if (embeddedCases.length === 0) {
+    return empty(
+      cases.length === 0
+        ? "No dataset cases to place yet."
+        : "No dataset case embeddings are available yet - set OPENAI_API_KEY, or wait for the cache to warm.",
+      pending,
+      tracePending
+    );
+  }
+  if (traceRows.length + embeddedCases.length < MIN_POINTS_FOR_MAP) {
+    return empty(null, pending, tracePending);
+  }
+
+  // Topic assignment for dataset points reuses the coverage table's exact matcher (bands and
+  // all), so a case never reads as covered here and off-map there.
+  const groups: TopicGroup[] = groupByIntent(allRows).filter(g => g.rows.length >= MIN_TRACES_PER_TOPIC);
+  const sim = embeddingSimilarity();
+  const topicOf = (item: DatasetCase): string => {
+    let bestTopic: string | null = null;
+    let bestMargin = -1;
+    let bestScore = -1;
+    let matched = false;
+    for (const group of groups) {
+      const match = sim.toTopic(item, group);
+      if (match.margin > bestMargin || (match.margin === bestMargin && match.score > bestScore)) {
+        bestMargin = match.margin;
+        bestScore = match.score;
+        bestTopic = group.topic;
+        matched = match.matched;
+      }
+    }
+    return matched && bestTopic ? bestTopic : "unmatched";
+  };
+
+  const vectors = [...traceRows.map(r => r.inputEmbedding), ...embeddedCases.map(c => c.embedding)];
+  const nNeighbors = Math.min(15, vectors.length - 1);
+  const projected = new UMAP({ nComponents: 2, nNeighbors }).fit(vectors);
+
+  const points: CoverageMapPoint[] = [
+    ...traceRows.map((row, i) => ({
+      x: projected[i]![0]!,
+      y: projected[i]![1]!,
+      source: "production" as const,
+      topic: row.intent,
+      query: inputTextOf(row).slice(0, 140),
+      traceId: row.traceId,
+    })),
+    ...embeddedCases.map((item, i) => ({
+      x: projected[traceRows.length + i]![0]!,
+      y: projected[traceRows.length + i]![1]!,
+      source: "dataset" as const,
+      topic: topicOf(item),
+      query: item.query,
+      datasetId: item.datasetId,
+      caseIndex: item.index,
+    })),
+  ];
+
+  const byTopic = new Map<string, CoverageMapTopic>();
+  for (const point of points) {
+    const entry = byTopic.get(point.topic) ?? { topic: point.topic, productionCount: 0, datasetCount: 0 };
+    if (point.source === "production") entry.productionCount++;
+    else entry.datasetCount++;
+    byTopic.set(point.topic, entry);
+  }
+  const topics = [...byTopic.values()].sort(
+    (a, b) => b.productionCount - a.productionCount || b.datasetCount - a.datasetCount
+  );
+
+  return {
+    window: windowLabel,
+    datasetIds,
+    insufficientData: false,
+    degradedReason: null,
+    caseEmbeddingsPending: pending,
+    traceEmbeddingsPending: tracePending,
+    points,
+    topics,
+  };
+}

--- a/engine/src/core/monitor/events.ts
+++ b/engine/src/core/monitor/events.ts
@@ -664,7 +664,10 @@ export async function getScorerGroupRatings(
   const bucketStartMs = Date.now() - bucketCount * bucketMs;
 
   const rows = (await listEventsSince(db, new Date(bucketStartMs))).filter(
-    r => r.patternKey === `scorer-group:${groupId}` && r.type === "scorer_group_score" && r.rating !== null
+    r =>
+      r.patternKey === `scorer-group:${groupId}` &&
+      (r.type === "scorer_group_score" || r.type === "scorer_group_session_score") &&
+      r.rating !== null
   );
 
   const buckets: { sum: number; count: number }[] = Array.from({ length: bucketCount }, () => ({ sum: 0, count: 0 }));

--- a/engine/src/core/monitor/scorerGroups.ts
+++ b/engine/src/core/monitor/scorerGroups.ts
@@ -47,6 +47,11 @@ export type ScorerGroupOnline = {
   // On the GROUP score, 0-10. Null = never raise a Signal (chart-only).
   alertThreshold: number | null;
   severity: string;
+  // "trace" (default) scores each sampled ingested trace; "session" scores whole multi-turn
+  // sessions once they have been idle for idleSeconds - the same trigger session-scoped online
+  // evaluators use (see sessionSweep.ts, which owns the group-session loop).
+  scope?: "trace" | "session";
+  idleSeconds?: number;
 };
 
 export type ScorerGroupRow = {
@@ -282,7 +287,7 @@ async function scoreJudgeMember(db: Db, member: ScorerGroupMember, content: Grou
   }
 }
 
-async function scorePatternMember(db: Db, member: ScorerGroupMember, content: GroupScoringContent): Promise<MemberScore> {
+export async function scorePatternMember(db: Db, member: ScorerGroupMember, content: GroupScoringContent): Promise<MemberScore> {
   const base = { kind: member.kind, refId: member.refId, weight: member.weight, gate: member.gate };
   const pattern = await getPatternRow(db, member.refId);
   if (!pattern) {
@@ -313,7 +318,7 @@ async function scorePatternMember(db: Db, member: ScorerGroupMember, content: Gr
   }
 }
 
-async function scoreCustomMember(db: Db, member: ScorerGroupMember, content: GroupScoringContent): Promise<MemberScore> {
+export async function scoreCustomMember(db: Db, member: ScorerGroupMember, content: GroupScoringContent): Promise<MemberScore> {
   const base = { kind: member.kind, refId: member.refId, weight: member.weight, gate: member.gate };
   const evaluator = (await getCustomEvaluatorRow(db, member.refId)) as CustomEvaluatorRow | null;
   if (!evaluator) {
@@ -396,7 +401,11 @@ export async function runScorerGroupsOnline(
   trace: { input: unknown; output: unknown; toolCalls?: unknown },
   ctx: { agentId: string | null; traceId: string | null }
 ): Promise<void> {
-  const groups = (await listScorerGroups(db)).filter(g => g.online?.enabled);
+  // Session-scoped groups are the idle-session sweep's job (sessionSweep.ts) - scoring them
+  // here too would judge every individual trace of a conversation a second time.
+  const groups = (await listScorerGroups(db)).filter(
+    g => g.online?.enabled && (g.online.scope ?? "trace") !== "session"
+  );
   if (groups.length === 0) return;
   const inputText = typeof trace.input === "string" ? trace.input : JSON.stringify(trace.input ?? "");
   const outputText = typeof trace.output === "string" ? trace.output : JSON.stringify(trace.output ?? "");

--- a/engine/src/core/monitor/sessionSweep.ts
+++ b/engine/src/core/monitor/sessionSweep.ts
@@ -19,6 +19,16 @@ import { matchesAgentScope, passesSampleRate } from "./routing.js";
 import { upsertSignal } from "./signals.js";
 import { recordEvent } from "./events.js";
 import { acquireSweepLease } from "../shared/sweepLease.js";
+import {
+  listScorerGroups,
+  scorePatternMember,
+  scoreCustomMember,
+  aggregateGroupScore,
+  describeGroupScore,
+  type MemberScore,
+  type ScorerGroupRow,
+} from "./scorerGroups.js";
+import { reserveOnlineJudgeCall } from "./onlineEvaluators.js";
 import { SESSION_BASELINE_KEY } from "./builtinEvaluators.js";
 import { logger } from "../../log.js";
 
@@ -337,6 +347,96 @@ export async function runSessionEvaluatorCheck(db: Db, sessionId: string, evalua
   });
 }
 
+// A group's judge MEMBER scoring a session needs only the rating and justification - findings
+// and drift belong to full session evaluators, not to one blended opinion inside a group.
+const MEMBER_SESSION_SCORE_SCHEMA = {
+  type: "object",
+  properties: {
+    rating: { type: "number", description: "0-10 rating for the whole session against the criteria" },
+    justification: { type: "string", description: "What the session did well or where it failed the criteria" },
+  },
+  required: ["rating", "justification"],
+};
+
+// Session-scope scorer-group scoring: every member scores the SAME assembled transcript. Judge
+// members get the structured session prompt built from their criteria (never their per-trace
+// judgePrompt - same rule as session evaluators); pattern and custom members receive the whole
+// transcript as both input and output, so "contains"-style conditions and script scorers read
+// the conversation, not one turn. Failures isolate per member exactly like trace-scope groups.
+export async function scoreSessionWithGroup(
+  db: Db,
+  group: ScorerGroupRow,
+  sessionId: string
+): Promise<{
+  score: number | null;
+  gatedBy: string | null;
+  members: MemberScore[];
+  justification: string;
+  anchorTraceId: string | null;
+  spanCount: number;
+} | null> {
+  const spans = (await listSessionSpans(db, sessionId)) as SpanWire[];
+  if (spans.length === 0) return null;
+  const { transcript, elidedNote } = buildSessionTranscript(spans, { includeToolLines: true });
+  const roots = spans.filter(s => !s.parentSpanId);
+  const anchorTraceId = (roots.length > 0 ? roots[roots.length - 1] : spans[spans.length - 1])?._id ?? null;
+
+  const members: MemberScore[] = [];
+  for (const member of group.members) {
+    const base = { kind: member.kind, refId: member.refId, weight: member.weight, gate: member.gate };
+    if (member.kind === "judge") {
+      const settings = await getEvaluationSettingsRow(db, member.refId);
+      if (!settings) {
+        members.push({ ...base, name: member.refId, goodness: null, detail: "-", error: "Scorer no longer exists" });
+        continue;
+      }
+      const name = settings.name ?? member.refId;
+      try {
+        const result = await callJudgeJson({
+          model: settings.judgeModel ?? DEFAULT_JUDGE_MODEL,
+          jsonSchema: MEMBER_SESSION_SCORE_SCHEMA,
+          userMessage: buildSessionJudgeMessage({
+            elidedNote,
+            criteria: settings,
+            toolDefinitions: null,
+            transcript,
+            withDrift: false,
+          }),
+          maxTokens: 1200,
+        });
+        const payload = result.payload as { rating?: unknown; justification?: unknown } | null;
+        const rating = typeof payload?.rating === "number" ? Math.max(0, Math.min(10, payload.rating)) : null;
+        if (rating === null) {
+          members.push({ ...base, name, goodness: null, detail: "-", error: "Judge returned no usable verdict" });
+        } else {
+          const justification = typeof payload?.justification === "string" ? payload.justification : "";
+          members.push({ ...base, name, goodness: rating / 10, detail: `${rating}/10 (${justification.slice(0, 140)})` });
+        }
+      } catch (err) {
+        members.push({ ...base, name, goodness: null, detail: "-", error: err instanceof Error ? err.message : "Judge failed" });
+      }
+    } else if (member.kind === "pattern") {
+      members.push(
+        await scorePatternMember(db, member, { input: transcript, output: transcript, traceId: anchorTraceId })
+      );
+    } else {
+      members.push(
+        await scoreCustomMember(db, member, { input: transcript, output: transcript, traceId: anchorTraceId })
+      );
+    }
+  }
+
+  const { score, gatedBy } = aggregateGroupScore(members);
+  return {
+    score,
+    gatedBy,
+    members,
+    justification: describeGroupScore({ score, gatedBy }, members),
+    anchorTraceId,
+    spanCount: spans.length,
+  };
+}
+
 // One pass over every project: find idle, unscored (or grown-since-scored) multi-turn sessions
 // and judge them against each enabled session-scoped evaluator. Exported for the manual-trigger
 // route (used by tests/demos); startSessionSweep below is the production path.
@@ -363,7 +463,12 @@ export async function sweepSessionsOnce(): Promise<{ judged: number }> {
     // enabled toggle replaced the old project-level coherence switch, and pausing it stops the
     // baseline judging like pausing any evaluator.
     const evaluators = (await listOnlineEvaluatorRows(db)).filter(e => e.enabled && e.scope === "session");
-    if (evaluators.length === 0) return;
+    // Session-scoped scorer GROUPS ride the same sweep: one idle trigger, one freshness rule,
+    // one judged-per-tick budget - the group score is just a composed verdict about the session.
+    const sessionGroups = (await listScorerGroups(db)).filter(
+      g => g.online?.enabled && g.online.scope === "session"
+    );
+    if (evaluators.length === 0 && sessionGroups.length === 0) return;
 
     const { sessions } = await listSessions(db, candidateWindow());
     const now = Date.now();
@@ -477,6 +582,116 @@ export async function sweepSessionsOnce(): Promise<{ judged: number }> {
           logger.error(
             { err },
             `Session sweep: evaluator "${evaluator.name}" failed on session ${session.sessionId}`
+          );
+        }
+      }
+
+      for (const group of sessionGroups) {
+        if (judged >= MAX_JUDGED_PER_SWEEP) break;
+        const online = group.online!;
+        if (now - lastActivity < (online.idleSeconds ?? 120) * 1000) continue;
+
+        const kind = `scorer-group:${group.id}`;
+        const latest = scores.find(s => s.kind === kind);
+        if (latest && new Date(latest.createdAt).getTime() >= lastActivity) continue;
+        if (!passesSampleRate(online.sampleRate)) continue;
+        // Judge members are real LLM spend, so they draw from the same online judge budget as
+        // trace-scope group scoring - all slots up front, and a refused reservation skips the
+        // whole group (a partial panel would score a different recipe than the one configured).
+        const judgeMemberCount = group.members.filter(m => m.kind === "judge").length;
+        let budgetOk = true;
+        for (let i = 0; i < judgeMemberCount; i++) {
+          if (!(await reserveOnlineJudgeCall(db))) {
+            budgetOk = false;
+            break;
+          }
+        }
+        if (!budgetOk) continue;
+
+        try {
+          const result = await scoreSessionWithGroup(db, group, session.sessionId);
+          if (!result) continue;
+          judged++;
+          if (result.score === null) {
+            // No member produced a score (judge outage, deleted refs). Same posture as the
+            // evaluator path: record the failure, insert no score row, let the next tick retry.
+            await recordEvent(db, {
+              signalId: null,
+              patternKey: kind,
+              type: "online_eval_judge_failure",
+              severity: "low",
+              polarity: "score",
+              agentId: session.agentId,
+              traceId: result.anchorTraceId,
+              onlineEvaluatorId: null,
+              rating: null,
+              justification: "No group member produced a usable score for this session",
+              sessionId: session.sessionId,
+            });
+            continue;
+          }
+          await insertSessionScore(db, {
+            sessionId: session.sessionId,
+            kind,
+            rating: result.score,
+            justification: result.justification,
+            spanCount: result.spanCount,
+            judgeModel: "scorer-group",
+          });
+
+          let signalId: string | null = null;
+          if (online.alertThreshold !== null && result.score < online.alertThreshold) {
+            const signal = await upsertSignal(
+              db,
+              {
+                type: "scorer_group_low_session_score",
+                severity: online.severity,
+                polarity: "failure",
+                summary: `Scorer group "${group.name}" rated session ${session.sessionId} ${result.score.toFixed(1)}/10 (below the ${online.alertThreshold} threshold): ${result.justification}`,
+                patternKey: kind,
+                rootCause: group.name,
+              },
+              { agentId: session.agentId, traceId: result.anchorTraceId }
+            );
+            signalId = signal._id;
+          }
+
+          // Same dual-write trace-scope group scoring does: the aggregate joins the group's
+          // ratings history (getScorerGroupRatings keys on this patternKey), member verdicts
+          // land alongside for the detailed breakdown.
+          await recordEvent(db, {
+            signalId,
+            patternKey: kind,
+            type: "scorer_group_session_score",
+            severity: "low",
+            polarity: "score",
+            agentId: session.agentId,
+            traceId: result.anchorTraceId,
+            onlineEvaluatorId: null,
+            rating: result.score,
+            justification: result.justification,
+            sessionId: session.sessionId,
+          });
+          for (const member of result.members) {
+            if (member.goodness === null) continue;
+            await recordEvent(db, {
+              signalId: null,
+              patternKey: `${kind}:${member.kind}:${member.refId}`,
+              type: "scorer_group_member_score",
+              severity: "low",
+              polarity: "score",
+              agentId: session.agentId,
+              traceId: result.anchorTraceId,
+              onlineEvaluatorId: null,
+              rating: Math.round(member.goodness * 100) / 10,
+              justification: JSON.stringify({ name: member.name, detail: member.detail }),
+              sessionId: session.sessionId,
+            });
+          }
+        } catch (err) {
+          logger.error(
+            { err },
+            `Session sweep: scorer group "${group.name}" failed on session ${session.sessionId}`
           );
         }
       }

--- a/engine/src/core/monitor/topics.ts
+++ b/engine/src/core/monitor/topics.ts
@@ -36,6 +36,10 @@ export type ClassificationRow = {
   // OPENAI_API_KEY was set or the embeddings call failed (see computeEmbedding), or for rows
   // classified before this column existed.
   embedding: number[] | null;
+  // The trace INPUT alone - the coverage map's question space (an identical question from
+  // production and a dataset case embeds identically here). Null for historical rows; the
+  // coverage map backfills lazily (coverageMap.ts).
+  inputEmbedding: number[] | null;
 };
 
 const ISSUE_TYPES = ["none", "refusal", "hallucination", "off_topic", "incomplete", "other"] as const;
@@ -77,6 +81,7 @@ async function recordClassification(
     sentiment: string;
     issueType: string;
     embedding: number[] | null;
+    inputEmbedding: number[] | null;
   }
 ): Promise<void> {
   const row: ClassificationRow = {
@@ -89,6 +94,7 @@ async function recordClassification(
     issueType: input.issueType as ClassificationRow["issueType"],
     createdAt: new Date(),
     embedding: input.embedding,
+    inputEmbedding: input.inputEmbedding,
   };
   if (db.kind === "sqlite") {
     await db.db.insert(db.schema.monitorClassifications).values(row);
@@ -154,13 +160,16 @@ export async function runClassification(
     // Embedding runs alongside the judge call, not after it - same trace text, independent
     // failure modes (a missing/bad OPENAI_API_KEY shouldn't block the classification itself, and
     // vice versa; see computeEmbedding's own null-on-failure posture), no reason to serialize them.
-    const [result, embedding] = await Promise.all([
+    const [result, embedding, inputEmbedding] = await Promise.all([
       callJudgeJson({
         model: await resolvePlatformModel(db),
         jsonSchema: classificationSchema,
         userMessage: `Classify this AI agent interaction.\n\nUser input:\n${inputText}\n\nAgent response:\n${outputText}${existingIntentsBlock}\n\nRespond with JSON matching the schema.`,
       }),
       computeEmbedding(`${inputText}\n\n${outputText}`),
+      // Question-space twin for the coverage map: the input alone, so an identical question
+      // from a dataset case (query-only embedding) lands in the same spot.
+      computeEmbedding(inputText),
     ]);
     const payload = result.payload as { intent?: string; sentiment?: string; issueType?: string } | null;
     if (!payload?.intent || !payload.sentiment || !payload.issueType) {
@@ -173,6 +182,7 @@ export async function runClassification(
       sentiment: payload.sentiment,
       issueType: payload.issueType,
       embedding,
+      inputEmbedding,
     });
   } catch (err) {
     logger.error({ err: err instanceof Error ? err.message : err }, "Trace classification failed:");

--- a/engine/src/core/trace/store/sqlTraceStore.ts
+++ b/engine/src/core/trace/store/sqlTraceStore.ts
@@ -135,10 +135,12 @@ export class SqlTraceStore implements TraceStore {
   async listBySession(sessionId: string): Promise<TraceRow[]> {
     const db = this.db;
     const cond = and(eq(db.schema.traces.sessionId, sessionId), eq(db.schema.traces.projectId, db.projectId));
+    // Capped: a runaway agent session with tens of thousands of spans must not pull them all
+    // into the heap on every dialog open. 5000 is far beyond any real conversation.
     const rows =
       db.kind === "sqlite"
-        ? db.db.select().from(db.schema.traces).where(cond).all()
-        : await db.db.select().from(db.schema.traces).where(cond);
+        ? db.db.select().from(db.schema.traces).where(cond).limit(5000).all()
+        : await db.db.select().from(db.schema.traces).where(cond).limit(5000);
     return rows as TraceRow[];
   }
 

--- a/engine/src/routes/agentMonitoringDashboard.ts
+++ b/engine/src/routes/agentMonitoringDashboard.ts
@@ -262,7 +262,7 @@ agentMonitoringDashboardRouter.get("/review-queue", async (req: Request, res: Re
       status: typeof status === "string" ? status : undefined,
       source: typeof source === "string" ? source : undefined,
     },
-    limit ? Math.min(Number(limit) || 100, 200) : 100
+    limit ? Math.min(Math.max(1, Number(limit) || 100), 200) : 100
   );
   res.status(200).json(result);
 });
@@ -347,7 +347,7 @@ agentMonitoringDashboardRouter.get("/signals", async (req: Request, res: Respons
       agentId: typeof agentId === "string" ? await resolveExistingAgentId(scopedDb(req), agentId) : undefined,
       polarity: typeof polarity === "string" ? polarity : undefined,
     },
-    limit ? Math.min(Number(limit) || 50, 100) : 50
+    limit ? Math.min(Math.max(1, Number(limit) || 50), 100) : 50
   );
   res.status(200).json({ signals });
 });
@@ -412,6 +412,18 @@ agentMonitoringDashboardRouter.put("/patterns/:patternId", async (req: Request, 
   // full replace, not a sparse patch), so conditions are re-derived the same way createPattern
   // derives them, from whatever shape (multi-condition builder or legacy fields) was submitted.
   const conditions = legacyPayloadToConditions(body);
+  // A client that explicitly sent condition fields but produced zero usable conditions gets a
+  // 400 - previously the old conditions were silently kept while the caller believed its
+  // "replace" landed. Requests that omit condition fields entirely still mean "keep".
+  const sentConditionFields =
+    body.conditions !== undefined ||
+    body.includeTerms !== undefined ||
+    body.regex !== undefined ||
+    body.semanticPrompt !== undefined;
+  if (sentConditionFields && conditions.length === 0) {
+    res.status(400).json({ error: "Add at least one condition (includeTerms, regex, or semanticPrompt)" });
+    return;
+  }
   const regexCheck = validateConditionRegexes(conditions);
   if (!regexCheck.ok) {
     res.status(400).json({ error: regexCheck.error });
@@ -516,8 +528,20 @@ agentMonitoringDashboardRouter.put("/profiles/:agentId", async (req: Request, re
 
 agentMonitoringDashboardRouter.patch("/profiles/:agentId/approval-policy", async (req: Request, res: Response) => {
   const body = req.body ?? {};
+  // Shape-checked (a flat string->string map) so a typo'd or malformed policy is a 400, not a
+  // silently-persisted governance setting the caller believes was applied.
+  const policy = body.approvalPolicy;
+  const isStringMap =
+    !!policy &&
+    typeof policy === "object" &&
+    !Array.isArray(policy) &&
+    Object.values(policy).every(value => typeof value === "string");
+  if (policy !== null && !isStringMap) {
+    res.status(400).json({ error: "approvalPolicy must be an object of string values (or null to clear)" });
+    return;
+  }
   const agentId = await resolveAgentId(scopedDb(req), req.params.agentId!);
-  const profile = await updateProfile(scopedDb(req), agentId, { approvalPolicy: body.approvalPolicy });
+  const profile = await updateProfile(scopedDb(req), agentId, { approvalPolicy: policy });
   res.status(200).json(profile);
 });
 
@@ -809,6 +833,10 @@ const scorerGroupOnlineSchema = z
     sampleRate: z.number().min(0).max(1),
     alertThreshold: z.number().min(0).max(10).nullable(),
     severity: z.enum(["low", "medium", "high", "critical"]),
+    // "trace" (default) scores each sampled trace at ingest; "session" scores whole multi-turn
+    // sessions via the idle-session sweep once quiet for idleSeconds.
+    scope: z.enum(["trace", "session"]).optional(),
+    idleSeconds: z.number().int().min(0).max(86400).optional(),
   })
   .strip();
 const createScorerGroupSchema = z
@@ -868,6 +896,12 @@ agentMonitoringDashboardRouter.put(
 
 // Ratings history for one group - same shape as /online-evaluators/:id/ratings.
 agentMonitoringDashboardRouter.get("/scorer-groups/:id/ratings", async (req: Request, res: Response) => {
+  // 404 for an unknown group rather than an all-empty 200 - an integration polling a deleted
+  // group's history should learn it is gone, not read "no scores yet" forever.
+  if (!(await getScorerGroup(scopedDb(req), req.params.id!))) {
+    res.status(404).json({ error: "Scorer group not found" });
+    return;
+  }
   res.status(200).json(await getScorerGroupRatings(scopedDb(req), req.params.id!, parseWindow(req)));
 });
 
@@ -1923,9 +1957,19 @@ agentMonitoringDashboardRouter.get("/traces/:traceId/portability-preview", async
 });
 
 agentMonitoringDashboardRouter.post("/traces/:traceId/portability", async (req: Request, res: Response) => {
-  const modelIds = Array.isArray(req.body?.modelIds) ? req.body.modelIds.filter((id: unknown) => typeof id === "string") : [];
+  // Deduped and capped: each entry is TWO real provider calls (completion + judge), so an
+  // unbounded/repeated list is an unbounded LLM bill in a single request.
+  const modelIds = [
+    ...new Set(
+      Array.isArray(req.body?.modelIds) ? req.body.modelIds.filter((id: unknown) => typeof id === "string") : []
+    ),
+  ] as string[];
   if (modelIds.length === 0) {
     res.status(400).json({ error: "modelIds must be a non-empty array" });
+    return;
+  }
+  if (modelIds.length > 10) {
+    res.status(400).json({ error: "At most 10 models per portability check" });
     return;
   }
   const result = await runModelPortabilityCheck(scopedDb(req), req.params.traceId!, modelIds);

--- a/engine/src/routes/auditTap.ts
+++ b/engine/src/routes/auditTap.ts
@@ -37,8 +37,11 @@ const TRANSIENT_MARKERS = [
   "/suggest-",
   "/estimate",
   "/test-connection",
-  "/tune",
-  "/validate",
+  // Deliberately narrow: "/tune" alone would also swallow /tune/publish - the one tuning call
+  // that permanently rewrites a production rubric and MUST land in the audit trail.
+  "/tune/validate",
+  "/tune/preview",
+  "/validate-tuning",
   "/mcp-oauth",
 ];
 

--- a/engine/src/routes/evaluateDashboard.ts
+++ b/engine/src/routes/evaluateDashboard.ts
@@ -273,6 +273,10 @@ evaluateDashboardRouter.get("/evaluationSettings/:id/versions", async (req: Requ
 
 evaluateDashboardRouter.delete("/evaluationSettings/:id/versions/:versionId", async (req: Request, res: Response) => {
   const deleted = await deleteEvaluationSettingsVersion(scopedDb(req), req.params.id!, req.params.versionId!);
+  if (!deleted) {
+    res.status(404).json({ error: "Version not found" });
+    return;
+  }
   res.status(200).json({ deleted });
 });
 
@@ -296,6 +300,10 @@ evaluateDashboardRouter.get("/datasets/:id/versions", async (req: Request, res: 
 
 evaluateDashboardRouter.delete("/datasets/:id/versions/:versionId", async (req: Request, res: Response) => {
   const deleted = await deleteDatasetVersion(scopedDb(req), req.params.id!, req.params.versionId!);
+  if (!deleted) {
+    res.status(404).json({ error: "Version not found" });
+    return;
+  }
   res.status(200).json({ deleted });
 });
 
@@ -559,8 +567,8 @@ evaluateDashboardRouter.post("/agent-connectors", async (req: Request, res: Resp
     res.status(400).json({ error: "name is required" });
     return;
   }
-  if (typeof body.url !== "string" || !body.url.trim()) {
-    res.status(400).json({ error: "url is required" });
+  if (!isHttpUrl(body.url)) {
+    res.status(400).json({ error: "url must be an http(s) URL" });
     return;
   }
   const connector = await createAgentConnector(scopedDb(req), {
@@ -574,6 +582,10 @@ evaluateDashboardRouter.post("/agent-connectors", async (req: Request, res: Resp
 
 evaluateDashboardRouter.put("/agent-connectors/:id", async (req: Request, res: Response) => {
   const body = req.body ?? {};
+  if (body.url !== undefined && !isHttpUrl(body.url)) {
+    res.status(400).json({ error: "url must be an http(s) URL" });
+    return;
+  }
   const connector = await updateAgentConnector(scopedDb(req), req.params.id!, {
     name: typeof body.name === "string" ? body.name : undefined,
     url: typeof body.url === "string" ? body.url : undefined,
@@ -601,8 +613,8 @@ evaluateDashboardRouter.delete("/agent-connectors/:id", async (req: Request, res
 // posture as core/evaluate/models.ts's testCustomModelConnection.
 evaluateDashboardRouter.post("/agent-connectors/test-connection", async (req: Request, res: Response) => {
   const body = req.body ?? {};
-  if (typeof body.url !== "string" || !body.url.trim()) {
-    res.status(400).json({ error: "url is required" });
+  if (!isHttpUrl(body.url)) {
+    res.status(400).json({ error: "url must be an http(s) URL" });
     return;
   }
   const result = await testAgentConnectorConnection({
@@ -671,7 +683,9 @@ evaluateDashboardRouter.post("/playground/run", async (req: Request, res: Respon
     const ids = value.filter((id): id is string => typeof id === "string" && id.trim().length > 0);
     return ids.length > 0 ? ids : undefined;
   };
-  const result = await runPlayground(scopedDb(req), {
+  let result;
+  try {
+    result = await runPlayground(scopedDb(req), {
     model: body.model,
     messages: body.messages,
     query: body.query,
@@ -684,9 +698,15 @@ evaluateDashboardRouter.post("/playground/run", async (req: Request, res: Respon
     onlineEvaluatorIds: extractIds(body.onlineEvaluatorIds),
     additionalScorerIds: extractIds(body.additionalScorerIds),
     scorerGroupId: typeof body.scorerGroupId === "string" && body.scorerGroupId ? body.scorerGroupId : undefined,
-    maxTokens: typeof body.maxTokens === "number" ? body.maxTokens : undefined,
-    temperature: typeof body.temperature === "number" ? body.temperature : undefined,
-  });
+      maxTokens: typeof body.maxTokens === "number" ? body.maxTokens : undefined,
+      temperature: typeof body.temperature === "number" ? body.temperature : undefined,
+    });
+  } catch (err) {
+    // Same class and shape as /synthesize-cases: the common real-world failure here is a
+    // missing/invalid provider key, and it must not read as an engine fault (500).
+    res.status(502).json({ error: err instanceof Error ? err.message : "Playground run failed" });
+    return;
+  }
   res.status(200).json(result);
 });
 
@@ -811,7 +831,11 @@ evaluateDashboardRouter.patch("/playground/runs/:id", async (req: Request, res: 
     res.status(400).json({ error: "results is required" });
     return;
   }
-  await updatePlaygroundRunResults(scopedDb(req), req.params.id!, body.results);
+  const updated = await updatePlaygroundRunResults(scopedDb(req), req.params.id!, body.results);
+  if (!updated) {
+    res.status(404).json({ error: "Playground run not found" });
+    return;
+  }
   res.status(200).json({ ok: true });
 });
 
@@ -961,6 +985,10 @@ evaluateDashboardRouter.post("/mcp/tools", async (req: Request, res: Response) =
   // The OAuth redirect URI must be browser-reachable: explicit AGENTX_PUBLIC_URL wins (proxied
   // deployments), else the origin this request arrived on (localhost self-host).
   const base = process.env.AGENTX_PUBLIC_URL?.trim() || `${req.protocol}://${req.get("host")}`;
+  if (!isHttpUrl(body.serverUrl)) {
+    res.status(400).json({ error: "serverUrl must be an http(s) URL" });
+    return;
+  }
   const result = await loadMcpTools({
     serverUrl: body.serverUrl,
     headers,
@@ -1568,8 +1596,8 @@ async function toEvaluateWire(db: Db, run: FullRunRow, includeResults: boolean) 
     resultCount: results.length,
     liveStatistics: {
       averageRating,
-      minRating: rated.length ? Math.min(...rated) : null,
-      maxRating: rated.length ? Math.max(...rated) : null,
+      minRating: rated.length ? rated.reduce((a, b) => (b < a ? b : a)) : null,
+      maxRating: rated.length ? rated.reduce((a, b) => (b > a ? b : a)) : null,
       ratedCount: rated.length,
       skippedCount: results.filter(r => r.status === "skipped").length,
       failedCount: results.filter(r => r.status === "failed").length,

--- a/engine/src/routes/evaluations.ts
+++ b/engine/src/routes/evaluations.ts
@@ -175,6 +175,12 @@ evaluationsRouter.post("/runs/:runId/results", async (req: Request, res: Respons
     res.status(400).json({ error: `Batch size must not exceed ${MAX_BATCH_SIZE}` });
     return;
   }
+  // Element shape is validated HERE, not discovered as a TypeError inside appendResults - a
+  // null/non-object element used to surface as a 409 carrying the raw engine error message.
+  if (!results.every((item: unknown) => !!item && typeof item === "object" && !Array.isArray(item))) {
+    res.status(400).json({ error: "Every results entry must be an object" });
+    return;
+  }
 
   try {
     const outcome = await appendResults(scopedDb(req), req.params.runId!, batchId, results);
@@ -186,7 +192,14 @@ evaluationsRouter.post("/runs/:runId/results", async (req: Request, res: Respons
     // run.average_rating updates as scoring lands, not only at finalize.
     res.status(200).json({ ...outcome, liveStatistics: await computeLiveStatistics(scopedDb(req), req.params.runId!) });
   } catch (err) {
-    res.status(409).json({ error: err instanceof Error ? err.message : "Unable to append results" });
+    // The only expected throw is the terminal-state guard - a real conflict. Anything else is
+    // an engine fault and must not masquerade as one.
+    const message = err instanceof Error ? err.message : "Unable to append results";
+    if (message.includes("terminal state")) {
+      res.status(409).json({ error: message });
+      return;
+    }
+    throw err;
   }
 });
 

--- a/engine/src/routes/insights.ts
+++ b/engine/src/routes/insights.ts
@@ -4,6 +4,7 @@ import { asyncRouter } from "./asyncRouter.js";
 import { validateBody } from "./validateBody.js";
 import { scopedDb } from "../auth/apiKey.js";
 import { curateCasesFromTraces, getCoverage } from "../core/insights/coverage.js";
+import { getCoverageMap } from "../core/insights/coverageMap.js";
 import { probe, probeBatch } from "../core/insights/probe.js";
 import type { MonitoringRange, MonitoringWindow } from "../core/monitor/events.js";
 
@@ -62,6 +63,13 @@ const scopeOf = (body: { datasetIds?: string[]; datasetId?: string }): string[] 
 // The sweep: three headline numbers, the topic list with its state, and the off-map cases.
 insightsRouter.get("/coverage", async (req: Request, res: Response) => {
   res.status(200).json(await getCoverage(scopedDb(req), { window: parseRange(req), datasetIds: datasetIdsOf(req) }));
+});
+
+// The coverage MAP: production traces and dataset cases in ONE joint UMAP projection - see
+// core/insights/coverageMap.ts. Separate route because the UMAP fit is genuinely heavier than
+// the coverage sweep, and a caller only pays for it with the Map tab open.
+insightsRouter.get("/coverage/map", async (req: Request, res: Response) => {
+  res.status(200).json(await getCoverageMap(scopedDb(req), { window: parseRange(req), datasetIds: datasetIdsOf(req) }));
 });
 
 const probeSchema = z

--- a/engine/src/routes/monitor.ts
+++ b/engine/src/routes/monitor.ts
@@ -95,8 +95,10 @@ monitorRouter.get("/patterns/:id", async (req: Request, res: Response) => {
 });
 
 monitorRouter.get("/profiles/:agentId", async (req: Request, res: Response) => {
-  const agentId = await resolveAgentId(scopedDb(req), req.params.agentId!);
-  const profile = await getProfile(scopedDb(req), agentId);
+  // Read-side resolution: a GET must never create an agent row (resolveAgentId auto-registers
+  // unknown names - correct for the PUT below, wrong for a lookup or a stale-id poll).
+  const agentId = await resolveExistingAgentId(scopedDb(req), req.params.agentId!);
+  const profile = agentId ? await getProfile(scopedDb(req), agentId) : null;
   res.status(200).json({ profile: profile ?? null });
 });
 
@@ -131,7 +133,7 @@ monitorRouter.get("/signals", async (req: Request, res: Response) => {
       agentId: typeof agentId === "string" ? await resolveExistingAgentId(scopedDb(req), agentId) : undefined,
       polarity: typeof polarity === "string" ? polarity : undefined,
     },
-    limit ? Math.min(Number(limit) || 50, 100) : 50
+    limit ? Math.min(Math.max(1, Number(limit) || 50), 100) : 50
   );
   res.status(200).json({ signals });
 });

--- a/engine/src/routes/outcomes.ts
+++ b/engine/src/routes/outcomes.ts
@@ -22,13 +22,20 @@ outcomesRouter.post("/", async (req: Request, res: Response) => {
     res.status(400).json({ error: "isNegative (boolean) is required" });
     return;
   }
-  if (!body.traceId && !body.evaluationRunResultId) {
-    res.status(400).json({ error: "traceId or evaluationRunResultId is required" });
+  const traceId = typeof body.traceId === "string" && body.traceId.trim() ? body.traceId : undefined;
+  const runResultId =
+    typeof body.evaluationRunResultId === "string" && body.evaluationRunResultId.trim()
+      ? body.evaluationRunResultId
+      : undefined;
+  // Both checked as STRINGS - a numeric/object id used to pass the truthy guard and then be
+  // stored as null, creating an orphan ground-truth row calibration can never join.
+  if (!traceId && !runResultId) {
+    res.status(400).json({ error: "traceId or evaluationRunResultId (string) is required" });
     return;
   }
   const report = await createOutcomeReport(scopedDb(req), {
-    traceId: typeof body.traceId === "string" ? body.traceId : undefined,
-    evaluationRunResultId: typeof body.evaluationRunResultId === "string" ? body.evaluationRunResultId : undefined,
+    traceId,
+    evaluationRunResultId: runResultId,
     outcome: body.outcome,
     isNegative: body.isNegative,
     reason: typeof body.reason === "string" ? body.reason : undefined,

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -721,6 +721,7 @@ export function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean }
       case_key TEXT NOT NULL,
       query TEXT NOT NULL,
       embedding TEXT,
+      input_embedding TEXT,
       embedding_full TEXT,
       model TEXT,
       created_at INTEGER NOT NULL
@@ -1098,6 +1099,7 @@ export function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean }
     // pairwise_comparisons shipped before the both-orders pass existed; an install upgraded past
     // that point 500s on every new comparison without this (fresh DBs get it via CREATE TABLE).
     ["pairwise_comparisons", "ALTER TABLE pairwise_comparisons ADD COLUMN both_orders INTEGER NOT NULL DEFAULT 0"],
+    ["monitor_classifications", "ALTER TABLE monitor_classifications ADD COLUMN input_embedding TEXT"],
     ["monitor_signal_feedback", "ALTER TABLE monitor_signal_feedback ADD COLUMN event_id TEXT"],
     ["monitor_profiles", "ALTER TABLE monitor_profiles ADD COLUMN topics_enabled INTEGER NOT NULL DEFAULT 0"],
     ["traces", "ALTER TABLE traces ADD COLUMN span_id TEXT"],
@@ -2082,6 +2084,7 @@ export async function bootstrapPostgres(pool: Pool): Promise<{ freshInstall: boo
       case_key TEXT NOT NULL,
       query TEXT NOT NULL,
       embedding JSONB,
+      input_embedding JSONB,
       embedding_full JSONB,
       model TEXT,
       created_at TIMESTAMP NOT NULL
@@ -2406,6 +2409,7 @@ export async function bootstrapPostgres(pool: Pool): Promise<{ freshInstall: boo
     ALTER TABLE monitor_patterns ADD COLUMN IF NOT EXISTS agent_ids JSONB;
     ALTER TABLE pairwise_comparisons ADD COLUMN IF NOT EXISTS both_orders BOOLEAN NOT NULL DEFAULT FALSE;
     ALTER TABLE evaluation_runs ADD COLUMN IF NOT EXISTS scorer_group_id TEXT;
+    ALTER TABLE monitor_classifications ADD COLUMN IF NOT EXISTS input_embedding JSONB;
     ALTER TABLE monitor_profiles ADD COLUMN IF NOT EXISTS channels JSONB;
     ALTER TABLE monitor_signals ADD COLUMN IF NOT EXISTS review_status TEXT;
     ALTER TABLE monitor_signals ADD COLUMN IF NOT EXISTS resolution_reason TEXT;

--- a/engine/src/storage/schema.pg.ts
+++ b/engine/src/storage/schema.pg.ts
@@ -323,6 +323,7 @@ export const monitorClassifications = pgTable("monitor_classifications", {
   projectId: text("project_id"),
   // See schema.sqlite.ts's embedding column for the full comment.
   embedding: jsonb("embedding"),
+  inputEmbedding: jsonb("input_embedding"),
 });
 
 

--- a/engine/src/storage/schema.sqlite.ts
+++ b/engine/src/storage/schema.sqlite.ts
@@ -497,6 +497,9 @@ export const monitorClassifications = sqliteTable("monitor_classifications", {
   // the Topics "Map" view's UMAP projection (core/monitor/topics.ts's getTopicsMap); not
   // backfilled for rows classified before this column existed.
   embedding: text("embedding", { mode: "json" }),
+  // Query-only embedding (the trace INPUT alone) - the coverage map's question space, where an
+  // identical question from production and a dataset lands in the same spot. Backfilled lazily.
+  inputEmbedding: text("input_embedding", { mode: "json" }),
 });
 
 // core/insights/: one cached embedding per distinct dataset case query. Keyed by a content hash

--- a/engine/src/test/insights.integration.test.ts
+++ b/engine/src/test/insights.integration.test.ts
@@ -3,6 +3,7 @@ import { nanoid } from "nanoid";
 import { openTestDb, type TestDb } from "./dbHarness.js";
 import type { Db } from "../storage/db.js";
 import { curateCasesFromTraces, getCoverage } from "../core/insights/coverage.js";
+import { getCoverageMap } from "../core/insights/coverageMap.js";
 import { probe, probeBatch } from "../core/insights/probe.js";
 import { caseKeyFor } from "../core/insights/cases.js";
 import { createDataset, getDataset } from "../core/evaluate/datasets.js";
@@ -113,6 +114,8 @@ async function classify(opts: {
     createdAt: opts.createdAt ?? new Date(),
     projectId: db.projectId,
     embedding: opts.angle === null ? null : unit(opts.angle),
+    // Question-space twin (coverage map) - same angle keeps the test geometry readable.
+    inputEmbedding: opts.angle === null ? null : unit(opts.angle),
   });
 }
 
@@ -793,5 +796,95 @@ describe("the probe", () => {
     expect(result.rollup.covered).toBe(1);
     expect(result.rollup.gap).toBe(1);
     expect(result.rollup.untestedAndUnasked).toBe(1);
+  });
+});
+
+describe("coverage map (joint UMAP over both sources)", () => {
+  it("projects production traces and dataset cases into one picture, topics matched consistently", async () => {
+    const scoped = test.scoped(await test.newProject("Map"));
+    const saved = db;
+    db = scoped;
+    try {
+      for (let i = 0; i < 6; i++) {
+        await classify({ intent: "refund request", angle: SAME });
+        await classify({ intent: "vpn issue", angle: UNRELATED });
+      }
+      const dsId = await newDataset("map-ds", [
+        { query: "I want a refund", angle: SAME },
+        { query: "refund my order", angle: NEAR },
+        // Far from BOTH topic centroids - must land as "unmatched", not get force-assigned.
+        { query: "totally unrelated thing", angle: 2.8 },
+      ]);
+
+      const result = await getCoverageMap(db, { window: "7d", datasetIds: [dsId] });
+      expect(result.insufficientData).toBe(false);
+      expect(result.degradedReason).toBeNull();
+
+      const production = result.points.filter(p => p.source === "production");
+      const dataset = result.points.filter(p => p.source === "dataset");
+      expect(production).toHaveLength(12);
+      expect(dataset).toHaveLength(3);
+      // One joint projection: every point has real coordinates.
+      expect(result.points.every(p => Number.isFinite(p.x) && Number.isFinite(p.y))).toBe(true);
+
+      // Dataset points carry the SAME topic assignment the coverage table would give them.
+      const byQuery = Object.fromEntries(dataset.map(p => [p.query, p.topic]));
+      expect(byQuery["I want a refund"]).toBe("refund request");
+      expect(byQuery["refund my order"]).toBe("refund request");
+      expect(byQuery["totally unrelated thing"]).toBe("unmatched");
+
+      const refund = result.topics.find(t => t.topic === "refund request");
+      expect(refund).toMatchObject({ productionCount: 6, datasetCount: 2 });
+
+      // THE property the map exists for: an identical question from both sources (identical
+      // question-space vectors here) sits together, far from the unrelated cluster.
+      const dist = (a: { x: number; y: number }, b: { x: number; y: number }) =>
+        Math.hypot(a.x - b.x, a.y - b.y);
+      const refundCase = dataset.find(p => p.query === "I want a refund")!;
+      const nearestRefundProd = Math.min(
+        ...production.filter(p => p.topic === "refund request").map(p => dist(p, refundCase))
+      );
+      const nearestVpnProd = Math.min(...production.filter(p => p.topic === "vpn issue").map(p => dist(p, refundCase)));
+      expect(nearestRefundProd).toBeLessThan(nearestVpnProd);
+
+      // Dataset scoping is honored - an empty scope covers every dataset, a bogus one none.
+      const scopedOut = await getCoverageMap(db, { window: "7d", datasetIds: ["nope"] });
+      expect(scopedOut.insufficientData).toBe(true);
+    } finally {
+      db = saved;
+    }
+  });
+
+  it("refuses to draw below the point floor or without embeddings, with an honest reason", async () => {
+    const scoped = test.scoped(await test.newProject("MapEmpty"));
+    const saved = db;
+    db = scoped;
+    try {
+      // Classified traffic but zero dataset cases.
+      for (let i = 0; i < 6; i++) {
+        await classify({ intent: "refund request", angle: SAME });
+      }
+      const noCases = await getCoverageMap(db, { window: "7d" });
+      expect(noCases.insufficientData).toBe(true);
+      expect(noCases.degradedReason).toContain("No dataset cases");
+
+      // Cases but no embedded production traffic.
+      const scoped2 = test.scoped(await test.newProject("MapEmpty2"));
+      db = scoped2;
+      const dsId = await newDataset("bare", [{ query: "hello", angle: SAME }]);
+      const noTraces = await getCoverageMap(db, { window: "7d", datasetIds: [dsId] });
+      expect(noTraces.insufficientData).toBe(true);
+      expect(noTraces.degradedReason).toContain("No classified production traffic");
+
+      // Historical rows without a question-space embedding (and nothing registered to embed
+      // them with) are excluded and counted, never silently dropped.
+      for (let i = 0; i < 3; i++) {
+        await classify({ intent: "legacy", angle: null });
+      }
+      const pendingRes = await getCoverageMap(db, { window: "7d", datasetIds: [dsId] });
+      expect(pendingRes.traceEmbeddingsPending).toBe(3);
+    } finally {
+      db = saved;
+    }
   });
 });

--- a/engine/src/test/scorerGroups.integration.test.ts
+++ b/engine/src/test/scorerGroups.integration.test.ts
@@ -345,3 +345,77 @@ describe("scorer groups", () => {
     expect(kpis.totalRuns).toBe(1);
   }, 30_000);
 });
+
+describe("session-scope scorer groups", () => {
+  it("the idle-session sweep scores a multi-turn session with a session-scoped group", async () => {
+    const harshId = await makeJudge("Session harsh", "HARSHMARK"); // rates 2
+    const group = await api(
+      "/agent-monitoring/scorer-groups",
+      postJson({
+        name: "Session group",
+        members: [{ kind: "judge", refId: harshId, weight: 1 }],
+        // idleSeconds 0: the session qualifies as idle immediately, so the manual sweep run
+        // below picks it up without the test having to wait out a real idle window.
+        online: { enabled: true, sampleRate: 1, alertThreshold: 5, severity: "high", scope: "session", idleSeconds: 0 },
+      })
+    );
+    expect(group.status).toBe(201);
+    const groupId = (group.body as { scorerGroup: { _id: string } }).scorerGroup._id;
+    const wired = (group.body as { scorerGroup: { online: { scope?: string; idleSeconds?: number } } }).scorerGroup;
+    expect(wired.online.scope).toBe("session");
+
+    // Two turns in one session - the sweep only judges multi-turn sessions.
+    for (const [i, [input, output]] of [
+      ["book a table", "sure, for when?"],
+      ["tomorrow 7pm", "booked!"],
+    ].entries()) {
+      const ingested = await api(
+        "/ingest/traces",
+        postJson({ name: "conv-agent", span_id: `sg-sess-${i}`, session_id: "sg-conv-1", input, output })
+      );
+      expect(ingested.status).toBe(200);
+    }
+    // The ingest path must NOT score a session-scoped group per trace - give the async
+    // pipeline a beat, then assert no per-trace group event exists yet.
+    await new Promise(resolve => setTimeout(resolve, 500));
+    const preSweep = (await api(`/agent-monitoring/scorer-groups/${groupId}/ratings?window=24h`)).body as {
+      points: Array<{ count: number }>;
+    };
+    expect(preSweep.points.every(p => p.count === 0)).toBe(true);
+
+    const swept = await api("/agent-monitoring/session-sweep/run", postJson({}));
+    expect(swept.status).toBe(200);
+
+    // The group verdict lands as a session score (kind scorer-group:<id>)...
+    const scores = (await api("/agent-monitoring/sessions/sg-conv-1/scores")).body as {
+      scores: Array<{ kind: string; rating: number | null; justification: string | null }>;
+    };
+    const groupScore = scores.scores.find(s => s.kind === `scorer-group:${groupId}`);
+    expect(groupScore, "expected a scorer-group session score").toBeTruthy();
+    expect(groupScore!.rating).toBe(2);
+    expect(groupScore!.justification).toContain("Session harsh");
+
+    // ...raises a below-threshold Signal keyed on the group...
+    const signals = ((await api("/agent-monitoring/signals")).body as {
+      signals: Array<{ patternKey?: string; type?: string; summary?: string }>;
+    }).signals.filter(s => s.patternKey === `scorer-group:${groupId}`);
+    expect(signals.length).toBeGreaterThan(0);
+    expect(signals[0]!.type).toBe("scorer_group_low_session_score");
+    expect(signals[0]!.summary).toContain("rated session sg-conv-1");
+
+    // ...and joins the group's ratings history alongside trace-scope verdicts.
+    const ratings = (await api(`/agent-monitoring/scorer-groups/${groupId}/ratings?window=24h`)).body as {
+      points: Array<{ count: number; averageRating: number | null }>;
+    };
+    const rated = ratings.points.filter(p => p.count > 0);
+    expect(rated.length).toBeGreaterThan(0);
+    expect(rated[0]!.averageRating).toBe(2);
+
+    // Freshness: a second sweep with no new session activity judges nothing again.
+    await api("/agent-monitoring/session-sweep/run", postJson({}));
+    const after = (await api("/agent-monitoring/sessions/sg-conv-1/scores")).body as {
+      scores: Array<{ kind: string }>;
+    };
+    expect(after.scores.filter(s => s.kind === `scorer-group:${groupId}`).length).toBe(1);
+  }, 45_000);
+});


### PR DESCRIPTION
<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
