### PR TITLE
group scorer with session test scripts

### DIFF
--- a/engine/src/test/coverageMap.pg.test.ts
+++ b/engine/src/test/coverageMap.pg.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { nanoid } from "nanoid";
+import { openTestDb, type TestDb } from "./dbHarness.js";
+import type { Db } from "../storage/db.js";
+import { getCoverageMap } from "../core/insights/coverageMap.js";
+import { createDataset } from "../core/evaluate/datasets.js";
+import { caseKeyFor } from "../core/insights/cases.js";
+
+// Postgres twin for the one dialect-branched WRITE in the coverage-map path: the lazy
+// question-space backfill (coverageMap.ts persists input_embedding with a per-dialect UPDATE).
+// The sqlite branch is covered by insights.integration.test.ts; openTestDb allows one database
+// per worker, which is why this lives in its own file. Opt-in via AGENTX_TEST_DB_URL like every
+// other Postgres suite.
+
+const { registered } = vi.hoisted(() => ({ registered: new Map<string, number[]>() }));
+
+vi.mock("../core/evaluate/judge.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../core/evaluate/judge.js")>();
+  const one = (text: string): number[] | null => registered.get(text.trim()) ?? null;
+  return {
+    ...actual,
+    embeddingsAvailable: async () => true,
+    computeEmbedding: async (text: string) => one(text),
+    computeEmbeddings: async (texts: string[]) => texts.map(one),
+  };
+});
+
+const unit = (angle: number): number[] => [Math.cos(angle), Math.sin(angle), 0, 0];
+
+// Same narrowing trick as insights.integration.test.ts's insertRow: the sqlite/pg handle union
+// isn't callable until db.kind narrows it, even though both branches are the same statement.
+async function insertRow(handle: Db, table: unknown, values: Record<string, unknown>): Promise<void> {
+  if (handle.kind === "sqlite") {
+    await handle.db.insert(table as Parameters<typeof handle.db.insert>[0]).values(values as never);
+  } else {
+    await handle.db.insert(table as Parameters<typeof handle.db.insert>[0]).values(values as never);
+  }
+}
+
+let test: TestDb;
+let db: Db;
+
+async function classify(opts: { intent: string; input: string; embedded: boolean }): Promise<void> {
+  const traceId = nanoid();
+  await insertRow(db, db.schema.traces, {
+    id: traceId,
+    name: "insights-agent",
+    input: opts.input,
+    output: "a",
+    projectId: db.projectId,
+    createdAt: new Date(),
+  });
+  await insertRow(db, db.schema.monitorClassifications, {
+    id: nanoid(),
+    traceId,
+    agentId: null,
+    intent: opts.intent,
+    sentiment: "neutral",
+    issueType: "none",
+    createdAt: new Date(),
+    projectId: db.projectId,
+    embedding: unit(0),
+    inputEmbedding: opts.embedded ? unit(0) : null,
+  });
+}
+
+describe.skipIf(!process.env.AGENTX_TEST_DB_URL)("coverage map on Postgres", () => {
+  beforeAll(async () => {
+    test = await openTestDb({ postgres: true });
+    db = test.scoped(await test.newProject("MapPg"));
+  }, 60_000);
+
+  afterAll(async () => {
+    await test?.close();
+  });
+
+  it("lazily backfills input_embedding through the pg branch and reads it back on the next call", async () => {
+    for (let i = 0; i < 6; i++) {
+      await classify({ intent: "refund request", input: "I want a refund", embedded: true });
+    }
+    // Historical rows: classified before the question-space column existed (inputEmbedding
+    // null), but their input text embeds - exactly what the lazy backfill is for.
+    const legacyTexts = ["legacy q 0", "legacy q 1", "legacy q 2"];
+    for (const text of legacyTexts) {
+      registered.set(text, unit(0.3));
+      await classify({ intent: "refund request", input: text, embedded: false });
+    }
+
+    const query = "I want a refund";
+    const dataset = await createDataset(db, {
+      name: "map-pg-ds",
+      questions: [{ main_question: { query, expectedResults: `expected for ${query}` }, follow_up_questions: [] }],
+    });
+    const datasetId = (dataset as { _id: string })._id;
+    await insertRow(db, db.schema.insightCaseEmbeddings, {
+      id: nanoid(),
+      projectId: db.projectId,
+      datasetId,
+      caseKey: caseKeyFor(query, `expected for ${query}`),
+      query,
+      embedding: unit(0),
+      embeddingFull: unit(0),
+      model: "test-injected",
+      createdAt: new Date(),
+    });
+
+    const first = await getCoverageMap(db, { window: "7d", datasetIds: [datasetId] });
+    expect(first.insufficientData).toBe(false);
+    expect(first.traceEmbeddingsPending).toBe(0);
+    expect(first.points.filter(p => p.source === "production")).toHaveLength(9);
+
+    // Persistence, not recomputation: forget the texts the mock could embed - a second call
+    // must serve the same 9 points from the input_embedding column the UPDATE wrote.
+    for (const text of legacyTexts) {
+      registered.delete(text);
+    }
+    const second = await getCoverageMap(db, { window: "7d", datasetIds: [datasetId] });
+    expect(second.traceEmbeddingsPending).toBe(0);
+    expect(second.points.filter(p => p.source === "production")).toHaveLength(9);
+  }, 30_000);
+});

--- a/engine/src/test/insights.integration.test.ts
+++ b/engine/src/test/insights.integration.test.ts
@@ -888,3 +888,4 @@ describe("coverage map (joint UMAP over both sources)", () => {
     }
   });
 });
+

--- a/engine/src/test/scorerGroups.integration.test.ts
+++ b/engine/src/test/scorerGroups.integration.test.ts
@@ -419,3 +419,123 @@ describe("session-scope scorer groups", () => {
     expect(after.scores.filter(s => s.kind === `scorer-group:${groupId}`).length).toBe(1);
   }, 45_000);
 });
+
+// ---------------------------------------------------------------------------------------------
+// Backend matrix: the same session-scope flow on Postgres (control plane dialect #2) and with
+// ClickHouse telemetry (spans live in CH, session sweep reads them through the trace store).
+// Opt-in like every other dialect suite: AGENTX_TEST_DB_URL / AGENTX_TEST_CLICKHOUSE_URL.
+// ---------------------------------------------------------------------------------------------
+
+async function runSessionGroupFlow(eng: TestEngine, projectName: string) {
+  const created = await eng.json("/api/v1/projects", { ...postJson({ name: projectName }), apiKey: null });
+  const projectKey = (created.body as { project: { apiKey: string } }).project.apiKey;
+  const call = (path: string, init?: Parameters<TestEngine["json"]>[1]) =>
+    eng.json(`/api/v1${path}`, { apiKey: projectKey, ...(init ?? {}) });
+
+  const model = await call(
+    "/agent-monitoring/portability/models",
+    postJson({
+      id: "stub-judge-sx",
+      provider: "custom",
+      label: "Stub judge SX",
+      baseUrl: stubUrl,
+      pricePerMInputTokens: 0,
+      pricePerMOutputTokens: 0,
+    })
+  );
+  expect(model.status).toBe(201);
+  const judge = await call(
+    "/agent-monitoring/judge-scorers",
+    postJson({ name: "Matrix harsh", judge: { evaluationCriteria: "Judge with HARSHMARK.", judgeModel: "stub-judge-sx" } })
+  );
+  expect(judge.status).toBe(201);
+  const judgeId = (judge.body as { judgeScorer: { _id: string } }).judgeScorer._id;
+
+  const group = await call(
+    "/agent-monitoring/scorer-groups",
+    postJson({
+      name: "Matrix session group",
+      members: [{ kind: "judge", refId: judgeId, weight: 1 }],
+      online: { enabled: true, sampleRate: 1, alertThreshold: 5, severity: "high", scope: "session", idleSeconds: 0 },
+    })
+  );
+  expect(group.status).toBe(201);
+  const groupId = (group.body as { scorerGroup: { _id: string } }).scorerGroup._id;
+
+  for (const [i, [input, output]] of [
+    ["first question", "vague answer"],
+    ["follow-up", "still vague"],
+  ].entries()) {
+    const ingested = await call(
+      "/ingest/traces",
+      postJson({ name: "matrix-agent", span_id: `mx-${i}`, session_id: "mx-conv-1", input, output })
+    );
+    expect(ingested.status).toBe(200);
+  }
+  // CH mode ingests through a queue; wait until the session's spans are readable before sweeping.
+  let spanCount = 0;
+  for (let i = 0; i < 40 && spanCount < 2; i++) {
+    const spans = (await call("/ingest/sessions/mx-conv-1/spans")).body as { spans?: unknown[] };
+    spanCount = spans.spans?.length ?? 0;
+    if (spanCount < 2) await new Promise(resolve => setTimeout(resolve, 250));
+  }
+  expect(spanCount).toBe(2);
+
+  const swept = await call("/agent-monitoring/session-sweep/run", postJson({}));
+  expect(swept.status).toBe(200);
+
+  const scores = (await call("/agent-monitoring/sessions/mx-conv-1/scores")).body as {
+    scores: Array<{ kind: string; rating: number | null }>;
+  };
+  const groupScore = scores.scores.find(s => s.kind === `scorer-group:${groupId}`);
+  expect(groupScore, "expected a scorer-group session score").toBeTruthy();
+  expect(groupScore!.rating).toBe(2);
+
+  const signals = ((await call("/agent-monitoring/signals")).body as {
+    signals: Array<{ patternKey?: string; type?: string }>;
+  }).signals.filter(s => s.patternKey === `scorer-group:${groupId}`);
+  expect(signals.length).toBeGreaterThan(0);
+  expect(signals[0]!.type).toBe("scorer_group_low_session_score");
+
+  const ratings = (await call(`/agent-monitoring/scorer-groups/${groupId}/ratings?window=24h`)).body as {
+    points: Array<{ count: number; averageRating: number | null }>;
+  };
+  expect(ratings.points.some(p => p.count > 0 && p.averageRating === 2)).toBe(true);
+}
+
+const PG_AVAILABLE = Boolean(process.env.AGENTX_TEST_DB_URL);
+describe.skipIf(!PG_AVAILABLE)("session-scope scorer groups on Postgres", () => {
+  let pgEngine: TestEngine;
+  beforeAll(async () => {
+    pgEngine = await startEngine({ OPENAI_API_KEY: "", ANTHROPIC_API_KEY: "", GEMINI_API_KEY: "" }, { postgres: true });
+  }, 90_000);
+  afterAll(async () => {
+    await pgEngine?.stop();
+  });
+
+  it("sweeps, scores, and signals identically on the Postgres control plane", async () => {
+    expect(pgEngine.backend).toBe("postgres");
+    await runSessionGroupFlow(pgEngine, "sg-session-pg");
+  }, 45_000);
+});
+
+const CH_URL_MATRIX = process.env.AGENTX_TEST_CLICKHOUSE_URL;
+describe.skipIf(!CH_URL_MATRIX)("session-scope scorer groups with ClickHouse telemetry", () => {
+  let chEngine: TestEngine;
+  beforeAll(async () => {
+    chEngine = await startEngine({
+      OPENAI_API_KEY: "",
+      ANTHROPIC_API_KEY: "",
+      GEMINI_API_KEY: "",
+      AGENTX_TELEMETRY_URL: CH_URL_MATRIX!,
+    });
+  }, 90_000);
+  afterAll(async () => {
+    await chEngine?.stop();
+  });
+
+  it("the sweep assembles the transcript from ClickHouse spans and scores it", async () => {
+    expect(chEngine.log()).toContain("Telemetry store: ClickHouse");
+    await runSessionGroupFlow(chEngine, "sg-session-ch");
+  }, 45_000);
+});


### PR DESCRIPTION
<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
