### PR TITLE
docs: cover smoke-binary.sh and pin the toolchain versions CI builds on

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,12 +281,14 @@ That is a focused subset. The full eval workflow lives in
 | `install.sh`           | The `curl \| bash` installer - downloads the platform binary from GitHub Releases.                                                                                                                                                                                     |
 | `build.sh`             | Builds a local `dist/` laid out the same way a real install would, for testing the full distribution without cutting a release.                                                                                                                                        |
 | `Dockerfile`           | Multi-stage build producing a container image - see [Docker](#docker).                                                                                                                                                                                                 |
-| `scripts/`             | `smoke-test.sh` / `smoke_test.py` - end-to-end verification against a real running engine and the real Python SDK.                                                                                                                                                     |
+| `scripts/`             | `smoke-test.sh` / `smoke_test.py` - end-to-end verification against a real running engine and the real Python SDK. `smoke-binary.sh` covers the compiled binary instead, which takes the `bun:sqlite` branch nothing under `engine/src/test` reaches.                    |
 
 ## Building from source
 
 Prerequisites: [Go](https://go.dev/), Node.js + [Yarn](https://yarnpkg.com/), and
 [Bun](https://bun.sh/) (only needed for the compiled single-binary path, not day-to-day dev).
+CI builds on Node.js 24.x, Bun 1.3.14, and the Go toolchain in `cli/go.mod`, so those are the
+versions a local pass predicts a green build against.
 
 ```bash
 git clone git@github.com:AgentX-ai/AgentX-trace-eval.git && cd AgentX-trace-eval


### PR DESCRIPTION
Two spots where the build docs do not match the repo.

**`scripts/` row in "What's in this repo"** listed `smoke-test.sh` / `smoke_test.py` only. `smoke-binary.sh` is a CI job of its own (`test.yml`'s `binary`) and the only cover the `bun:sqlite` branch gets, so leaving it out of the table made it look like an undocumented helper. It is already referenced further down under Building from source; this just makes the index agree.

**Prerequisites under Building from source** named Go, Node and Bun with no versions, while every workflow pins Node 24.x and Bun 1.3.14 and reads the Go version from `cli/go.mod`. CONTRIBUTING.md's whole framing is that a local pass should predict CI, and that only holds if the toolchain matches.

Docs only, no code touched.