### PR TITLE
fix score correctness and CH trace store

### DIFF
--- a/engine/src/core/evaluate/runs.ts
+++ b/engine/src/core/evaluate/runs.ts
@@ -474,6 +474,12 @@ async function scoreOneResult(
     });
     judged.rating = groupResult.score;
     judged.justification = describeGroupScore(groupResult, groupResult.members);
+    if (groupResult.score === null) {
+      // No member scored (or a must-pass member could not run) - surface it as a judge error
+      // so the row lands as "skipped" with the group's explanation, instead of a scored-null
+      // row that liveStatistics counts in no bucket at all.
+      judged.judgeError = new Error(judged.justification || "The scorer group produced no score");
+    }
     for (const member of groupResult.members) {
       if (member.kind === "judge") {
         judgeScorerResults.push({
@@ -579,9 +585,13 @@ export async function appendResults(
     run.datasetId,
     (run.additionalScorerIds as string[] | null) ?? []
   );
-  const scorerGroup = (run as { scorerGroupId?: string | null }).scorerGroupId
-    ? await getScorerGroup(db, (run as { scorerGroupId?: string | null }).scorerGroupId!)
-    : null;
+  const runGroupId = (run as { scorerGroupId?: string | null }).scorerGroupId ?? null;
+  const scorerGroup = runGroupId ? await getScorerGroup(db, runGroupId) : null;
+  if (runGroupId && !scorerGroup) {
+    // Falling through to the dataset's own config would grade half the run on a different
+    // rubric than the half scored before the deletion - refuse loudly instead.
+    throw new Error("The scorer group grading this run no longer exists");
+  }
 
   let accepted = 0;
   let duplicates = 0;
@@ -1071,7 +1081,9 @@ export async function getRun(db: Db, runId: string) {
     runId: run.id,
     datasetId: run.datasetId,
     evaluationSettingsId: run.evaluationSettingsId,
-    scorerGroupId: runScorerGroup?.id ?? null,
+    // The STORED id, not the resolved row's - a deleted group must not erase which grader
+    // produced this run's ratings.
+    scorerGroupId: (run as { scorerGroupId?: string | null }).scorerGroupId ?? null,
     scorerGroupName: runScorerGroup?.name ?? null,
     additionalScorerIds: (run.additionalScorerIds as string[] | null) ?? null,
     scorerBreakdown,

--- a/engine/src/core/insights/coverageMap.ts
+++ b/engine/src/core/insights/coverageMap.ts
@@ -1,7 +1,8 @@
 import { UMAP } from "umap-js";
+import { logger } from "../../log.js";
 import type { Db } from "../../storage/db.js";
 import { resolveRange, type MonitoringRange, type MonitoringWindow } from "../monitor/events.js";
-import { listClassificationsSince, type ClassificationRow } from "../monitor/topics.js";
+import { listClassificationsSince, questionTextOf, type ClassificationRow } from "../monitor/topics.js";
 import { listDatasetRows, listDatasetCases, attachCaseEmbeddings, type DatasetCase } from "./cases.js";
 import { traceStoreFor } from "../trace/store/index.js";
 import { computeEmbeddings } from "../evaluate/judge.js";
@@ -30,6 +31,8 @@ const MIN_POINTS_FOR_MAP = 10;
 // Historical rows lacking input_embedding, embedded per map request - bounded like the case
 // cache's own warming so one request never turns into hundreds of embedding calls.
 const MAX_TRACE_BACKFILL_PER_REQUEST = 100;
+// Single-flight guard for the backfill, per project - see the block below.
+const backfillInFlight = new Set<string>();
 
 export type CoverageMapPoint = {
   x: number;
@@ -77,52 +80,70 @@ export async function getCoverageMap(
   });
 
   const allRows = await listClassificationsSince(db, new Date(sinceMs), new Date(untilMs));
-  const candidates = allRows
+  const withTrace = allRows
     .filter(r => r.traceId)
-    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
-    .slice(0, MAX_POINTS_PER_SOURCE);
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  const hasVector = (r: ClassificationRow): boolean => Array.isArray(r.inputEmbedding) && r.inputEmbedding.length > 0;
+  // Plot-ready rows first, THEN cap - capping before filtering could return "no embeddings"
+  // while thousands of older embedded rows sat just past the cap.
+  const embedded = withTrace.filter(hasVector);
+  // Newest-first, BOUNDED: on a large install the un-backfilled backlog can be thousands of
+  // rows, and one map request must not fetch every one of their traces just to count them.
+  // The window converges anyway - each request backfills up to 100, so the considered slice
+  // drains front-to-back across requests.
+  const MAX_UNEMBEDDED_CONSIDERED = 500;
+  const unembedded = withTrace.filter(r => !hasVector(r)).slice(0, MAX_UNEMBEDDED_CONSIDERED);
 
-  // Question-space vectors: input_embedding when stored, else a bounded lazy backfill embedding
-  // the trace's input text now and persisting it for every later request.
+  // Texts for point labels (and the backfill) - fetched only for rows that might be plotted
+  // or backfilled this request.
   const traceTexts = await traceStoreFor(db).getByIds(
-    candidates.map(r => r.traceId).filter((id): id is string => !!id)
+    [...embedded.slice(0, MAX_POINTS_PER_SOURCE), ...unembedded]
+      .map(r => r.traceId)
+      .filter((id): id is string => !!id)
   );
-  const inputTextOf = (row: ClassificationRow): string => {
-    const input = row.traceId ? traceTexts.get(row.traceId)?.input : undefined;
-    if (typeof input === "string") return input;
-    if (input && typeof input === "object" && typeof (input as { query?: unknown }).query === "string") {
-      return (input as { query: string }).query;
-    }
-    return input ? JSON.stringify(input) : "";
-  };
+  const inputTextOf = (row: ClassificationRow): string =>
+    questionTextOf(row.traceId ? traceTexts.get(row.traceId)?.input : undefined);
 
-  const missing = candidates
-    .filter(r => !Array.isArray(r.inputEmbedding) || r.inputEmbedding.length === 0)
-    .filter(r => inputTextOf(r).trim().length > 0)
-    .slice(0, MAX_TRACE_BACKFILL_PER_REQUEST);
-  if (missing.length > 0) {
-    const vectors = await computeEmbeddings(missing.map(r => inputTextOf(r)));
-    for (let i = 0; i < missing.length; i++) {
-      const vector = vectors[i];
-      if (!vector) continue;
-      missing[i]!.inputEmbedding = vector;
-      const cond = and(
-        eq(db.schema.monitorClassifications.id, missing[i]!.id),
-        eq(db.schema.monitorClassifications.projectId, db.projectId)
-      );
-      if (db.kind === "sqlite") {
-        db.db.update(db.schema.monitorClassifications).set({ inputEmbedding: vector }).where(cond).run();
-      } else {
-        await db.db.update(db.schema.monitorClassifications).set({ inputEmbedding: vector }).where(cond);
+  // Rows whose trace was pruned by retention can never be embedded - they are excluded from
+  // the pending count instead of reading "still indexing" forever.
+  const backfillable = unembedded.filter(r => inputTextOf(r).trim().length > 0);
+
+  // Lazy backfill, bounded per request and single-flight per project: two Map tabs polling at
+  // once must not both pay for the same 100 embeddings. The loser simply reports the rows as
+  // pending; the winner persists them for every later request.
+  const missing = backfillable.slice(0, MAX_TRACE_BACKFILL_PER_REQUEST);
+  if (missing.length > 0 && !backfillInFlight.has(db.projectId ?? "")) {
+    backfillInFlight.add(db.projectId ?? "");
+    try {
+      const vectors = await computeEmbeddings(missing.map(r => inputTextOf(r)));
+      for (let i = 0; i < missing.length; i++) {
+        const vector = vectors[i];
+        if (!vector) continue;
+        missing[i]!.inputEmbedding = vector;
+        const cond = and(
+          eq(db.schema.monitorClassifications.id, missing[i]!.id),
+          eq(db.schema.monitorClassifications.projectId, db.projectId)
+        );
+        if (db.kind === "sqlite") {
+          db.db.update(db.schema.monitorClassifications).set({ inputEmbedding: vector }).where(cond).run();
+        } else {
+          await db.db.update(db.schema.monitorClassifications).set({ inputEmbedding: vector }).where(cond);
+        }
       }
+    } catch (err) {
+      // Embedding spend already happened for nothing on a DB error - but the map itself can
+      // still render from what IS embedded; failing the whole request would waste that too.
+      logger.warn({ err }, "Coverage map: input-embedding backfill failed");
+    } finally {
+      backfillInFlight.delete(db.projectId ?? "");
     }
   }
 
-  const traceRows = candidates.filter(
-    (r): r is ClassificationRow & { inputEmbedding: number[] } =>
-      Array.isArray(r.inputEmbedding) && r.inputEmbedding.length > 0
-  );
-  const tracePending = candidates.length - traceRows.length;
+  const traceRows = [...embedded, ...missing.filter(hasVector)]
+    .filter((r): r is ClassificationRow & { inputEmbedding: number[] } => hasVector(r))
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+    .slice(0, MAX_POINTS_PER_SOURCE);
+  const tracePending = backfillable.filter(r => !hasVector(r)).length;
 
   const datasetRows = await listDatasetRows(db);
   const cases = await listDatasetCases(db, options.datasetIds, datasetRows);
@@ -147,19 +168,28 @@ export async function getCoverageMap(
     );
   }
   if (traceRows.length + embeddedCases.length < MIN_POINTS_FOR_MAP) {
-    return empty(null, pending, tracePending);
+    return empty(
+      `The map needs at least ${MIN_POINTS_FOR_MAP} embedded points across production traffic and dataset cases - only ${traceRows.length + embeddedCases.length} available in this window.`,
+      pending,
+      tracePending
+    );
   }
 
   // Topic assignment for dataset points reuses the coverage table's exact matcher (bands and
-  // all), so a case never reads as covered here and off-map there.
-  const groups: TopicGroup[] = groupByIntent(allRows).filter(g => g.rows.length >= MIN_TRACES_PER_TOPIC);
+  // all), so a case never reads as covered here and off-map there. Two parity rules from the
+  // table: a case with no interaction-space embedding (embeddingFull) is never matched by
+  // similarity - the table skips those outright - and a case whose best match lives in a RARE
+  // topic (below MIN_TRACES_PER_TOPIC) still gets that topic, exactly like the table's
+  // allGroups check keeps it out of off-map.
+  const allGroups: TopicGroup[] = groupByIntent(allRows);
+  const groups: TopicGroup[] = allGroups.filter(g => g.rows.length >= MIN_TRACES_PER_TOPIC);
   const sim = embeddingSimilarity();
-  const topicOf = (item: DatasetCase): string => {
+  const bestIn = (item: DatasetCase, pool: TopicGroup[]): { topic: string | null; matched: boolean } => {
     let bestTopic: string | null = null;
     let bestMargin = -1;
     let bestScore = -1;
     let matched = false;
-    for (const group of groups) {
+    for (const group of pool) {
       const match = sim.toTopic(item, group);
       if (match.margin > bestMargin || (match.margin === bestMargin && match.score > bestScore)) {
         bestMargin = match.margin;
@@ -168,7 +198,14 @@ export async function getCoverageMap(
         matched = match.matched;
       }
     }
-    return matched && bestTopic ? bestTopic : "unmatched";
+    return { topic: bestTopic, matched };
+  };
+  const topicOf = (item: DatasetCase): string => {
+    if (!Array.isArray(item.embeddingFull) || item.embeddingFull.length === 0) return "unmatched";
+    const main = bestIn(item, groups);
+    if (main.matched && main.topic) return main.topic;
+    const rare = bestIn(item, allGroups.filter(g => g.rows.length < MIN_TRACES_PER_TOPIC));
+    return rare.matched && rare.topic ? rare.topic : "unmatched";
   };
 
   const vectors = [...traceRows.map(r => r.inputEmbedding), ...embeddedCases.map(c => c.embedding)];

--- a/engine/src/core/monitor/events.ts
+++ b/engine/src/core/monitor/events.ts
@@ -779,6 +779,10 @@ export async function listTraceEvaluations(db: Db, traceId: string): Promise<Tra
   const scored = rows.filter(
     (r): r is EventRow & { rating: number } =>
       r.rating !== null &&
+      // Session-scoped verdicts carry a sessionId and anchor the session's LAST trace only as
+      // a triage jump target - rendering them here would present a whole-conversation opinion
+      // as a rating of that single reply.
+      r.sessionId === null &&
       (r.onlineEvaluatorId !== null || r.type === "scorer_group_score" || r.type === "scorer_group_member_score")
   );
   scored.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());

--- a/engine/src/core/monitor/onlineEvaluators.ts
+++ b/engine/src/core/monitor/onlineEvaluators.ts
@@ -332,8 +332,17 @@ export async function reserveOnlineJudgeCall(db: Db): Promise<boolean> {
       const midnight = new Date();
       midnight.setHours(0, 0, 0, 0);
       const rows = await listEventsSince(db, midnight);
+      // Approximate judge calls made today: per-trace and per-session evaluator verdicts and
+      // failures, plus scorer-group JUDGE member verdicts (their patternKey embeds the member
+      // kind - pattern/custom members cost no judge call and are excluded). Restart-resistant:
+      // without the group terms, a mid-day restart re-seeded 0 and handed the cap out twice.
       const spent = rows.filter(
-        r => r.onlineEvaluatorId && (r.type === "online_eval_score" || r.type === "online_eval_judge_failure")
+        r =>
+          (r.onlineEvaluatorId &&
+            (r.type === "online_eval_score" ||
+              r.type === "online_eval_judge_failure" ||
+              r.type === "online_eval_session_score")) ||
+          (r.type === "scorer_group_member_score" && r.patternKey.includes(":judge:"))
       ).length;
       entry = { day, count: spent };
       onlineJudgeSpend.set(key, entry);

--- a/engine/src/core/monitor/scorerGroups.ts
+++ b/engine/src/core/monitor/scorerGroups.ts
@@ -103,6 +103,40 @@ function toRow(raw: Record<string, unknown>): ScorerGroupRow {
   };
 }
 
+// Create/update-time member validation: a typo'd refId used to 201 and produce a group that
+// permanently scores null (silently, one "Scorer no longer exists" member at a time), and a
+// reference-centric judge (requiresExpected) could ride a group straight past the guard that
+// 409s it as a standalone online evaluator. Returns human-readable problems; empty = valid.
+export async function validateGroupMembers(
+  db: Db,
+  members: ScorerGroupMember[],
+  options: { onlineEnabled: boolean; grandfathered?: Set<string> }
+): Promise<string[]> {
+  const problems: string[] = [];
+  for (const member of members) {
+    // A ref that is ALREADY stored on this group is never rejected: a scorer deleted after the
+    // group was built legitimately dangles (scoring degrades it to "not scored"), and the
+    // dashboard round-trips the full member list on every save - refusing the dangling entry
+    // would make the whole group uneditable. Only NEW refs must resolve.
+    const stored = options.grandfathered?.has(`${member.kind}:${member.refId}`) ?? false;
+    if (member.kind === "judge") {
+      const settings = await getEvaluationSettingsRow(db, member.refId);
+      if (!settings) {
+        if (!stored) problems.push(`Unknown judge scorer id "${member.refId}"`);
+      } else if (options.onlineEnabled && settings.requiresExpected) {
+        problems.push(
+          `"${settings.name}" needs a reference answer (requiresExpected) and cannot grade live traffic - disable requiresExpected or keep the group's live scoring off`
+        );
+      }
+    } else if (member.kind === "pattern") {
+      if (!stored && !(await getPatternRow(db, member.refId))) problems.push(`Unknown pattern id "${member.refId}"`);
+    } else {
+      if (!stored && !(await getCustomEvaluatorRow(db, member.refId))) problems.push(`Unknown scorer id "${member.refId}"`);
+    }
+  }
+  return problems;
+}
+
 export function normalizeMembers(raw: unknown): ScorerGroupMember[] {
   if (!Array.isArray(raw)) return [];
   return raw
@@ -171,7 +205,13 @@ export async function updateScorerGroup(
   if (input.name !== undefined) patch.name = input.name;
   if (input.description !== undefined) patch.description = input.description;
   if (input.members !== undefined) patch.members = normalizeMembers(input.members);
-  if (input.online !== undefined) patch.online = input.online;
+  if (input.online !== undefined) {
+    // Merge, don't replace: a client that predates scope/idleSeconds (round-tripping only
+    // {enabled, sampleRate, alertThreshold, severity}) must not silently flip a session group
+    // back to per-trace scoring. online:null still detaches explicitly.
+    patch.online =
+      input.online === null ? null : ({ ...(existing.online ?? {}), ...input.online } as ScorerGroupOnline);
+  }
   const cond = and(eq(db.schema.scorerGroups.id, id), eq(db.schema.scorerGroups.projectId, db.projectId));
   if (db.kind === "sqlite") {
     db.db.update(db.schema.scorerGroups).set(patch).where(cond).run();
@@ -216,6 +256,10 @@ const GATE_FLOOR = 0.5;
 export function aggregateGroupScore(members: MemberScore[]): { score: number | null; gatedBy: string | null } {
   const gated = members.find(m => m.gate && m.goodness !== null && m.goodness < GATE_FLOOR);
   if (gated) return { score: 0, gatedBy: gated.name };
+  // Fail-closed: a must-pass member that could NOT score (judge outage, deleted ref, scorer
+  // 500) means the configured recipe was not evaluated - producing a blend without the gate
+  // would report "passed" for a safety check that never ran. No score is the honest answer.
+  if (members.some(m => m.gate && m.goodness === null)) return { score: null, gatedBy: null };
   let total = 0;
   let weightUsed = 0;
   for (const m of members) {
@@ -229,6 +273,10 @@ export function aggregateGroupScore(members: MemberScore[]): { score: number | n
 
 export function describeGroupScore(result: { score: number | null; gatedBy: string | null }, members: MemberScore[]): string {
   if (result.gatedBy) return `Gated to 0 by "${result.gatedBy}" (must-pass member failed).`;
+  const gateErrored = members.find(m => m.gate && m.goodness === null);
+  if (gateErrored) {
+    return `No score: must-pass member "${gateErrored.name}" could not score (${gateErrored.error ?? "scorer failed"}).`;
+  }
   const parts = members
     .filter(m => m.goodness !== null && m.weight > 0)
     .map(m => `${m.name} ${m.detail} ×${m.weight}`);
@@ -281,7 +329,8 @@ async function scoreJudgeMember(db: Db, member: ScorerGroupMember, content: Grou
       },
       { input: content.input, output: content.output, expected: content.expected }
     );
-    return { ...base, name, goodness: rating / 10, detail: `${rating}/10 (${justification.slice(0, 140)})` };
+    const clamped = Math.max(0, Math.min(10, rating));
+    return { ...base, name, goodness: clamped / 10, detail: `${clamped}/10 (${justification.slice(0, 140)})` };
   } catch (err) {
     return { ...base, name, goodness: null, detail: "-", error: err instanceof Error ? err.message : "Judge failed" };
   }
@@ -428,7 +477,7 @@ export async function runScorerGroupsOnline(
         break;
       }
     }
-    if (!budgetOk) return;
+    if (!budgetOk) continue;
     try {
       const result = await computeGroupScore(db, group, {
         input: inputText,

--- a/engine/src/core/monitor/sessionSweep.ts
+++ b/engine/src/core/monitor/sessionSweep.ts
@@ -29,6 +29,8 @@ import {
   type ScorerGroupRow,
 } from "./scorerGroups.js";
 import { reserveOnlineJudgeCall } from "./onlineEvaluators.js";
+import { getProfileRow } from "./profiles.js";
+import { notifyWebhooks, extractWebhookUrls } from "./webhooks.js";
 import { SESSION_BASELINE_KEY } from "./builtinEvaluators.js";
 import { logger } from "../../log.js";
 
@@ -189,6 +191,8 @@ async function judgeSessionAgainstEvaluator(
   anchorTraceId: string | null;
   driftSpanId: string | null;
   findings: SessionFinding[];
+  // What the judge actually read (all-time session spans), NOT the caller's windowed count.
+  spanCount: number;
 } | null> {
   const settings = evaluator.evaluationSettingsId
     ? await getEvaluationSettingsRow(db, evaluator.evaluationSettingsId)
@@ -279,9 +283,9 @@ async function judgeSessionAgainstEvaluator(
   // calibration and tuning. Fallback: last span of any kind (OTel sessions whose roots folded).
   const roots = spans.filter(s => !s.parentSpanId);
   const anchorTraceId = (roots.length > 0 ? roots[roots.length - 1] : spans[spans.length - 1])?._id ?? null;
-  // spanCount recorded via insertSessionScore by the caller; returned shape kept minimal.
+  // The caller's windowed count is NOT what the judge saw - listSessionSpans is all-time.
   void spanCount;
-  return { rating, justification, judgeModel, anchorTraceId, driftSpanId, findings };
+  return { rating, justification, judgeModel, anchorTraceId, driftSpanId, findings, spanCount: spans.length };
 }
 
 // The per-session "Re-run now" button's path (POST /sessions/:id/coherence-check, route name
@@ -358,11 +362,13 @@ const MEMBER_SESSION_SCORE_SCHEMA = {
   required: ["rating", "justification"],
 };
 
-// Session-scope scorer-group scoring: every member scores the SAME assembled transcript. Judge
-// members get the structured session prompt built from their criteria (never their per-trace
-// judgePrompt - same rule as session evaluators); pattern and custom members receive the whole
-// transcript as both input and output, so "contains"-style conditions and script scorers read
-// the conversation, not one turn. Failures isolate per member exactly like trace-scope groups.
+// Session-scope scorer-group scoring. Judge members get the structured session prompt built
+// from their own criteria (never their per-trace judgePrompt - same rule as session
+// evaluators) with each member's toolContext honored, so a member scores the same recipe it
+// would score standalone. Pattern and code/external members read the conversation with the
+// USER side as input and the AGENT side as output - a "response contains" condition must not
+// fire on something the user typed, and vice versa. Failures isolate per member exactly like
+// trace-scope groups; judge-call budget is reserved lazily, one slot per call actually made.
 export async function scoreSessionWithGroup(
   db: Db,
   group: ScorerGroupRow,
@@ -377,9 +383,29 @@ export async function scoreSessionWithGroup(
 } | null> {
   const spans = (await listSessionSpans(db, sessionId)) as SpanWire[];
   if (spans.length === 0) return null;
-  const { transcript, elidedNote } = buildSessionTranscript(spans, { includeToolLines: true });
   const roots = spans.filter(s => !s.parentSpanId);
   const anchorTraceId = (roots.length > 0 ? roots[roots.length - 1] : spans[spans.length - 1])?._id ?? null;
+
+  // Transcript variants per judge toolContext, assembled at most once each.
+  const variants = new Map<string, { transcript: string; elidedNote: string }>();
+  const transcriptFor = (toolContext: string): { transcript: string; elidedNote: string } => {
+    const key = toolContext === "none" ? "none" : "simple";
+    let variant = variants.get(key);
+    if (!variant) {
+      const source = key === "none" ? spans.filter(sp => !sp.parentSpanId) : spans;
+      const { transcript, elidedNote } = buildSessionTranscript(source, { includeToolLines: key !== "none" });
+      variant = { transcript, elidedNote };
+      variants.set(key, variant);
+    }
+    return variant;
+  };
+  let detailedDefinitions: string | null | undefined;
+
+  const asText = (value: unknown): string =>
+    typeof value === "string" ? value : value == null ? "" : JSON.stringify(value);
+  // The user side and the agent side of the conversation, for deterministic members.
+  const userText = roots.map(r => asText(r.input)).filter(Boolean).join("\n\n");
+  const agentText = roots.map(r => asText(r.output)).filter(Boolean).join("\n\n");
 
   const members: MemberScore[] = [];
   for (const member of group.members) {
@@ -391,6 +417,17 @@ export async function scoreSessionWithGroup(
         continue;
       }
       const name = settings.name ?? member.refId;
+      // One budget slot per judge call actually made - a deleted ref or empty session never
+      // burns a slot, and an exhausted budget degrades this member instead of the whole sweep.
+      if (!(await reserveOnlineJudgeCall(db))) {
+        members.push({ ...base, name, goodness: null, detail: "-", error: "Online judge budget exhausted" });
+        continue;
+      }
+      const toolContext = settings.toolContext ?? "simple";
+      const { transcript, elidedNote } = transcriptFor(toolContext);
+      if (toolContext === "detailed" && detailedDefinitions === undefined) {
+        detailedDefinitions = await renderSessionUsedToolDefinitions(db, sessionId).catch(() => null);
+      }
       try {
         const result = await callJudgeJson({
           model: settings.judgeModel ?? DEFAULT_JUDGE_MODEL,
@@ -398,7 +435,7 @@ export async function scoreSessionWithGroup(
           userMessage: buildSessionJudgeMessage({
             elidedNote,
             criteria: settings,
-            toolDefinitions: null,
+            toolDefinitions: toolContext === "detailed" ? (detailedDefinitions ?? null) : null,
             transcript,
             withDrift: false,
           }),
@@ -417,11 +454,11 @@ export async function scoreSessionWithGroup(
       }
     } else if (member.kind === "pattern") {
       members.push(
-        await scorePatternMember(db, member, { input: transcript, output: transcript, traceId: anchorTraceId })
+        await scorePatternMember(db, member, { input: userText, output: agentText, traceId: anchorTraceId })
       );
     } else {
       members.push(
-        await scoreCustomMember(db, member, { input: transcript, output: transcript, traceId: anchorTraceId })
+        await scoreCustomMember(db, member, { input: userText, output: agentText, traceId: anchorTraceId })
       );
     }
   }
@@ -437,12 +474,46 @@ export async function scoreSessionWithGroup(
   };
 }
 
+// Deterministic per-(session, scorer) sampling. The sweep re-visits an unscored idle session
+// every tick, so a fresh random roll each visit converges on scoring EVERYTHING
+// (p' = 1-(1-p)^ticks) - sampleRate would be a delay, not a fraction. Hashing the pair keeps
+// the decision stable: a sampled-out conversation stays out, and the configured rate is the
+// real fraction of conversations judged, the same meaning it has per trace.
+function passesSessionSample(sessionId: string, scorerId: string, rate: number): boolean {
+  if (rate >= 1) return true;
+  if (rate <= 0) return false;
+  let hash = 2166136261;
+  const text = `${sessionId}:${scorerId}`;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) / 4294967296 < rate;
+}
+
+// Failed scoring attempts back off instead of burning a sweep slot every tick forever: a
+// session whose scorer cannot produce a verdict (schema-breaking judge model, every member
+// deleted) retries at most once per RETRY_BACKOFF_MS instead of 1440 times a day, so a few
+// stuck sessions cannot starve every healthy one. In-process on purpose - a restart retrying
+// sooner is harmless; the map exists only to stop steady-state starvation.
+const RETRY_BACKOFF_MS = 10 * 60_000;
+const failedAttempts = new Map<string, number>();
+const attemptKey = (projectId: string | null, patternKey: string, sessionId: string) =>
+  `${projectId ?? ""}|${patternKey}|${sessionId}`;
+const inBackoff = (key: string): boolean => {
+  const last = failedAttempts.get(key);
+  return last !== undefined && Date.now() - last < RETRY_BACKOFF_MS;
+};
+
 // One pass over every project: find idle, unscored (or grown-since-scored) multi-turn sessions
 // and judge them against each enabled session-scoped evaluator. Exported for the manual-trigger
 // route (used by tests/demos); startSessionSweep below is the production path.
-export async function sweepSessionsOnce(): Promise<{ judged: number }> {
+export async function sweepSessionsOnce(options: { projectId?: string | null } = {}): Promise<{ judged: number }> {
   const baseDb = getDb();
-  const allProjects = await listProjectRows(baseDb);
+  const listed = await listProjectRows(baseDb);
+  // The manual trigger passes the caller's project: a project API key must spend only its own
+  // judge budget and LLM credentials, never sweep the whole instance.
+  const allProjects = options.projectId ? listed.filter(project => project.id === options.projectId) : listed;
   // Rotate the starting project each tick so the shared MAX_JUDGED_PER_SWEEP budget reaches
   // every project over time instead of being eaten by whichever lists first.
   const offset = allProjects.length > 0 ? sweepTick++ % allProjects.length : 0;
@@ -490,12 +561,22 @@ export async function sweepSessionsOnce(): Promise<{ judged: number }> {
         // Already scored and nothing new arrived since - the re-score path is exactly this check
         // failing after the session grows (lastAt moves past the score's createdAt).
         if (latest && new Date(latest.createdAt).getTime() >= lastActivity) continue;
-        if (!passesSampleRate(evaluator.sampleRate)) continue;
+        if (!passesSessionSample(session.sessionId, evaluator.id, evaluator.sampleRate)) continue;
+        const retryKey = attemptKey(db.projectId, kind, session.sessionId);
+        if (inBackoff(retryKey)) continue;
 
+        // Count the ATTEMPT, not the verdict: judge spend happens whether or not a usable
+        // rating comes back, and a cap that only counts successes is unbounded during an
+        // outage (blowing straight through the sweep lease TTL).
+        judged++;
         try {
           const verdict = await judgeSessionAgainstEvaluator(db, session.sessionId, session.spanCount, evaluator);
-          if (!verdict) continue;
-          judged++;
+          if (!verdict) {
+            // No spans (pruned mid-tick) - back off like any failed attempt so the race
+            // cannot consume a tick slot every 60s.
+            failedAttempts.set(retryKey, Date.now());
+            continue;
+          }
           if (verdict.rating === null) {
             // The judge returned no usable verdict (empty/unparseable, after judge-core's
             // retry). Do NOT insert a session score: a null-rating score row would mark the
@@ -516,8 +597,10 @@ export async function sweepSessionsOnce(): Promise<{ judged: number }> {
               justification: "Judge returned no usable verdict for this session",
               sessionId: session.sessionId,
             });
+            failedAttempts.set(retryKey, Date.now());
             continue;
           }
+          failedAttempts.delete(retryKey);
           await insertSessionScore(db, {
             sessionId: session.sessionId,
             kind,
@@ -525,7 +608,7 @@ export async function sweepSessionsOnce(): Promise<{ judged: number }> {
             justification: verdict.justification,
             driftSpanId: verdict.driftSpanId,
             findings: verdict.findings,
-            spanCount: session.spanCount,
+            spanCount: verdict.spanCount,
             judgeModel: verdict.judgeModel,
           });
 
@@ -553,6 +636,16 @@ export async function sweepSessionsOnce(): Promise<{ judged: number }> {
               { agentId: session.agentId, traceId: verdict.anchorTraceId }
             );
             signalId = signal._id;
+            // Same webhook fan-out a below-threshold trace verdict gets - a failing
+            // conversation pages the agent's alert channels, not just the triage queue.
+            const alertProfile = session.agentId ? await getProfileRow(db, session.agentId) : null;
+            notifyWebhooks(extractWebhookUrls(alertProfile?.channels), {
+              summary: `"${evaluator.name}" rated session ${session.sessionId} ${verdict.rating.toFixed(1)}/10 (below the ${evaluator.alertThreshold} threshold)`,
+              severity: evaluator.severity,
+              patternKey: `online-eval:${evaluator.id}`,
+              agentId: session.agentId,
+              rootCause: evaluator.name,
+            });
           }
 
           // Dual-write into monitor_events: before this, session verdicts lived only in
@@ -579,6 +672,7 @@ export async function sweepSessionsOnce(): Promise<{ judged: number }> {
         } catch (err) {
           // Isolated per session+evaluator, same posture as every other detector loop - one
           // failing judge call (missing key, provider outage) never blocks the rest of the sweep.
+          failedAttempts.set(retryKey, Date.now());
           logger.error(
             { err },
             `Session sweep: evaluator "${evaluator.name}" failed on session ${session.sessionId}`
@@ -594,24 +688,21 @@ export async function sweepSessionsOnce(): Promise<{ judged: number }> {
         const kind = `scorer-group:${group.id}`;
         const latest = scores.find(s => s.kind === kind);
         if (latest && new Date(latest.createdAt).getTime() >= lastActivity) continue;
-        if (!passesSampleRate(online.sampleRate)) continue;
-        // Judge members are real LLM spend, so they draw from the same online judge budget as
-        // trace-scope group scoring - all slots up front, and a refused reservation skips the
-        // whole group (a partial panel would score a different recipe than the one configured).
-        const judgeMemberCount = group.members.filter(m => m.kind === "judge").length;
-        let budgetOk = true;
-        for (let i = 0; i < judgeMemberCount; i++) {
-          if (!(await reserveOnlineJudgeCall(db))) {
-            budgetOk = false;
-            break;
-          }
-        }
-        if (!budgetOk) continue;
+        if (!passesSessionSample(session.sessionId, group.id, online.sampleRate)) continue;
+        const retryKey = attemptKey(db.projectId, kind, session.sessionId);
+        if (inBackoff(retryKey)) continue;
 
+        // Attempts count against the tick budget (see the evaluator loop). Judge-call budget
+        // is reserved lazily inside scoreSessionWithGroup, one slot per judge member as its
+        // call is actually made - reserving up front burned slots for members that turned out
+        // unscoreable (deleted refs, empty session).
+        judged++;
         try {
           const result = await scoreSessionWithGroup(db, group, session.sessionId);
-          if (!result) continue;
-          judged++;
+          if (!result) {
+            failedAttempts.set(retryKey, Date.now());
+            continue;
+          }
           if (result.score === null) {
             // No member produced a score (judge outage, deleted refs). Same posture as the
             // evaluator path: record the failure, insert no score row, let the next tick retry.
@@ -628,8 +719,10 @@ export async function sweepSessionsOnce(): Promise<{ judged: number }> {
               justification: "No group member produced a usable score for this session",
               sessionId: session.sessionId,
             });
+            failedAttempts.set(retryKey, Date.now());
             continue;
           }
+          failedAttempts.delete(retryKey);
           await insertSessionScore(db, {
             sessionId: session.sessionId,
             kind,
@@ -654,6 +747,15 @@ export async function sweepSessionsOnce(): Promise<{ judged: number }> {
               { agentId: session.agentId, traceId: result.anchorTraceId }
             );
             signalId = signal._id;
+            // Same webhook fan-out a below-threshold trace-scope group score gets.
+            const alertProfile = session.agentId ? await getProfileRow(db, session.agentId) : null;
+            notifyWebhooks(extractWebhookUrls(alertProfile?.channels), {
+              summary: `Scorer group "${group.name}" rated session ${session.sessionId} ${result.score.toFixed(1)}/10 (below the ${online.alertThreshold} threshold)`,
+              severity: online.severity,
+              patternKey: kind,
+              agentId: session.agentId,
+              rootCause: group.name,
+            });
           }
 
           // Same dual-write trace-scope group scoring does: the aggregate joins the group's
@@ -689,6 +791,7 @@ export async function sweepSessionsOnce(): Promise<{ judged: number }> {
             });
           }
         } catch (err) {
+          failedAttempts.set(retryKey, Date.now());
           logger.error(
             { err },
             `Session sweep: scorer group "${group.name}" failed on session ${session.sessionId}`
@@ -704,6 +807,21 @@ export async function sweepSessionsOnce(): Promise<{ judged: number }> {
 
 let sweepTimer: NodeJS.Timeout | null = null;
 let sweeping = false;
+
+// The route's entry point: scoped to one project, and serialized against both the interval
+// sweep and other manual invocations - N concurrent sweeps all pass the freshness check
+// before any inserts, judging the same sessions N times on the caller's bill.
+export async function runManualSweep(projectId: string | null): Promise<{ judged: number; skipped?: boolean }> {
+  if (sweeping) {
+    return { judged: 0, skipped: true };
+  }
+  sweeping = true;
+  try {
+    return await sweepSessionsOnce({ projectId });
+  } finally {
+    sweeping = false;
+  }
+}
 
 // Called once from index.ts after the server is listening. AGENTX_SESSION_SWEEP=false disables
 // entirely (e.g. test environments that don't want background judge spend).

--- a/engine/src/core/monitor/sessions.ts
+++ b/engine/src/core/monitor/sessions.ts
@@ -4,6 +4,7 @@ import { traceStoreFor } from "../trace/store/index.js";
 import { resolveRange, type MonitoringRange, type MonitoringWindow } from "./events.js";
 import { getAgentNamesById } from "./agents.js";
 import { listOnlineEvaluatorRows } from "./onlineEvaluators.js";
+import { listScorerGroups } from "./scorerGroups.js";
 import { SESSION_BASELINE_KEY } from "./builtinEvaluators.js";
 
 
@@ -131,6 +132,16 @@ export async function listSessions(db: Db, range: MonitoringRange): Promise<Sess
       evaluatorsById.set(evaluator.id, { name: evaluator.name, enabled: evaluator.enabled });
       if (evaluator.builtinKey === SESSION_BASELINE_KEY) baselineId = evaluator.id;
     }
+    // Session-scoped scorer GROUPS write verdicts to the same table under scorer-group:<id> -
+    // resolving them here keeps the Sessions table's judge column honest for a project that
+    // scores conversations with groups only. Keyed by the full kind so a group id can never
+    // collide with an evaluator id.
+    for (const group of await listScorerGroups(db)) {
+      evaluatorsById.set(`scorer-group:${group.id}`, {
+        name: `${group.name} (group)`,
+        enabled: !!group.online?.enabled,
+      });
+    }
     const scoreCond = and(
       inArray(db.schema.sessionScores.sessionId, sessionIds),
       eq(db.schema.sessionScores.projectId, db.projectId)
@@ -143,7 +154,13 @@ export async function listSessions(db: Db, range: MonitoringRange): Promise<Sess
     for (const score of scores) {
       // Legacy "coherence" rows (pre-baseline-judge) count as the baseline's own.
       const evaluatorId =
-        score.kind === "coherence" ? baselineId : score.kind.startsWith("online-eval:") ? score.kind.slice("online-eval:".length) : null;
+        score.kind === "coherence"
+          ? baselineId
+          : score.kind.startsWith("online-eval:")
+            ? score.kind.slice("online-eval:".length)
+            : score.kind.startsWith("scorer-group:")
+              ? score.kind
+              : null;
       if (!evaluatorId) continue;
       let perJudge = latestPerJudge.get(score.sessionId);
       if (!perJudge) {

--- a/engine/src/core/monitor/topics.ts
+++ b/engine/src/core/monitor/topics.ts
@@ -123,6 +123,18 @@ export async function getClassificationForTrace(db: Db, traceId: string): Promis
 
 type ScorableTrace = { input?: unknown; output?: unknown };
 
+// The question-space text for a trace input: the bare query when the input is the common
+// { query: "..." } shape, else the string itself, else its JSON. Exported for the coverage
+// map's lazy backfill so live-classified and backfilled rows embed the SAME text - the two
+// spellings of one question must never land in two clusters.
+export function questionTextOf(input: unknown): string {
+  if (typeof input === "string") return input;
+  if (input && typeof input === "object" && typeof (input as { query?: unknown }).query === "string") {
+    return (input as { query: string }).query;
+  }
+  return input == null ? "" : JSON.stringify(input);
+}
+
 export async function runClassification(
   db: Db,
   trace: ScorableTrace,
@@ -167,9 +179,10 @@ export async function runClassification(
         userMessage: `Classify this AI agent interaction.\n\nUser input:\n${inputText}\n\nAgent response:\n${outputText}${existingIntentsBlock}\n\nRespond with JSON matching the schema.`,
       }),
       computeEmbedding(`${inputText}\n\n${outputText}`),
-      // Question-space twin for the coverage map: the input alone, so an identical question
-      // from a dataset case (query-only embedding) lands in the same spot.
-      computeEmbedding(inputText),
+      // Question-space twin for the coverage map: the bare question text (questionTextOf), so
+      // an identical question from a dataset case (query-only embedding) lands in the same
+      // spot - stringified envelopes like {"query": ..., "user_id": ...} must not.
+      computeEmbedding(questionTextOf(trace.input)),
     ]);
     const payload = result.payload as { intent?: string; sentiment?: string; issueType?: string } | null;
     if (!payload?.intent || !payload.sentiment || !payload.issueType) {

--- a/engine/src/core/trace/store/clickhouseTraceStore.ts
+++ b/engine/src/core/trace/store/clickhouseTraceStore.ts
@@ -236,8 +236,10 @@ export class ClickHouseTraceStore implements TraceStore {
   }
 
   async listBySession(sessionId: string): Promise<TraceRow[]> {
+    // Same cap and ordering as the SQL store: oldest-first so a truncated runaway session
+    // keeps the conversation's beginning (the transcript's anchor), and 5000 bounds the heap.
     const rows = await this.rows(
-      `SELECT * FROM ${TABLE} WHERE ${this.scope()} AND session_id = {sessionId:String}`,
+      `SELECT * FROM ${TABLE} WHERE ${this.scope()} AND session_id = {sessionId:String} ORDER BY started_at ASC, created_at ASC LIMIT 5000`,
       { sessionId }
     );
     return rows.map(fromStored);

--- a/engine/src/core/trace/store/sqlTraceStore.ts
+++ b/engine/src/core/trace/store/sqlTraceStore.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, gt, gte, isNull, isNotNull, lt, ne, or, sql, type SQL } from "drizzle-orm";
+import { asc, and, count, desc, eq, gt, gte, isNull, isNotNull, lt, ne, or, sql, type SQL } from "drizzle-orm";
 import type { Db } from "../../../storage/db.js";
 import { EVAL_RUN_SOURCE } from "../evalTraffic.js";
 import type { RootsPageQuery, SpanWindowFilter, TraceRow, TraceStore } from "./traceStore.js";
@@ -137,10 +137,12 @@ export class SqlTraceStore implements TraceStore {
     const cond = and(eq(db.schema.traces.sessionId, sessionId), eq(db.schema.traces.projectId, db.projectId));
     // Capped: a runaway agent session with tens of thousands of spans must not pull them all
     // into the heap on every dialog open. 5000 is far beyond any real conversation.
+    // Oldest-first so the cap truncates the TAIL of a runaway session, not a storage-order-
+    // arbitrary subset - callers sort again, but they can only sort what they received.
     const rows =
       db.kind === "sqlite"
-        ? db.db.select().from(db.schema.traces).where(cond).limit(5000).all()
-        : await db.db.select().from(db.schema.traces).where(cond).limit(5000);
+        ? db.db.select().from(db.schema.traces).where(cond).orderBy(asc(db.schema.traces.createdAt)).limit(5000).all()
+        : await db.db.select().from(db.schema.traces).where(cond).orderBy(asc(db.schema.traces.createdAt)).limit(5000);
     return rows as TraceRow[];
   }
 

--- a/engine/src/routes/agentMonitoringDashboard.ts
+++ b/engine/src/routes/agentMonitoringDashboard.ts
@@ -53,7 +53,7 @@ import { getModelComparison } from "../core/monitor/modelComparison.js";
 import { listSessionScores } from "../core/monitor/sessionScores.js";
 import { listSessions } from "../core/monitor/sessions.js";
 import {
-  sweepSessionsOnce,
+  runManualSweep,
   runSessionBaselineCheck,
   runSessionEvaluatorCheck,
   isSessionScoreFresh,
@@ -129,6 +129,8 @@ import {
   deleteScorerGroup,
   toScorerGroupWire,
   type ScorerGroupOnline,
+  type ScorerGroupMember,
+  validateGroupMembers,
 } from "../core/monitor/scorerGroups.js";
 
 // Mounted at /api/v1/agent-monitoring - the paths AgentX-web-front's dashboard actually calls
@@ -564,9 +566,13 @@ function parseWindow(req: Request): MonitoringWindow {
 // date ranges and non-enum presets (6h, 14d, ...) arrive as from/to. Span clamped to a year so a
 // typo'd bound can't turn one request into a full-table sweep.
 function parseRange(req: Request): MonitoringRange {
-  const from = Number(req.query.from);
-  const to = Number(req.query.to);
-  if (Number.isFinite(from) && Number.isFinite(to) && to > from) {
+  // Number("") is 0 (finite!), so a blank ?from= must not silently become epoch 0 - only
+  // non-empty numeric strings qualify, both bounds must be positive, and to must exceed from.
+  const rawFrom = typeof req.query.from === "string" ? req.query.from.trim() : "";
+  const rawTo = typeof req.query.to === "string" ? req.query.to.trim() : "";
+  const from = rawFrom === "" ? Number.NaN : Number(rawFrom);
+  const to = rawTo === "" ? Number.NaN : Number(rawTo);
+  if (Number.isFinite(from) && Number.isFinite(to) && from > 0 && to > from) {
     const YEAR_MS = 366 * 24 * 60 * 60 * 1000;
     return { fromMs: Math.max(from, to - YEAR_MS), toMs: to };
   }
@@ -677,8 +683,11 @@ agentMonitoringDashboardRouter.get("/sessions", async (req: Request, res: Respon
 // Manual trigger for the idle-session sweep (core/monitor/sessionSweep.ts) - the production path
 // is the 60s interval started at boot; this exists for tests and demos that shouldn't have to
 // wait a tick. Sweeps ALL projects (the sweep is instance-wide by design), auth still required.
-agentMonitoringDashboardRouter.post("/session-sweep/run", async (_req: Request, res: Response) => {
-  res.status(200).json(await sweepSessionsOnce());
+agentMonitoringDashboardRouter.post("/session-sweep/run", async (req: Request, res: Response) => {
+  // Scoped to the caller's project (a key must not spend other tenants' budgets) and
+  // serialized - a concurrent sweep returns { judged: 0, skipped: true } instead of
+  // double-judging the sessions the in-flight one is still scoring.
+  res.status(200).json(await runManualSweep(scopedDb(req).projectId));
 });
 
 // Overview's "Total LLM cost" chart (core/monitor/cost.ts) - stacked by model, priced from Model
@@ -843,7 +852,7 @@ const createScorerGroupSchema = z
   .object({
     name: z.string().min(1).max(200),
     description: z.string().max(2000).optional(),
-    members: z.array(scorerGroupMemberSchema).max(20),
+    members: z.array(scorerGroupMemberSchema).min(1).max(20),
     online: scorerGroupOnlineSchema.nullable().optional(),
   })
   .strip();
@@ -857,6 +866,13 @@ agentMonitoringDashboardRouter.post(
   "/scorer-groups",
   validateBody(createScorerGroupSchema),
   async (req: Request, res: Response) => {
+    const memberProblems = await validateGroupMembers(scopedDb(req), req.body.members, {
+      onlineEnabled: !!(req.body.online as ScorerGroupOnline | null)?.enabled,
+    });
+    if (memberProblems.length > 0) {
+      res.status(400).json({ error: memberProblems.join("; ") });
+      return;
+    }
     const group = await createScorerGroup(scopedDb(req), {
       name: req.body.name,
       description: req.body.description,
@@ -880,6 +896,29 @@ agentMonitoringDashboardRouter.put(
   "/scorer-groups/:id",
   validateBody(updateScorerGroupSchema),
   async (req: Request, res: Response) => {
+    // Validate what the group WILL be, not just what the request carries: new members must
+    // hold up against the stored online profile (a members-only PUT on a live group), and a
+    // newly-enabled profile must hold up against the stored members (an online-only PUT that
+    // would take a reference-centric judge live).
+    const existing = await getScorerGroup(scopedDb(req), req.params.id!);
+    if (!existing) {
+      res.status(404).json({ error: "Scorer group not found" });
+      return;
+    }
+    const effectiveMembers = (req.body.members as ScorerGroupMember[] | undefined) ?? existing.members;
+    const bodyOnline = req.body.online as ScorerGroupOnline | null | undefined;
+    const effectiveOnlineEnabled =
+      bodyOnline === null ? false : bodyOnline !== undefined ? !!bodyOnline.enabled : !!existing.online?.enabled;
+    if (req.body.members !== undefined || (bodyOnline !== undefined && bodyOnline !== null)) {
+      const memberProblems = await validateGroupMembers(scopedDb(req), effectiveMembers, {
+        onlineEnabled: effectiveOnlineEnabled,
+        grandfathered: new Set(existing.members.map(m => `${m.kind}:${m.refId}`)),
+      });
+      if (memberProblems.length > 0) {
+        res.status(400).json({ error: memberProblems.join("; ") });
+        return;
+      }
+    }
     const group = await updateScorerGroup(scopedDb(req), req.params.id!, {
       name: req.body.name,
       description: req.body.description,

--- a/engine/src/routes/evaluateDashboard.ts
+++ b/engine/src/routes/evaluateDashboard.ts
@@ -573,7 +573,7 @@ evaluateDashboardRouter.post("/agent-connectors", async (req: Request, res: Resp
   }
   const connector = await createAgentConnector(scopedDb(req), {
     name: body.name,
-    url: body.url,
+    url: String(body.url).trim(),
     headers: body.headers && typeof body.headers === "object" ? body.headers : undefined,
     timeoutMs: typeof body.timeoutMs === "number" ? body.timeoutMs : undefined,
   });
@@ -683,9 +683,11 @@ evaluateDashboardRouter.post("/playground/run", async (req: Request, res: Respon
     const ids = value.filter((id): id is string => typeof id === "string" && id.trim().length > 0);
     return ids.length > 0 ? ids : undefined;
   };
-  let result;
-  try {
-    result = await runPlayground(scopedDb(req), {
+  // No try/catch: runPlayground catches its own body and reports provider failures as
+  // { output: null, error } in a 200, and getPortabilityModel returns null (not a throw) for
+  // unknown models - anything that escapes IS a genuine engine fault and belongs to the
+  // async error handler as the 500 it is, not a masqueraded 502/400.
+  const result = await runPlayground(scopedDb(req), {
     model: body.model,
     messages: body.messages,
     query: body.query,
@@ -698,15 +700,9 @@ evaluateDashboardRouter.post("/playground/run", async (req: Request, res: Respon
     onlineEvaluatorIds: extractIds(body.onlineEvaluatorIds),
     additionalScorerIds: extractIds(body.additionalScorerIds),
     scorerGroupId: typeof body.scorerGroupId === "string" && body.scorerGroupId ? body.scorerGroupId : undefined,
-      maxTokens: typeof body.maxTokens === "number" ? body.maxTokens : undefined,
-      temperature: typeof body.temperature === "number" ? body.temperature : undefined,
-    });
-  } catch (err) {
-    // Same class and shape as /synthesize-cases: the common real-world failure here is a
-    // missing/invalid provider key, and it must not read as an engine fault (500).
-    res.status(502).json({ error: err instanceof Error ? err.message : "Playground run failed" });
-    return;
-  }
+    maxTokens: typeof body.maxTokens === "number" ? body.maxTokens : undefined,
+    temperature: typeof body.temperature === "number" ? body.temperature : undefined,
+  });
   res.status(200).json(result);
 });
 
@@ -1538,7 +1534,12 @@ async function toEvaluateWire(db: Db, run: FullRunRow, includeResults: boolean) 
   const scorerGroupId = (run as { scorerGroupId?: string | null }).scorerGroupId ?? null;
   const [dataset, evaluationSettings, results, analysisRow, scorerGroup] = await Promise.all([
     getDataset(db, run.datasetId),
-    getMergedEvaluationSettings(db, run.evaluationSettingsId ?? run.datasetId),
+    // A group-graded run was NOT graded by any evaluationSettings row - presenting the dataset
+    // twin as its config would contradict scorerGroupName right next to it. The dataset's own
+    // questions still resolve through `dataset` above.
+    scorerGroupId
+      ? Promise.resolve(null)
+      : getMergedEvaluationSettings(db, run.evaluationSettingsId ?? run.datasetId),
     getRunResults(db, run.id),
     getEvaluationAnalysisRow(db, run.id),
     scorerGroupId ? getScorerGroup(db, scorerGroupId) : Promise.resolve(null),

--- a/engine/src/routes/evaluations.ts
+++ b/engine/src/routes/evaluations.ts
@@ -20,6 +20,7 @@ import {
   recordGateResult,
   computeLiveStatistics,
   MAX_BATCH_SIZE, getRunResults, type RunResultRow,} from "../core/evaluate/runs.js";
+import { getScorerGroup } from "../core/monitor/scorerGroups.js";
 import { createPrompt, getPromptForSdk, listPromptsForSdk } from "../core/evaluate/prompts.js";
 import { runEvaluationAnalysis, getEvaluationAnalysisStatus, getEvaluationAnalysisRow } from "../core/evaluate/analysis.js";
 import { handleCasePreview, handleSuggestExpected, handleAddCase } from "./curationHandlers.js";
@@ -142,6 +143,16 @@ evaluationsRouter.post("/runs", async (req: Request, res: Response) => {
     res.status(400).json({ error: "datasetId is required" });
     return;
   }
+  if (evaluationSettingsId !== undefined && evaluationSettingsId !== null && typeof evaluationSettingsId !== "string") {
+    res.status(400).json({ error: "evaluationSettingsId must be a string" });
+    return;
+  }
+  // A typo'd (or cross-project) group id must not silently downgrade the whole run to the
+  // dataset's own grading - the 201 would look identical and nothing downstream could tell.
+  if (typeof scorerGroupId === "string" && scorerGroupId && !(await getScorerGroup(scopedDb(req), scorerGroupId))) {
+    res.status(404).json({ error: "Scorer group not found" });
+    return;
+  }
   const run = await initRun(scopedDb(req), {
     datasetId,
     evaluationSettingsId,
@@ -195,7 +206,7 @@ evaluationsRouter.post("/runs/:runId/results", async (req: Request, res: Respons
     // The only expected throw is the terminal-state guard - a real conflict. Anything else is
     // an engine fault and must not masquerade as one.
     const message = err instanceof Error ? err.message : "Unable to append results";
-    if (message.includes("terminal state")) {
+    if (message.includes("terminal state") || message.includes("scorer group grading this run")) {
       res.status(409).json({ error: message });
       return;
     }
@@ -267,6 +278,12 @@ evaluationsRouter.post("/runs/:runId/analyze", async (req: Request, res: Respons
 });
 
 evaluationsRouter.get("/runs/:runId/analyze-status", async (req: Request, res: Response) => {
+  // 404 for an unknown run, like /report below - "not_started" for a typo'd id kept a poll
+  // loop waiting forever.
+  if (!(await getRun(scopedDb(req), req.params.runId!))) {
+    res.status(404).json({ error: "Run not found" });
+    return;
+  }
   res.status(200).json(await getEvaluationAnalysisStatus(scopedDb(req), req.params.runId!));
 });
 

--- a/engine/src/routes/ingest.ts
+++ b/engine/src/routes/ingest.ts
@@ -149,7 +149,11 @@ ingestRouter.post("/traces", async (req: Request, res: Response) => {
 
     // Scorer groups score live traffic the same fire-and-forget way - see
     // core/monitor/scorerGroups.ts's runScorerGroupsOnline.
-    runScorerGroupsOnline(db, { input: parsed.data.input, output: parsed.data.output }, { agentId, traceId }).catch(
+    runScorerGroupsOnline(
+      db,
+      { input: parsed.data.input, output: parsed.data.output, toolCalls: parsed.data.tool_calls },
+      { agentId, traceId }
+    ).catch(
       err => {
         logger.error({ err: err instanceof Error ? err.message : err }, "Scorer group scoring failed:");
       }

--- a/engine/src/routes/insights.ts
+++ b/engine/src/routes/insights.ts
@@ -29,9 +29,13 @@ function parseWindow(req: Request): MonitoringWindow {
 
 // Same from/to override the monitoring dashboard routes accept - see parseRange there.
 function parseRange(req: Request): MonitoringRange {
-  const from = Number(req.query.from);
-  const to = Number(req.query.to);
-  if (Number.isFinite(from) && Number.isFinite(to) && to > from) {
+  // Number("") is 0 (finite!), so a blank ?from= must not silently become epoch 0 - only
+  // non-empty numeric strings qualify, both bounds must be positive, and to must exceed from.
+  const rawFrom = typeof req.query.from === "string" ? req.query.from.trim() : "";
+  const rawTo = typeof req.query.to === "string" ? req.query.to.trim() : "";
+  const from = rawFrom === "" ? Number.NaN : Number(rawFrom);
+  const to = rawTo === "" ? Number.NaN : Number(rawTo);
+  if (Number.isFinite(from) && Number.isFinite(to) && from > 0 && to > from) {
     const YEAR_MS = 366 * 24 * 60 * 60 * 1000;
     return { fromMs: Math.max(from, to - YEAR_MS), toMs: to };
   }

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -721,7 +721,6 @@ export function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean }
       case_key TEXT NOT NULL,
       query TEXT NOT NULL,
       embedding TEXT,
-      input_embedding TEXT,
       embedding_full TEXT,
       model TEXT,
       created_at INTEGER NOT NULL
@@ -2084,7 +2083,6 @@ export async function bootstrapPostgres(pool: Pool): Promise<{ freshInstall: boo
       case_key TEXT NOT NULL,
       query TEXT NOT NULL,
       embedding JSONB,
-      input_embedding JSONB,
       embedding_full JSONB,
       model TEXT,
       created_at TIMESTAMP NOT NULL

--- a/engine/src/test/scorerGroups.integration.test.ts
+++ b/engine/src/test/scorerGroups.integration.test.ts
@@ -95,12 +95,22 @@ async function makePattern(name: string, phrase: string): Promise<string> {
 }
 
 describe("scorer groups", () => {
-  it("CRUD round-trips members and the online profile", async () => {
+  it("CRUD round-trips members and the online profile; unknown member refs are a 400", async () => {
+    // Members are validated at write time: a typo'd refId used to 201 into a group that
+    // permanently scored null, one "Scorer no longer exists" member at a time.
+    const bogus = await api(
+      "/agent-monitoring/scorer-groups",
+      postJson({ name: "Bogus", members: [{ kind: "judge", refId: "nope", weight: 1 }] })
+    );
+    expect(bogus.status).toBe(400);
+    expect((bogus.body as { error: string }).error).toContain("Unknown judge scorer id");
+
+    const judgeId = await makeJudge("CRUD judge", "NICE");
     const created = await api(
       "/agent-monitoring/scorer-groups",
       postJson({
         name: "Quality bar",
-        members: [{ kind: "judge", refId: "j1", weight: 2, gate: false }],
+        members: [{ kind: "judge", refId: judgeId, weight: 2, gate: false }],
         online: { enabled: false, sampleRate: 0.5, alertThreshold: 6, severity: "high" },
       })
     );
@@ -109,7 +119,7 @@ describe("scorer groups", () => {
 
     const fetched = await api(`/agent-monitoring/scorer-groups/${id}`);
     const wire = (fetched.body as { scorerGroup: Record<string, unknown> }).scorerGroup;
-    expect(wire.members).toEqual([{ kind: "judge", refId: "j1", weight: 2, gate: false }]);
+    expect(wire.members).toEqual([{ kind: "judge", refId: judgeId, weight: 2, gate: false }]);
     expect(wire.online).toEqual({ enabled: false, sampleRate: 0.5, alertThreshold: 6, severity: "high" });
 
     const updated = await api(`/agent-monitoring/scorer-groups/${id}`, {
@@ -118,8 +128,114 @@ describe("scorer groups", () => {
     });
     expect((updated.body as { scorerGroup: { name: string } }).scorerGroup.name).toBe("Quality bar v2");
 
+    // A scope-unaware PUT (no scope/idleSeconds in the online object) must not flip a session
+    // group back to per-trace scoring - the engine merges instead of replacing.
+    const sessionized = await api(`/agent-monitoring/scorer-groups/${id}`, {
+      ...postJson({ online: { enabled: true, sampleRate: 1, alertThreshold: 5, severity: "high", scope: "session", idleSeconds: 300 } }),
+      method: "PUT",
+    });
+    expect((sessionized.body as { scorerGroup: { online: { scope?: string } } }).scorerGroup.online.scope).toBe("session");
+    const legacyPut = await api(`/agent-monitoring/scorer-groups/${id}`, {
+      ...postJson({ online: { enabled: true, sampleRate: 0.4, alertThreshold: 4, severity: "medium" } }),
+      method: "PUT",
+    });
+    const mergedOnline = (legacyPut.body as { scorerGroup: { online: Record<string, unknown> } }).scorerGroup.online;
+    expect(mergedOnline.scope).toBe("session");
+    expect(mergedOnline.idleSeconds).toBe(300);
+    expect(mergedOnline.sampleRate).toBe(0.4);
+
     expect((await api(`/agent-monitoring/scorer-groups/${id}`, { method: "DELETE" })).status).toBe(200);
     expect((await api(`/agent-monitoring/scorer-groups/${id}`)).status).toBe(404);
+  });
+
+  it("a run cannot start against a nonexistent group, and a gate that cannot score fails closed", async () => {
+    // Typo'd/deleted group id on POST /runs is a 404, not a silent downgrade to dataset grading.
+    const ds = await api(
+      "/custom-agent-evaluations/datasets",
+      postJson({ name: "gate-ds", questions: [{ main_question: { query: "q1" }, follow_up_questions: [] }] })
+    );
+    const datasetId = ((ds.body as { dataset?: { _id: string } }).dataset?._id ??
+      (ds.body as { _id?: string })._id) as string;
+    const bogusRun = await api(
+      "/custom-agent-evaluations/runs",
+      postJson({ datasetId, scorerGroupId: "not-a-group" })
+    );
+    expect(bogusRun.status).toBe(404);
+
+    // A must-pass member that CANNOT score (custom scorer deleted after group creation) fails
+    // closed: the row lands skipped with the gate named, never a blend that ignores the gate.
+    const niceId = await makeJudge("Gate nice", "NICE"); // rates 8
+    const ext = await api(
+      "/agent-monitoring/custom-evaluators",
+      postJson({ name: "Doomed gate", kind: "code", language: "javascript", script: "return { score: 1 };" })
+    );
+    expect(ext.status).toBe(201);
+    const extId = (ext.body as { evaluator: { _id: string } }).evaluator._id;
+    const group = await api(
+      "/agent-monitoring/scorer-groups",
+      postJson({
+        name: "Gated bar hard",
+        members: [
+          { kind: "judge", refId: niceId, weight: 1, gate: false },
+          { kind: "custom", refId: extId, weight: 0, gate: true },
+        ],
+      })
+    );
+    const groupId = (group.body as { scorerGroup: { _id: string } }).scorerGroup._id;
+    await api(`/agent-monitoring/custom-evaluators/${extId}`, { method: "DELETE" });
+
+    const run = await api("/custom-agent-evaluations/runs", postJson({ datasetId, scorerGroupId: groupId }));
+    expect(run.status).toBe(201);
+    const runId = (run.body as { runId: string }).runId;
+    const submitted = await api(
+      `/custom-agent-evaluations/runs/${runId}/results`,
+      postJson({
+        batchId: "b1",
+        results: [{ idempotencyKey: "k1", questionIndex: 0, runNumber: 1, input: { query: "q1" }, output: { text: "an answer" } }],
+      })
+    );
+    expect(submitted.status).toBe(200);
+    const detail = (await api(`/custom-agent-evaluations/runs/${runId}`)).body as {
+      results: Array<{ status: string; rating: number | null; justification: string | null }>;
+      liveStatistics: { skippedCount: number; ratedCount: number };
+    };
+    expect(detail.results[0]!.status).toBe("skipped");
+    expect(detail.results[0]!.rating).toBeNull();
+    expect(detail.results[0]!.justification).toContain("must-pass");
+    expect(detail.liveStatistics.skippedCount).toBe(1);
+    expect(detail.liveStatistics.ratedCount).toBe(0);
+
+    // A group whose member's referent was deleted stays EDITABLE: the dashboard round-trips
+    // the full member list on save, and stored (grandfathered) refs must not 400 - only new
+    // unknown refs do.
+    const rename = await api(`/agent-monitoring/scorer-groups/${groupId}`, {
+      ...postJson({
+        name: "Gated bar hard v2",
+        members: [
+          { kind: "judge", refId: niceId, weight: 1, gate: false },
+          { kind: "custom", refId: extId, weight: 0, gate: true },
+        ],
+      }),
+      method: "PUT",
+    });
+    expect(rename.status).toBe(200);
+    const addBogus = await api(`/agent-monitoring/scorer-groups/${groupId}`, {
+      ...postJson({ members: [{ kind: "custom", refId: "brand-new-bogus", weight: 1 }] }),
+      method: "PUT",
+    });
+    expect(addBogus.status).toBe(400);
+
+    // Deleting the group mid-run makes further submissions a hard 409, not a silent regrade.
+    await api(`/agent-monitoring/scorer-groups/${groupId}`, { method: "DELETE" });
+    const after = await api(
+      `/custom-agent-evaluations/runs/${runId}/results`,
+      postJson({
+        batchId: "b2",
+        results: [{ idempotencyKey: "k2", questionIndex: 0, runNumber: 2, input: { query: "q1" }, output: { text: "another" } }],
+      })
+    );
+    expect(after.status).toBe(409);
+    expect((after.body as { error: string }).error).toContain("scorer group");
   });
 
   it("grades a dataset run: weighted blend in the rating column, member verdicts per row", async () => {


### PR DESCRIPTION
<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
