### PR TITLE
Self-host MCP server: /mcp endpoint with project-key and OAuth 2.1 authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1001,4 +1001,10 @@ consent, code exchange, refresh rotation, revocation, cross-project isolation, t
 replayed/PKCE-mismatch failure paths, and both auth modes - and by hand with a running engine.
 The suite's Postgres describe ran green against a local Postgres 16 as well as SQLite. Not yet
 verified: an actual claude.ai connector through a tunnel (the SDK client is the closest stand-in
-available offline).
+available offline). A follow-up review pass hardened the grant lifecycle: authorization codes are
+claimed atomically and PKCE is verified after the claim (a wrong verifier burns the code), refresh
+rotation writes the new pair before retiring the old and tolerates a retry inside a 60-second grace
+window while treating later reuse as theft (whole grant revoked), a scope-narrowed refresh narrows
+only the access token, and a dashboard user's grant is re-checked against their organization
+membership on every refresh and token verification. The consent page's CSP now lists the client's
+callback origin in `form-action`, which Chromium applies to the post-submit redirect.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1008,3 +1008,12 @@ window while treating later reuse as theft (whole grant revoked), a scope-narrow
 only the access token, and a dashboard user's grant is re-checked against their organization
 membership on every refresh and token verification. The consent page's CSP now lists the client's
 callback origin in `form-action`, which Chromium applies to the post-submit redirect.
+
+`POST /mcp` now negotiates the `Accept` header instead of insisting on the exact pair the
+Streamable HTTP spec asks clients to send. A client offering `*/*`, `application/*`, or no header
+at all used to be refused at the handshake with a `406` that most hosts never surface: the
+connector registered no tools and the model was left to improvise around an MCP server that looked
+present but empty. The engine now answers in the shape the caller can actually read - a single
+JSON body unless the client named `text/event-stream` outright, which keeps spec-compliant clients
+on the event stream exactly as before - and still returns `406` when nothing on offer is
+serviceable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -981,3 +981,24 @@ Python SDK stays permissively licensed (it ships inside customer applications). 
 OpenTelemetry proto schema keeps its upstream Apache-2.0 notice. Applied to LICENSE, the README
 badge and License section, CONTRIBUTING's contribution terms, and the workspace package.json
 license fields (SPDX id `Elastic-2.0`).
+
+---
+
+**MCP connector.** The engine now serves its own remote MCP server at `POST /mcp` (Streamable
+HTTP, stateless so replicas need no sticky sessions), with nineteen read-only `agentx_*` tools
+mirroring the hosted connector's names, each a thin adapter over the same project-scoped core
+function the matching dashboard route calls, and each tool call audited as `mcp.tool_call`. Two
+credential paths: a bearer project API key (Claude Code, `mcp-remote`, the Agent SDK, CI), and
+OAuth 2.1 for claude.ai, where the engine is its own authorization server on top of the MCP SDK's
+`mcpAuthRouter`: RFC 9728/8414 metadata, dynamic client registration behind a redirect
+allow-list, PKCE, single-use codes, hashed opaque tokens (1h access / 30d refresh, rotated),
+RFC 7009 revocation, audience binding to `<AGENTX_PUBLIC_URL>/mcp`, and a server-rendered consent
+page that asks for a dashboard sign-in plus project pick in `AGENTX_AUTH=enabled` and for the
+project API key in disabled mode. Regenerating a project key revokes its grants; grants are
+listed and revoked under `/api/v1/mcp/grants` (under wire contract). Verified end to end with the
+real MCP SDK client in `engine/src/test/mcp.integration.test.ts` - discovery, registration,
+consent, code exchange, refresh rotation, revocation, cross-project isolation, the tampered/denied/
+replayed/PKCE-mismatch failure paths, and both auth modes - and by hand with a running engine.
+The suite's Postgres describe ran green against a local Postgres 16 as well as SQLite. Not yet
+verified: an actual claude.ai connector through a tunnel (the SDK client is the closest stand-in
+available offline).

--- a/README.md
+++ b/README.md
@@ -242,7 +242,15 @@ How a client authenticates depends on where it runs:
 | Claude Code | `claude mcp add --transport http agentx http://localhost:4700/mcp --header "Authorization: Bearer <project API key>"` | Project API key (printed at startup) |
 | Claude Desktop, Cursor, other stdio-only hosts | A stdio bridge, e.g. `npx mcp-remote http://localhost:4700/mcp --header "Authorization: Bearer <key>"` | Same key |
 | Agent SDK, scripts, CI | Any MCP client pointed at `/mcp` with the header | Same key |
+| Codex and other HTTP connectors | Point at `http://localhost:4700/mcp`; `x-api-key: <key>` works wherever a bearer header is awkward | Same key |
 | **claude.ai / Claude Desktop connectors** | Add `https://<your instance>/mcp` as a custom connector | OAuth 2.1 (below) - static keys are not an option there |
+
+If a host is configured with the *name* of an environment variable holding the key (Codex's
+`bearer_token_env_var`, for one), put the variable name there and export the key in the
+environment that launches the host - pasting the key itself makes the host look up a variable
+that does not exist, send no credential, and quietly register no tools. The engine logs every
+request with its status, so a `401` on `/mcp` in its output is the credential, a `406` is the
+`Accept` header, and no line at all means the host never dialled.
 
 **OAuth for claude.ai.** Anthropic's servers open the connection, so the instance needs a public
 HTTPS URL, and the engine acts as the OAuth 2.1 authorization server for its own `/mcp`: RFC 9728

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ browser, and prints the Default project API key for the SDK. Prefer a container?
 - [Configuration](#configuration)
 - [Scaling tiers](#scaling-tiers)
 - [SDK & OpenTelemetry](#sdk--opentelemetry)
+- [Connect Claude (MCP)](#connect-claude-mcp)
 - [Claude Code skills](#claude-code-skills)
 - [What's in this repo](#whats-in-this-repo)
 - [Building from source](#building-from-source)
@@ -141,6 +142,8 @@ Set these in the environment before starting `agentx-server`:
 | `AGENTX_METRICS_TOKEN`       | -                | When set, `GET /metrics` requires `Authorization: Bearer <token>`; unset leaves the endpoint open (fine for a local install, not for a network-exposed one).                                                                                    |
 | `AGENTX_PUBLIC_URL`          | -                | The externally reachable base URL when running behind a proxy/domain with auth enabled (used for auth callbacks/cookies).                                                                                                                       |
 | `AGENTX_TRUSTED_ORIGINS`     | -                | Comma-separated extra origins allowed to make authenticated browser requests (e.g. a dev dashboard on another port).                                                                                                                            |
+| `AGENTX_MCP`                 | (enabled)        | Set to `disabled` to turn off the MCP connector surface (`POST /mcp` and the OAuth endpoints) entirely. See [Connect Claude (MCP)](#connect-claude-mcp).                                                                                          |
+| `AGENTX_MCP_REDIRECT_ALLOWLIST` | -             | Comma-separated extra OAuth redirect URIs an MCP client may register with (exact match, or a prefix ending in `*`). claude.ai's callback and loopback URIs are always allowed.                                                                  |
 
 Trace ingest and pattern matching on phrase/regex both work with no keys configured at all - only
 judge scoring, semantic pattern detection, and the embeddings-backed features (topic clustering,
@@ -222,6 +225,50 @@ OTel traffic is a first-class citizen of the full loop, via three attribute conv
 | `gen_ai.tool.name` on a child span                             | The tool call is folded up into its root interaction's `tool_calls` (with `success`/`error` from the span's status), lighting up the Tool quality column, the built-in Tool failure check, and Tool Schema evidence. In-batch only: a parent exported in an earlier OTLP batch isn't updated retroactively. |
 
 Known gap: gRPC transport isn't supported (HTTP only).
+
+## Connect Claude (MCP)
+
+The engine is also a remote [MCP](https://modelcontextprotocol.io) server: `POST /mcp` (Streamable
+HTTP) exposes read-only tools over one project's traces, sessions, signals and KPIs, datasets and
+evaluation runs, the Prompt and Tool Schema registries, and coverage insights - the same
+`agentx_*` tool names as the hosted AgentX connector, so prompts and skills port between the two.
+Every call runs through the same project-scoped core functions the dashboard uses; there is no
+side door.
+
+How a client authenticates depends on where it runs:
+
+| Client | How it reaches the engine | Credential |
+| --- | --- | --- |
+| Claude Code | `claude mcp add --transport http agentx http://localhost:4700/mcp --header "Authorization: Bearer <project API key>"` | Project API key (printed at startup) |
+| Claude Desktop, Cursor, other stdio-only hosts | A stdio bridge, e.g. `npx mcp-remote http://localhost:4700/mcp --header "Authorization: Bearer <key>"` | Same key |
+| Agent SDK, scripts, CI | Any MCP client pointed at `/mcp` with the header | Same key |
+| **claude.ai / Claude Desktop connectors** | Add `https://<your instance>/mcp` as a custom connector | OAuth 2.1 (below) - static keys are not an option there |
+
+**OAuth for claude.ai.** Anthropic's servers open the connection, so the instance needs a public
+HTTPS URL, and the engine acts as the OAuth 2.1 authorization server for its own `/mcp`: RFC 9728
+protected-resource metadata, RFC 8414 discovery, dynamic client registration (PKCE required,
+redirect URIs limited to claude.ai's callback, loopback, and `AGENTX_MCP_REDIRECT_ALLOWLIST`),
+one-hour access tokens bound to this server, 30-day refresh tokens rotated on every use, and
+revocation. An access token is a short-lived stand-in for the project API key: regenerating the
+key revokes every grant. What the consent page asks for follows the auth mode:
+
+- `AGENTX_AUTH=enabled` (recommended for anything internet-reachable): sign in with your dashboard
+  account, pick the project to connect, approve.
+- `AGENTX_AUTH=disabled`: paste the project API key. Same trust posture as the rest of that mode,
+  which lets you connect claude.ai to a laptop through a tunnel (`cloudflared tunnel --url
+  http://localhost:4700`, Tailscale Funnel, ngrok) without turning on accounts.
+
+```bash
+AGENTX_PUBLIC_URL=https://agentx.example.com AGENTX_AUTH=enabled agentx-server
+# claude.ai -> Settings -> Connectors -> Add custom connector -> https://agentx.example.com/mcp
+```
+
+`AGENTX_PUBLIC_URL` must be `https://` for OAuth to mount (loopback `http://localhost` also works,
+for local clients); without it `/mcp` still accepts the bearer key. Live grants are listed at
+`GET /api/v1/mcp/grants` (key-authenticated) and revoked with `DELETE /api/v1/mcp/grants/:id`; every
+tool call lands in the audit trail as `mcp.tool_call`. Design notes and the roadmap (write tools
+behind an `mcp:write` scope, a dashboard "connected apps" card) live in
+[docs/self-hosted-mcp-plan.md](docs/self-hosted-mcp-plan.md).
 
 ## Claude Code skills
 

--- a/docs/self-hosted-mcp-plan.md
+++ b/docs/self-hosted-mcp-plan.md
@@ -1,0 +1,260 @@
+# Self-host MCP server: plan
+
+**Status:** design. Nothing below is implemented yet.
+
+**Goal:** a Claude user adds `https://<their-self-host>/mcp` as a custom connector in claude.ai
+(or `claude mcp add` in Claude Code) and Claude can read traces, sessions, signals, datasets,
+evaluations, prompts and insights from their own instance - the same experience as the hosted
+AgentX MCP, against data that never leaves their box.
+
+## 1. The authorization problem, stated precisely
+
+The hosted AgentX MCP has an account system behind it. Self-host, by default, has none:
+`AGENTX_AUTH=disabled` means "reachable port = trusted", `/api/v1/auth/config` hands the default
+project's API key to anyone who asks, and every data-plane route is keyed by that project API
+key (`x-api-key`, resolved in `engine/src/auth/apiKey.ts`).
+
+Three facts decide the design:
+
+1. **A claude.ai connector needs a public HTTPS URL.** claude.ai's servers fetch the MCP endpoint,
+   not the user's browser, so `localhost` never works and the endpoint is reachable from the
+   whole internet. An authless `/mcp` on a public host hands every trace and prompt on the
+   instance to anyone who guesses the URL. So the MCP endpoint can never be authless when it is
+   reachable by claude.ai, regardless of what the rest of the engine does.
+2. **claude.ai custom connectors authenticate with OAuth 2.1**, discovering the authorization
+   server through RFC 9728 protected-resource metadata and registering themselves with Dynamic
+   Client Registration (RFC 7591). Their callback is `https://claude.ai/api/mcp/auth_callback`.
+   A client ID/secret can be typed in under Advanced settings when a server does not offer DCR.
+   Static header credentials are reported as a beta option and are not something to build on.
+   Claude Code, the Agent SDK and the Messages API MCP connector *do* accept a static bearer
+   header (`--header "Authorization: Bearer ..."` / `authorization_token`).
+3. **The engine already has the only identity that matters: the project.** Every core function
+   is scoped with `withProjectId(getDb(), projectId)` inside `runWithTenancy(...)`. Whatever the
+   MCP accepts as a credential must resolve to a `projectId` (plus `organizationId`), exactly as
+   `requireApiKey()` does today.
+
+**Decision:** do not make the MCP authless, and do not invent a second identity system. Make the
+engine itself a small OAuth 2.1 authorization server whose access tokens are short-lived,
+audience-bound stand-ins for a project API key. What the user does on the authorize page depends
+on the auth mode the instance already runs in:
+
+| Instance mode | What "log in" means on the authorize page | Who this is for |
+|---|---|---|
+| `AGENTX_AUTH=enabled` (recommended for anything public) | Existing dashboard sign-in (better-auth cookie), then pick the project(s) to grant and confirm scopes | Team servers, anything on a real domain |
+| `AGENTX_AUTH=disabled` | Paste a project API key; the key is verified and the token is minted for that project | Local instances exposed through a tunnel (cloudflared/ngrok) for a personal claude.ai connector |
+
+The disabled-mode path adds no protection beyond what the README already documents for that
+mode (anyone who reaches the port gets the key), but it also removes none, and it keeps the
+zero-setup posture for people who just want to point claude.ai at their laptop through a tunnel.
+The docs must say plainly: a self-host that is reachable from the internet should run
+`AGENTX_AUTH=enabled`, and the connector is one more reason to.
+
+Alongside OAuth, the MCP endpoint accepts `Authorization: Bearer <project API key>` (and
+`x-api-key`) directly. That is the Claude Code / Agent SDK / CI path, it costs nothing, and it
+ships first.
+
+### Rejected
+
+- **Authless `/mcp`, even behind a flag.** Public URL is a requirement of the consumer; see fact 1.
+- **`@better-auth/mcp` / `@better-auth/oauth-provider` as the authorization server.** better-auth
+  1.7 moved these to separate packages that peer on `better-auth ^1.7.3` (the repo pins 1.7.1),
+  add five OAuth tables through their own schema generator, need the `jwt` plugin, and
+  `@better-auth/mcp` documents itself as accepting only the MCP `2026-07-28` protocol version,
+  which is not something we can guarantee claude.ai's client sends. Most decisively: better-auth
+  is only initialized in enabled mode, so this could never serve the disabled-mode tunnel case.
+  Revisit if the hand-rolled provider grows past a few hundred lines.
+- **Delegating to the customer's own IdP (OIDC) as the authorization server.** The IdP does not
+  know what a project is, so a token from it still needs a project-selection step inside the
+  engine. Keep as an optional Phase 3 using the SDK's `ProxyOAuthServerProvider`, not as the base.
+- **A separate MCP process/port.** One binary, one port, one `AGENTX_PUBLIC_URL` is the whole
+  self-host promise; the transport is a route.
+
+## 2. Architecture
+
+Everything lives in the engine, on the existing port, built on `@modelcontextprotocol/sdk`
+(already a dependency at 1.30.0, the current release - the engine uses its *client* side in
+`core/evaluate/mcp.ts` for the Register Tool flow; this adds the *server* side).
+
+```
+claude.ai / Claude Code
+   │  POST /mcp  (Streamable HTTP, stateless)         Authorization: Bearer <token|project key>
+   ▼
+requireMcpAuth  ──►  token store / projects table  ──►  req.projectId, runWithTenancy(...)
+   │
+   ▼
+McpServer (tools) ──► core/* functions with withProjectId(getDb(), projectId)   (no HTTP self-calls)
+
+OAuth 2.1 authorization server (SDK mcpAuthRouter + engine OAuthServerProvider):
+  GET  /.well-known/oauth-protected-resource/mcp    (RFC 9728, points at issuer = AGENTX_PUBLIC_URL)
+  GET  /.well-known/oauth-authorization-server      (RFC 8414)
+  POST /register                                    (DCR, redirect allow-list)
+  GET  /authorize                                   (login/consent page, PKCE required)
+  POST /token                                       (code + refresh grants, rotation)
+  POST /revoke
+```
+
+### 2.1 MCP endpoint
+
+- `POST /mcp` with `StreamableHTTPServerTransport` in **stateless** mode (`sessionIdGenerator:
+  undefined`): no server-side session table, so multi-replica Postgres/Helm deployments need no
+  sticky routing. `GET`/`DELETE /mcp` return 405. Registered before the SPA catch-all in
+  `index.ts` (the `^(?!\/api).*` fallback would otherwise swallow it), under `dataPlaneLimit`.
+- `requireMcpAuth` middleware, in order: `Authorization: Bearer` that resolves as an MCP access
+  token → `Authorization: Bearer` / `x-api-key` that resolves as a project API key → 401 with
+  `WWW-Authenticate: Bearer resource_metadata="<PUBLIC_URL>/.well-known/oauth-protected-resource/mcp"`
+  (the SDK's `requireBearerAuth` produces this header; wrap it so the project-key fallback runs
+  first). Sets `req.projectId` and enters `runWithTenancy`, so every tool call inherits tenancy
+  the same way route handlers do.
+- Tool handlers call core functions directly with a scoped `Db`. No loopback HTTP: the audit tap
+  (`routes/auditTap.ts`) gets an explicit `mcp.tool_call` event (tool name, project, client id,
+  outcome) instead.
+
+### 2.2 Tool surface
+
+Mirror the hosted MCP's naming (`agentx_*`) and argument shapes wherever the same concept exists,
+so prompts, skills and docs written for one work against the other. Phase 1 is read-only:
+
+| Area | Tools | Backed by |
+|---|---|---|
+| Identity | `agentx_whoami` (project, org, mode, engine version) | `projects.ts` |
+| Trace | `agentx_list_traces`, `agentx_get_trace`, `agentx_list_sessions`, `agentx_get_session` | `core/trace/*` |
+| Monitor | `agentx_get_kpis`, `agentx_list_signals`, `agentx_get_signal`, `agentx_list_agents`, `agentx_list_topics` | `core/monitor/*` |
+| Evaluate | `agentx_list_datasets`, `agentx_get_dataset`, `agentx_list_evaluations`, `agentx_get_evaluation`, `agentx_list_prompts`, `agentx_get_prompt`, `agentx_list_tool_schemas` | `core/evaluate/*` |
+| Insights | `agentx_get_coverage`, `agentx_probe_coverage` | `core/insights/*` |
+
+Writes come in Phase 3 behind the `mcp:write` scope: add a dataset case from a trace, run an
+evaluation, propose (never publish) a prompt improvement. Publish/promote stays human-only, which
+is the same rule the dashboard enforces.
+
+Every list tool takes `limit` (default 20, max 100) and returns compact rows; detail tools return
+the full record. Input schemas are zod, the same validators the routes use where they exist.
+
+### 2.3 Authorization server
+
+Implement the SDK's `OAuthServerProvider` interface (`clientsStore`, `authorize`,
+`challengeForAuthorizationCode`, `exchangeAuthorizationCode`, `exchangeRefreshToken`,
+`verifyAccessToken`, `revokeToken`) and mount it with `mcpAuthRouter({ provider, issuerUrl,
+resourceServerUrl: <PUBLIC_URL>/mcp, scopesSupported: ["mcp:read", "mcp:write"] })`. The SDK
+handles PKCE verification, DCR request validation, metadata documents and error shapes; the engine
+supplies storage and the login/consent step.
+
+**Storage** - three tables, both dialects, created in `storage/db.ts` next to the existing
+`CREATE TABLE IF NOT EXISTS` blocks:
+
+| Table | Columns (abridged) | Notes |
+|---|---|---|
+| `mcp_oauth_clients` | id, client_name, redirect_uris (json), token_endpoint_auth_method, client_secret_hash (nullable), created_at, last_used_at | DCR output; also holds any manually provisioned client |
+| `mcp_oauth_codes` | code_hash, client_id, project_id, organization_id, user_id (nullable), scopes, code_challenge, redirect_uri, resource, expires_at | single use, 10 min |
+| `mcp_oauth_tokens` | token_hash, kind (access/refresh), client_id, project_id, organization_id, user_id (nullable), scopes, resource, expires_at, revoked_at, parent_refresh_hash | opaque random tokens, sha256 at rest; access 1h, refresh 30d, rotated on use |
+
+Tokens are hashed even though project keys are stored in plaintext today: these are derived,
+short-lived credentials and hashing them is free.
+
+**DCR policy** - `/register` is unauthenticated by spec, so constrain it:
+- Exact-match redirect URIs against an allow-list: `https://claude.ai/api/mcp/auth_callback`,
+  `https://claude.com/api/mcp/auth_callback`, and loopback `http://127.0.0.1:<any port>/…` /
+  `http://localhost:<any port>/…` (Claude Code uses a varying port). Extendable with
+  `AGENTX_MCP_REDIRECT_ALLOWLIST` for other MCP clients.
+- `credentialLimit` on `/register`, `/authorize`, `/token`; clients never used within 30 days are
+  pruned by the existing sweep cadence.
+- Public clients only (`token_endpoint_auth_method: none`) plus PKCE S256 required - which is
+  what claude.ai and Claude Code send.
+
+**Authorize page** - server-rendered HTML from the engine (same approach as the existing
+`/api/v1/mcp-oauth/callback` page), no dashboard build needed:
+- Enabled mode: `getSessionUser(req)`; no session → redirect to the SPA login with a `redirect`
+  back to the full authorize URL; with a session → list the projects of the user's orgs
+  (`listProjectsWireForOrgs`), radio-select one, scope checkboxes (read pre-checked, write
+  unchecked), Approve. The form posts to `POST /authorize/decision` with a nonce bound to the
+  pending request; `X-Frame-Options: DENY`.
+- Disabled mode: the same page with a single "project API key" field instead of the project list;
+  verified through `resolveProjectByApiKey` (constant-time by construction of the lookup).
+- On approve: mint the code, redirect to the validated `redirect_uri` with `code` and `state`.
+
+**Token validation** (`verifyAccessToken`): hash lookup, not revoked, not expired, `resource`
+equals the canonical `<PUBLIC_URL>/mcp` (RFC 8707 audience binding, required by the MCP spec),
+project still exists. Returns `AuthInfo` with `extra: { projectId, organizationId, userId }`,
+which `requireMcpAuth` copies onto the request.
+
+**Preconditions and switches**
+- `AGENTX_PUBLIC_URL` must be set and `https://` for the OAuth routes to mount (issuer must be
+  HTTPS; the SDK refuses otherwise except for localhost). Without it the `/mcp` endpoint still
+  works with a bearer project key and the boot log says why OAuth is off.
+- `AGENTX_MCP=disabled` turns the whole surface off. Default on: it exposes nothing a project key
+  does not already expose.
+- `AGENTX_TRUST_PROXY` matters here as it does everywhere else behind an ingress.
+
+### 2.4 Revocation and visibility
+
+- `POST /revoke` (SDK-mounted) for the client side.
+- Session-authenticated engine routes `GET/DELETE /api/v1/mcp/grants` (enabled mode) and
+  key-authenticated equivalents under the project (disabled mode) list and revoke grants per
+  project. A "Connected apps" card in the dashboard consumes these (front-end repo, Phase 3).
+- Regenerating a project API key (`POST /agent-monitoring/settings/api-key/regenerate`) revokes
+  every MCP token minted for that project - the token is a stand-in for the key, so it dies with
+  it.
+
+## 3. Phases
+
+**Phase 1 - MCP endpoint with bearer project key** (engine only, ~2-3 days)
+- `routes/mcp.ts`: `POST /mcp`, stateless Streamable HTTP, `requireMcpAuth` with the project-key
+  path only (401 without `WWW-Authenticate` metadata yet).
+- `core/mcp/tools/*.ts`: the read tools in §2.2, one file per area, each a thin adapter over an
+  existing core function.
+- Audit event `mcp.tool_call`; access-log `projectId` already flows.
+- Tests: `src/test/mcp.integration.test.ts` drives the SDK `Client` +
+  `StreamableHTTPClientTransport` against a booted engine: initialize, `tools/list`, a call per
+  area, project isolation (key A cannot see project B), 401 without a key.
+- README: "Connect Claude" section with `claude mcp add --transport http agentx
+  http://localhost:4700/mcp --header "Authorization: Bearer <key>"`.
+- Unblocks: Claude Code, Agent SDK, Messages API `mcp_servers` (+ `authorization_token`), CI.
+
+**Phase 2 - OAuth 2.1 authorization server** (engine only, ~3-5 days)
+- Tables (§2.3, both dialects), `core/mcp/oauthProvider.ts`, `mcpAuthRouter` mount, protected
+  resource metadata, `WWW-Authenticate` on 401, DCR allow-list, authorize page in both modes,
+  refresh rotation, revoke, key-regeneration cascade.
+- Tests: full flow through the SDK client's `OAuthClientProvider` (the same interface
+  `core/evaluate/mcp.ts` implements for the outbound case): DCR → authorize (test session or
+  pasted key) → token → tool call; then audience mismatch, expired, revoked, replayed code, bad
+  redirect URI, PKCE mismatch all 4xx. Both `AGENTX_AUTH` modes.
+- Manual verification: cloudflared tunnel to a dev engine, add the connector in claude.ai, run
+  a conversation that lists traces. Same against Claude Code's `/mcp` login.
+- Docs: configuration table rows (`AGENTX_MCP`, `AGENTX_MCP_REDIRECT_ALLOWLIST`), a "Connecting
+  claude.ai to a self-host" walkthrough for both modes with the enabled-mode recommendation
+  stated up front, runbook entry for "connector says unauthorized".
+
+**Phase 3 - polish and reach** (engine + dashboard, ongoing)
+- Write tools behind `mcp:write` (§2.2); "Connected apps" card in the dashboard; Helm values for
+  `AGENTX_PUBLIC_URL`.
+- Optional external IdP as authorization server via `ProxyOAuthServerProvider` for enterprises
+  that already run OIDC (`AGENTX_OIDC_*`), keeping the engine's project-selection step.
+- Share tool definitions with the hosted MCP (a `packages/agentx-mcp-tools` workspace) once both
+  sides have stabilized, so the two servers cannot drift apart.
+
+## 4. Security checklist (carried into the implementation PR)
+
+- [ ] `/mcp` never answers without a credential that resolves to a project.
+- [ ] Tokens: opaque, hashed at rest, 1h access / 30d refresh, refresh rotation, revocation.
+- [ ] Audience: `resource` checked on every token; no token passthrough anywhere.
+- [ ] Redirect URIs: exact match, allow-listed; codes single-use with a 10-minute TTL.
+- [ ] PKCE S256 required (SDK enforces); `state` echoed untouched.
+- [ ] Authorize page: session or key proof, nonce-bound decision POST, `X-Frame-Options: DENY`,
+      no autosubmit.
+- [ ] `/register`, `/authorize`, `/token` under `credentialLimit`; `/mcp` under `dataPlaneLimit`.
+- [ ] Project key regeneration revokes derived tokens.
+- [ ] Every tool call audited with client id and project.
+- [ ] Docs state the public-URL-implies-enabled-mode recommendation explicitly.
+
+## 5. Open questions
+
+1. **claude.ai's DCR expectations.** Reports exist of connectors that register fine and then
+   fail at the callback; the Phase 2 manual tunnel test is the gate, and the SDK's router is the
+   most-tested implementation available to us. If claude.ai turns out to need something the
+   router does not emit, the fix is in `oauthProvider.ts`, not a redesign.
+2. **One project per token, or several?** Start with one (matches the key model, keeps every
+   tool call unambiguous). Multi-project grants would need a `project` argument on every tool.
+3. **Authorize page ownership.** Engine-rendered HTML ships without a dashboard release; if the
+   team prefers the SPA look, the decision POST is the same and only the page moves.
+4. **Should Phase 1 also accept the project key on claude.ai's header-credential option?** It
+   does automatically (same bearer path); whether to document it depends on that option leaving
+   beta.

--- a/docs/self-hosted-mcp-plan.md
+++ b/docs/self-hosted-mcp-plan.md
@@ -184,7 +184,7 @@ supplies storage and the login/consent step.
 |---|---|---|
 | `mcp_oauth_clients` | id, client_name, redirect_uris (json), token_endpoint_auth_method, client_secret_hash (nullable), created_at, last_used_at | DCR output; also holds any manually provisioned client |
 | `mcp_oauth_codes` | code_hash, client_id, project_id, organization_id, user_id (nullable), scopes, code_challenge, redirect_uri, resource, expires_at | single use, 10 min |
-| `mcp_oauth_tokens` | token_hash, kind (access/refresh), client_id, project_id, organization_id, user_id (nullable), scopes, resource, expires_at, revoked_at, parent_refresh_hash | opaque random tokens, sha256 at rest; access 1h, refresh 30d, rotated on use |
+| `mcp_oauth_tokens` | token_hash, kind (access/refresh), grant_id, client_id, project_id, organization_id, user_id (nullable), scopes, resource, expires_at, revoked_at, rotated_at | opaque random tokens, sha256 at rest; access 1h, refresh 30d, rotated on use. A rotated-out refresh token presented again within a 60s grace window is a retry (mints another pair); after it, reuse revokes the whole grant |
 
 Tokens are hashed even though project keys are stored in plaintext today: these are derived,
 short-lived credentials and hashing them is free.
@@ -275,8 +275,14 @@ which `requireMcpAuth` copies onto the request.
 - [ ] `/mcp` never answers without a credential that resolves to a project.
 - [ ] Tokens: opaque, hashed at rest, 1h access / 30d refresh, refresh rotation, revocation.
 - [ ] Audience: `resource` checked on every token; no token passthrough anywhere.
-- [ ] Redirect URIs: exact match, allow-listed; codes single-use with a 10-minute TTL.
-- [ ] PKCE S256 required (SDK enforces); `state` echoed untouched.
+- [ ] Redirect URIs: exact match, allow-listed; codes single-use with a 10-minute TTL, claimed
+      atomically (`DELETE ... RETURNING`) so a concurrent retry cannot double-mint.
+- [ ] PKCE S256 required, verified by the engine after the code is claimed (a wrong verifier burns
+      the code); `state` echoed untouched.
+- [ ] A dashboard user's grant is re-checked against their organization membership on every
+      refresh and every access-token verification; removal from the org cuts the connector off.
+- [ ] Consent page CSP lists the client's callback origin in `form-action` (Chromium applies it to
+      the redirect that follows the submit).
 - [ ] Authorize page: session or key proof, nonce-bound decision POST, `X-Frame-Options: DENY`,
       no autosubmit.
 - [ ] `/register`, `/authorize`, `/token` under `credentialLimit`; `/mcp` under `dataPlaneLimit`.

--- a/docs/self-hosted-mcp-plan.md
+++ b/docs/self-hosted-mcp-plan.md
@@ -1,6 +1,45 @@
 # Self-host MCP server: plan
 
-**Status:** design. Nothing below is implemented yet.
+**Status:** Phases 1 and 2 are implemented; Phase 3 is still design.
+
+| Shipped | Where |
+|---|---|
+| `POST /mcp` (stateless Streamable HTTP), key + OAuth bearer auth, 405 on other verbs | `engine/src/routes/mcp.ts` |
+| Nineteen read-only `agentx_*` tools, audited per call | `engine/src/core/mcp/tools.ts`, `server.ts` |
+| OAuth 2.1 authorization server: DCR allow-list, consent page in both auth modes, PKCE, hashed tokens, refresh rotation, revocation, audience binding | `engine/src/core/mcp/oauthProvider.ts`, `oauthStore.ts`, `authorizePage.ts`, `config.ts` |
+| Tables in both dialects | `engine/src/storage/schema.{sqlite,pg}.ts`, `db.ts` |
+| Grants list/revoke (`/api/v1/mcp/grants`, under wire contract) and key-regeneration cascade | `engine/src/routes/mcp.ts`, `apiV1.ts`, `agentMonitoringDashboard.ts` |
+| Tests: SDK client end to end, both auth modes, failure paths | `engine/src/test/mcp.integration.test.ts` |
+| README section, configuration rows | `README.md` |
+
+**Three things changed during implementation.**
+
+1. **Only one scope exists.** `mcp:write` was dropped from the consent page until a write tool
+   ships - a checkbox that gates nothing is the placebo knob CONTRIBUTING.md bans. §2.3 and §2.4
+   below still describe the two-scope end state.
+2. **The issuer defaults to loopback.** With no `AGENTX_PUBLIC_URL`, the issuer is
+   `http://localhost:<port>` rather than "OAuth off": the spec allows plain HTTP on loopback, so
+   Claude Code can run the real OAuth flow against a local engine, and the integration tests
+   exercise the exact code path claude.ai will. A non-loopback `http://` public URL still
+   disables OAuth with a boot warning.
+3. **Consent requests are signed, not stored.** The authorize page carries the request back as
+   HMAC-signed hidden fields (keyed by the persisted instance secret), so multi-replica
+   deployments need no pending-request table and a tampered form fails before any principal check.
+
+**Verified on both dialects**: the suite's opt-in Postgres describe ran against a local
+Postgres 16 alongside the SQLite run. **Still unverified:** a real claude.ai connector through a
+tunnel (the SDK's own OAuth client is the closest offline stand-in and passes).
+
+### Localhost
+
+"Localhost MCP" means different things per surface, and only the last row needs Phase 2:
+
+| Surface | How it reaches a local engine | Needs |
+|---|---|---|
+| Claude Code | `claude mcp add --transport http agentx http://localhost:4700/mcp --header "Authorization: Bearer <key>"` (or `/mcp` login via the loopback OAuth issuer) | Phase 1 |
+| Claude Desktop, Cursor, other stdio-only hosts | `npx mcp-remote http://localhost:4700/mcp --header "Authorization: Bearer <key>"` in the host's MCP config; an `agentx mcp` stdio proxy in the Go CLI would remove the Node dependency (Phase 3) | Phase 1 |
+| Agent SDK, scripts, CI | Any HTTP MCP client with the header | Phase 1 |
+| claude.ai web / mobile, Messages API connector | Cannot reach localhost at all - Anthropic's servers open the connection. Expose the engine (cloudflared, ngrok, Tailscale Funnel), set `AGENTX_PUBLIC_URL` to that HTTPS URL, connect | Phase 2 |
 
 **Goal:** a Claude user adds `https://<their-self-host>/mcp` as a custom connector in claude.ai
 (or `claude mcp add` in Claude Code) and Claude can read traces, sessions, signals, datasets,

--- a/engine/src/auth/rateLimit.ts
+++ b/engine/src/auth/rateLimit.ts
@@ -17,6 +17,12 @@ const WINDOW_MS = 60_000;
 export const CREDENTIAL_LIMIT = Number(process.env.AGENTX_RATE_LIMIT_CREDENTIAL || 120);
 export const DATA_PLANE_LIMIT = Number(process.env.AGENTX_RATE_LIMIT_DATA_PLANE || 6000);
 
+// The operator kill-switch, exported so a limiter built elsewhere (routes/mcp.ts's consent
+// ceiling, which CodeQL needs to see at the route) honours it too.
+export function rateLimitDisabled(): boolean {
+  return process.env.AGENTX_RATE_LIMIT === "off";
+}
+
 export function rateLimit(limit: number): RequestHandler {
   return rateLimitMiddleware({
     windowMs: WINDOW_MS,
@@ -24,7 +30,7 @@ export function rateLimit(limit: number): RequestHandler {
     standardHeaders: "draft-7",
     legacyHeaders: false,
     // Each call builds its own store, so the two surfaces never share a counter.
-    skip: () => process.env.AGENTX_RATE_LIMIT === "off" || !Number.isFinite(limit) || limit <= 0,
+    skip: () => rateLimitDisabled() || !Number.isFinite(limit) || limit <= 0,
     handler: (_req, res) => {
       // Same statusCode-carrying JSON shape as every other error this engine returns, which is
       // what AgentX-web-front's axios interceptor reads.

--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -639,6 +639,30 @@ export const modelCatalogSchema = z
   })
   .strict();
 
+// ---- GET /mcp/grants -----------------------------------------------------------------------
+
+// OAuth grants issued to MCP clients (claude.ai connectors, Claude Code) for the caller's
+// project - the dashboard's "connected apps" list. One row per live grant; revoking one kills
+// its refresh chain and every access token minted from it (routes/mcp.ts).
+export const mcpGrantsResponseSchema = z
+  .object({
+    grants: z.array(
+      z
+        .object({
+          grantId: z.string(),
+          clientId: z.string(),
+          clientName: z.string().nullable(),
+          userId: z.string().nullable(),
+          scopes: z.array(z.string()),
+          createdAt: isoDate,
+          lastUsedAt: isoDate.nullable(),
+          expiresAt: isoDate,
+        })
+        .strict()
+    ),
+  })
+  .strict();
+
 export const WIRE_CONTRACT = [
   {
     method: "get" as const,
@@ -787,5 +811,12 @@ export const WIRE_CONTRACT = [
     summary: "The same verdict for a list of queries, plus a rollup",
     response: insightsProbeBatchResponseSchema,
     name: "InsightsProbeBatchResponse",
+  },
+  {
+    method: "get" as const,
+    path: "/mcp/grants",
+    summary: "OAuth grants issued to MCP clients for the project",
+    response: mcpGrantsResponseSchema,
+    name: "McpGrantsResponse",
   },
 ];

--- a/engine/src/core/audit/auditLog.ts
+++ b/engine/src/core/audit/auditLog.ts
@@ -9,7 +9,8 @@ import { logger } from "../../log.js";
 // single-binary engine can make (an operator with database access can always do anything; the
 // audit trail's job is making the ENGINE incapable of quietly rewriting history).
 
-export type AuditActorType = "project-key" | "user" | "admin" | "anonymous";
+// "mcp-token": an MCP client acting under an OAuth grant (core/mcp/tools.ts records these).
+export type AuditActorType = "project-key" | "user" | "admin" | "anonymous" | "mcp-token";
 
 export type AuditEventInput = {
   actor: string;

--- a/engine/src/core/mcp/authorizePage.ts
+++ b/engine/src/core/mcp/authorizePage.ts
@@ -10,6 +10,10 @@ export type AuthorizePageInput = {
   clientUri: string | null;
   scopes: string[];
   redirectHost: string;
+  // The origin the decision route redirects to after the form is submitted. Chromium applies
+  // the page's form-action directive to redirects that follow a form submission, so the client's
+  // callback origin has to be listed next to 'self' or the approval never reaches claude.ai.
+  redirectOrigin: string;
   // The signed request bundle (oauthProvider.ts) carried through as hidden inputs.
   hidden: AuthorizeField[];
   // Loopback issuers have no HTTPS; the browser must still be told what it is approving.
@@ -53,13 +57,13 @@ const STYLE = `
   code { font-size: 12px; background: #f3f4f6; padding: 1px 5px; border-radius: 4px; }
 `;
 
-function shell(title: string, body: string, nonce: string, script = ""): string {
+function shell(title: string, body: string, nonce: string, script = "", formAction = "'self'"): string {
   return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}'; connect-src 'self'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}'; connect-src 'self'; form-action ${formAction}; base-uri 'none'; frame-ancestors 'none'">
 <title>${esc(title)}</title>
 <style nonce="${nonce}">${STYLE}</style>
 </head>
@@ -76,6 +80,9 @@ function scopeList(scopes: string[]): string {
 }
 
 export function renderAuthorizePage(input: AuthorizePageInput, nonce: string): string {
+  // The origin of a URL the provider already parsed and matched against the client's registered
+  // redirect URIs; a CSP source list is space-separated, so it cannot smuggle a second source.
+  const formAction = `'self' ${esc(input.redirectOrigin)}`;
   const client = input.clientUri
     ? `<a href="${esc(input.clientUri)}" rel="noreferrer">${esc(input.clientName)}</a>`
     : `<strong>${esc(input.clientName)}</strong>`;
@@ -96,7 +103,7 @@ ${hiddenInputs(input.hidden)}
   <button type="submit" name="action" value="approve" class="primary">Approve</button>
 </div>
 </form>`;
-    return shell("Connect to AgentX", body, nonce);
+    return shell("Connect to AgentX", body, nonce, "", formAction);
   }
 
   if (!input.mode.signedIn) {
@@ -163,7 +170,7 @@ ${projectPicker}
   <button type="submit" name="action" value="approve" class="primary" ${projects.length === 0 ? "disabled" : ""}>Approve</button>
 </div>
 </form>`;
-  return shell("Connect to AgentX", body, nonce);
+  return shell("Connect to AgentX", body, nonce, "", formAction);
 }
 
 export function renderMessagePage(title: string, message: string, nonce: string): string {

--- a/engine/src/core/mcp/authorizePage.ts
+++ b/engine/src/core/mcp/authorizePage.ts
@@ -1,0 +1,171 @@
+// Server-rendered consent page for the MCP OAuth flow (oauthProvider.ts). Deliberately not part
+// of the dashboard bundle: the flow has to work on an API-only install and on a dashboard build
+// that predates it. Every interpolated value goes through esc(); the page ships a strict CSP and
+// refuses to be framed, because this is the one screen where a click hands out data access.
+
+export type AuthorizeField = { name: string; value: string };
+
+export type AuthorizePageInput = {
+  clientName: string;
+  clientUri: string | null;
+  scopes: string[];
+  redirectHost: string;
+  // The signed request bundle (oauthProvider.ts) carried through as hidden inputs.
+  hidden: AuthorizeField[];
+  // Loopback issuers have no HTTPS; the browser must still be told what it is approving.
+  mode:
+    | { kind: "disabled" }
+    | { kind: "enabled"; signedIn: false }
+    | { kind: "enabled"; signedIn: true; email: string; projects: { id: string; name: string }[] };
+  error?: string | null;
+  // The dashboard root, for the "sign in there" escape hatch when SSO is the only door.
+  dashboardUrl: string;
+};
+
+export function esc(value: unknown): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+const SCOPE_LABELS: Record<string, string> = {
+  "mcp:read": "Read traces, sessions, signals, datasets, evaluations, prompts and insights",
+};
+
+const STYLE = `
+  :root { color-scheme: light; }
+  body { margin: 0; background: #f6f7f9; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; color: #111827; }
+  main { max-width: 440px; margin: 48px auto; background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; padding: 28px 32px; box-shadow: 0 1px 2px rgba(0,0,0,.04); }
+  h1 { font-size: 18px; margin: 0 0 6px; }
+  p { margin: 0 0 12px; line-height: 1.45; color: #374151; font-size: 14px; }
+  .muted { color: #6b7280; font-size: 13px; }
+  ul { padding-left: 18px; margin: 0 0 16px; font-size: 14px; color: #374151; }
+  label { display: block; font-size: 13px; font-weight: 600; margin: 14px 0 6px; }
+  input[type=text], input[type=password], input[type=email], select { width: 100%; box-sizing: border-box; padding: 9px 10px; border: 1px solid #d1d5db; border-radius: 8px; font-size: 14px; }
+  .actions { display: flex; gap: 10px; margin-top: 20px; }
+  button { flex: 1; padding: 10px 12px; border-radius: 8px; border: 1px solid #d1d5db; background: #fff; font-size: 14px; cursor: pointer; }
+  button.primary { background: #111827; color: #fff; border-color: #111827; }
+  .error { background: #fef2f2; border: 1px solid #fecaca; color: #991b1b; border-radius: 8px; padding: 10px 12px; font-size: 13px; margin-bottom: 12px; }
+  .radio { display: flex; align-items: center; gap: 8px; font-weight: 400; margin: 6px 0; }
+  code { font-size: 12px; background: #f3f4f6; padding: 1px 5px; border-radius: 4px; }
+`;
+
+function shell(title: string, body: string, nonce: string, script = ""): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}'; connect-src 'self'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'">
+<title>${esc(title)}</title>
+<style nonce="${nonce}">${STYLE}</style>
+</head>
+<body><main>${body}</main>${script ? `<script nonce="${nonce}">${script}</script>` : ""}</body>
+</html>`;
+}
+
+function hiddenInputs(fields: AuthorizeField[]): string {
+  return fields.map(f => `<input type="hidden" name="${esc(f.name)}" value="${esc(f.value)}">`).join("\n");
+}
+
+function scopeList(scopes: string[]): string {
+  return `<ul>${scopes.map(s => `<li>${esc(SCOPE_LABELS[s] ?? s)}</li>`).join("")}</ul>`;
+}
+
+export function renderAuthorizePage(input: AuthorizePageInput, nonce: string): string {
+  const client = input.clientUri
+    ? `<a href="${esc(input.clientUri)}" rel="noreferrer">${esc(input.clientName)}</a>`
+    : `<strong>${esc(input.clientName)}</strong>`;
+  const intro = `<h1>Connect ${esc(input.clientName)} to AgentX</h1>
+<p>${client} is asking to use this AgentX instance through its MCP connector. After you approve, the browser returns to <code>${esc(input.redirectHost)}</code>.</p>
+<p class="muted">It will be able to:</p>${scopeList(input.scopes)}`;
+  const error = input.error ? `<div class="error">${esc(input.error)}</div>` : "";
+
+  if (input.mode.kind === "disabled") {
+    const body = `${intro}${error}
+<form method="post" action="/authorize/decision">
+${hiddenInputs(input.hidden)}
+<label for="api_key">Project API key</label>
+<input id="api_key" name="api_key" type="password" autocomplete="off" required placeholder="agtx_local_...">
+<p class="muted">This instance runs without dashboard sign-in, so the project API key (printed when the engine starts, and shown in the dashboard's settings) is what authorizes the connection. The key itself is never sent to ${esc(input.clientName)}.</p>
+<div class="actions">
+  <button type="submit" name="action" value="deny">Cancel</button>
+  <button type="submit" name="action" value="approve" class="primary">Approve</button>
+</div>
+</form>`;
+    return shell("Connect to AgentX", body, nonce);
+  }
+
+  if (!input.mode.signedIn) {
+    const body = `${intro}${error}
+<p><strong>Sign in to continue.</strong></p>
+<form id="signin">
+<label for="email">Email</label>
+<input id="email" name="email" type="email" autocomplete="username" required>
+<label for="password">Password</label>
+<input id="password" name="password" type="password" autocomplete="current-password" required>
+<div id="signin-error" class="error" hidden></div>
+<div class="actions"><button type="submit" class="primary">Sign in</button></div>
+</form>
+<p class="muted" style="margin-top:16px">Using single sign-on? <a href="${esc(input.dashboardUrl)}" target="_blank" rel="noreferrer">Sign in to the dashboard</a> in another tab, then reload this page.</p>`;
+    // Same-origin call to the existing better-auth endpoint; the session cookie it sets is what
+    // the reload picks up. No token ever touches this page.
+    const script = `
+document.getElementById("signin").addEventListener("submit", async function (event) {
+  event.preventDefault();
+  var errorBox = document.getElementById("signin-error");
+  errorBox.hidden = true;
+  try {
+    var res = await fetch("/api/v1/auth/sign-in/email", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      credentials: "same-origin",
+      body: JSON.stringify({ email: document.getElementById("email").value, password: document.getElementById("password").value })
+    });
+    if (!res.ok) {
+      var text = await res.text();
+      var message = "Sign-in failed";
+      try { message = JSON.parse(text).message || message; } catch (e) {}
+      errorBox.textContent = message;
+      errorBox.hidden = false;
+      return;
+    }
+    window.location.reload();
+  } catch (e) {
+    errorBox.textContent = "Sign-in failed: " + (e && e.message ? e.message : e);
+    errorBox.hidden = false;
+  }
+});`;
+    return shell("Sign in to AgentX", body, nonce, script);
+  }
+
+  const projects = input.mode.projects;
+  const projectPicker =
+    projects.length === 0
+      ? `<div class="error">Your account has no projects to grant. Create one in the dashboard first.</div>`
+      : `<label>Project to connect</label>
+${projects
+  .map(
+    (p, i) =>
+      `<label class="radio"><input type="radio" name="project_id" value="${esc(p.id)}" ${i === 0 ? "checked" : ""} required> ${esc(p.name)}</label>`
+  )
+  .join("\n")}`;
+  const body = `${intro}${error}
+<form method="post" action="/authorize/decision">
+${hiddenInputs(input.hidden)}
+<p class="muted">Signed in as <strong>${esc(input.mode.email)}</strong>.</p>
+${projectPicker}
+<div class="actions">
+  <button type="submit" name="action" value="deny">Cancel</button>
+  <button type="submit" name="action" value="approve" class="primary" ${projects.length === 0 ? "disabled" : ""}>Approve</button>
+</div>
+</form>`;
+  return shell("Connect to AgentX", body, nonce);
+}
+
+export function renderMessagePage(title: string, message: string, nonce: string): string {
+  return shell(title, `<h1>${esc(title)}</h1><p>${esc(message)}</p>`, nonce);
+}

--- a/engine/src/core/mcp/config.ts
+++ b/engine/src/core/mcp/config.ts
@@ -1,0 +1,107 @@
+// Configuration for the engine's MCP surface (routes/mcp.ts): where the endpoint lives, who the
+// OAuth issuer is, which scopes exist, and which redirect URIs a dynamically registered client
+// may use. Env-driven and dependency-free so both the route layer and the OAuth provider can
+// read it without pulling in each other.
+
+export const MCP_PATH = "/mcp";
+
+// The one scope that exists today: every tool is read-only, so a second scope would be a placebo
+// checkbox on the consent page. Add "mcp:write" the day a tool mutates something.
+export const MCP_READ_SCOPE = "mcp:read";
+export const MCP_SCOPES_SUPPORTED = [MCP_READ_SCOPE];
+
+export function mcpEnabled(): boolean {
+  return process.env.AGENTX_MCP !== "disabled";
+}
+
+// The OAuth issuer is the instance's public origin. AGENTX_PUBLIC_URL pins it (the same variable
+// dashboard auth already uses for callbacks); without it the issuer is the loopback origin on
+// the listening port, which is exactly right for a client on the same machine (Claude Code) and
+// exactly wrong for anything else - claude.ai cannot reach it, and the spec requires HTTPS for
+// any non-loopback issuer, which mcpOauthAvailable() enforces below.
+//
+// Normalized to the origin: RFC 8414 puts the metadata document at a path derived from the
+// issuer, and the SDK serves it at /.well-known/oauth-authorization-server on the root, so a
+// path component on the issuer would point clients at a document that is not there.
+export function mcpIssuerUrl(port: number): URL {
+  const pinned = process.env.AGENTX_PUBLIC_URL?.trim();
+  const base = pinned ? new URL(pinned) : new URL(`http://localhost:${port}`);
+  return new URL(base.origin + "/");
+}
+
+// The canonical RFC 8707 resource identifier of this MCP server - what clients send as
+// `resource` and what tokens are audience-bound to.
+export function mcpResourceUrl(issuer: URL): URL {
+  return new URL(MCP_PATH, issuer);
+}
+
+// OAuth endpoints only mount on an issuer the spec allows: HTTPS, or plain HTTP on loopback.
+// A plain-HTTP public URL would be refused by the SDK's router anyway; this makes the reason
+// visible in the boot log instead of a stack trace.
+export function mcpOauthAvailable(issuer: URL): boolean {
+  if (issuer.protocol === "https:") return true;
+  return issuer.hostname === "localhost" || issuer.hostname === "127.0.0.1" || issuer.hostname === "[::1]";
+}
+
+// Audience check: a token (or an authorization request) names the resource it is for; it must
+// be this server. Trailing-slash and case differences in the origin are not different servers.
+export function resourceMatches(candidate: string | URL | null | undefined, canonical: URL): boolean {
+  if (candidate === null || candidate === undefined) return true;
+  let url: URL;
+  try {
+    url = typeof candidate === "string" ? new URL(candidate) : candidate;
+  } catch {
+    return false;
+  }
+  const norm = (u: URL) => `${u.origin.toLowerCase()}${u.pathname.replace(/\/+$/, "")}`;
+  return url.hash === "" && url.search === "" && norm(url) === norm(canonical);
+}
+
+// Redirect URIs a dynamically registered client may present. /register is unauthenticated by
+// spec, so an open redirect list would let anyone register a client that receives authorization
+// codes for this instance; the list below is what real MCP hosts use, and
+// AGENTX_MCP_REDIRECT_ALLOWLIST extends it (comma-separated; an entry ending in `*` matches by
+// prefix, anything else must match exactly).
+//
+// Loopback on any port is allowed by RFC 8252 for native clients (Claude Code picks an
+// ephemeral port); the SDK's authorize handler relaxes the port the same way when it later
+// compares the request against the registered URI.
+const DEFAULT_REDIRECT_ALLOWLIST = [
+  "https://claude.ai/api/mcp/auth_callback",
+  "https://claude.com/api/mcp/auth_callback",
+];
+
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+export function redirectUriAllowed(uri: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    return false;
+  }
+  if (url.hash) return false;
+  if ((url.protocol === "http:" || url.protocol === "https:") && LOOPBACK_HOSTS.has(url.hostname)) {
+    return true;
+  }
+  const extra = (process.env.AGENTX_MCP_REDIRECT_ALLOWLIST ?? "")
+    .split(",")
+    .map(entry => entry.trim())
+    .filter(Boolean);
+  for (const entry of [...DEFAULT_REDIRECT_ALLOWLIST, ...extra]) {
+    if (entry.endsWith("*")) {
+      if (uri.startsWith(entry.slice(0, -1))) return true;
+    } else if (entry === uri) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Token lifetimes. Access tokens are short so a leaked one is worth little; the refresh token
+// is what keeps a claude.ai connector working between conversations, rotated on every use.
+export const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000;
+export const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+export const AUTHORIZATION_CODE_TTL_MS = 10 * 60 * 1000;
+// How long an unsubmitted consent page stays valid.
+export const AUTHORIZE_REQUEST_TTL_MS = 15 * 60 * 1000;

--- a/engine/src/core/mcp/config.ts
+++ b/engine/src/core/mcp/config.ts
@@ -37,10 +37,12 @@ export function mcpResourceUrl(issuer: URL): URL {
 
 // OAuth endpoints only mount on an issuer the spec allows: HTTPS, or plain HTTP on loopback.
 // A plain-HTTP public URL would be refused by the SDK's router anyway; this makes the reason
-// visible in the boot log instead of a stack trace.
+// visible in the boot log instead of a stack trace. The loopback list mirrors the SDK's
+// checkIssuerUrl exactly (localhost and 127.0.0.1, not [::1]): anything accepted here and
+// refused there would crash the boot instead of degrading to key-only access.
 export function mcpOauthAvailable(issuer: URL): boolean {
   if (issuer.protocol === "https:") return true;
-  return issuer.hostname === "localhost" || issuer.hostname === "127.0.0.1" || issuer.hostname === "[::1]";
+  return issuer.hostname === "localhost" || issuer.hostname === "127.0.0.1";
 }
 
 // Audience check: a token (or an authorization request) names the resource it is for; it must
@@ -105,3 +107,9 @@ export const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 export const AUTHORIZATION_CODE_TTL_MS = 10 * 60 * 1000;
 // How long an unsubmitted consent page stays valid.
 export const AUTHORIZE_REQUEST_TTL_MS = 15 * 60 * 1000;
+// After a refresh token is rotated out, presenting it again inside this window is treated as a
+// retry (two tabs refreshing at once, a response lost to a timeout) and mints another pair under
+// the same grant; presenting it after the window is the reuse OAuth 2.1 says to punish by
+// revoking the whole grant. Env-tunable only so the integration suite can exercise the far side
+// of the window without waiting it out.
+export const REFRESH_ROTATION_GRACE_MS = Number(process.env.AGENTX_MCP_REFRESH_GRACE_MS || 60 * 1000);

--- a/engine/src/core/mcp/oauthProvider.ts
+++ b/engine/src/core/mcp/oauthProvider.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import type { Request, Response } from "express";
 import { nanoid } from "nanoid";
 import type { AuthorizationParams, OAuthServerProvider } from "@modelcontextprotocol/sdk/server/auth/provider.js";
@@ -28,12 +28,13 @@ import {
   AUTHORIZE_REQUEST_TTL_MS,
   MCP_READ_SCOPE,
   MCP_SCOPES_SUPPORTED,
+  REFRESH_ROTATION_GRACE_MS,
   REFRESH_TOKEN_TTL_MS,
   redirectUriAllowed,
   resourceMatches,
 } from "./config.js";
 import {
-  deleteCode,
+  claimCode,
   getClient,
   getCode,
   getToken,
@@ -97,12 +98,22 @@ function bundleSignature(bundle: Bundle, secret: string): string {
 }
 
 function normalizeScopes(requested: string[] | undefined): string[] {
+  // The SDK splits the raw `scope` parameter on spaces, so an empty or padded value arrives as
+  // empty strings rather than as "absent".
+  requested = requested?.filter(Boolean);
   if (!requested || requested.length === 0) return [MCP_READ_SCOPE];
   const unknown = requested.filter(scope => !MCP_SCOPES_SUPPORTED.includes(scope));
   if (unknown.length > 0) {
     throw new InvalidScopeError(`Unknown scope(s): ${unknown.join(", ")}. Supported: ${MCP_SCOPES_SUPPORTED.join(", ")}`);
   }
   return [...new Set(requested)];
+}
+
+// RFC 7636 S256: BASE64URL(SHA256(code_verifier)) must equal the challenge the code was bound to.
+function pkceVerifies(codeVerifier: string | undefined, codeChallenge: string): boolean {
+  if (!codeVerifier) return false;
+  const digest = createHash("sha256").update(codeVerifier).digest("base64url");
+  return digest.length === codeChallenge.length && timingSafeEqual(Buffer.from(digest), Buffer.from(codeChallenge));
 }
 
 function redirectWith(res: Response, redirectUri: string, params: Record<string, string | undefined>): void {
@@ -136,6 +147,10 @@ function pageHeaders(res: Response): string {
 
 export class EngineOAuthProvider implements OAuthServerProvider {
   readonly clientsStore: OAuthRegisteredClientsStore;
+  // PKCE is verified here, inside exchangeAuthorizationCode, AFTER the code has been claimed:
+  // the SDK's local check runs before the exchange and leaves a code live when the verifier is
+  // wrong, which would let an attacker who stole a code keep guessing verifiers for ten minutes.
+  readonly skipLocalPkceValidation = true;
 
   constructor(
     private readonly resource: URL,
@@ -222,6 +237,7 @@ export class EngineOAuthProvider implements OAuthServerProvider {
           clientUri: httpUrlOrNull(client.client_uri),
           scopes: bundle.scope.split(" ").filter(Boolean),
           redirectHost: new URL(bundle.redirect_uri).host,
+          redirectOrigin: new URL(bundle.redirect_uri).origin,
           hidden,
           mode,
           error,
@@ -314,6 +330,18 @@ export class EngineOAuthProvider implements OAuthServerProvider {
     redirectWith(res, bundle.redirect_uri, { code, state: bundle.state });
   }
 
+  // A grant approved by a dashboard user stays valid only while that user can still see the
+  // project: membership is re-read on every refresh and every access-token check (one indexed
+  // lookup, the same cost as the project-exists check next to it), so removing someone from the
+  // organization cuts their connector off at the next request rather than at the 30-day mark.
+  // Key-approved grants (disabled mode, userId null) have no user to lose.
+  private async grantStillAuthorized(row: TokenRow, project: { organizationId: string | null }): Promise<boolean> {
+    if (!row.userId) return true;
+    if (!row.organizationId || project.organizationId !== row.organizationId) return false;
+    if (authMode() !== "enabled") return true;
+    return (await getUserOrganizationIds(row.userId)).includes(row.organizationId);
+  }
+
   async challengeForAuthorizationCode(client: OAuthClientInformationFull, authorizationCode: string): Promise<string> {
     const row = await getCode(getDb(), hashSecret(authorizationCode));
     if (!row || row.clientId !== client.client_id) {
@@ -325,20 +353,22 @@ export class EngineOAuthProvider implements OAuthServerProvider {
   async exchangeAuthorizationCode(
     client: OAuthClientInformationFull,
     authorizationCode: string,
-    _codeVerifier?: string,
+    codeVerifier?: string,
     redirectUri?: string,
     resource?: URL
   ): Promise<OAuthTokens> {
     const db = getDb();
-    const codeHash = hashSecret(authorizationCode);
-    const row = await getCode(db, codeHash);
-    // Consumed on first sight, valid or not: a replayed code must fail even if this exchange does.
-    if (row) await deleteCode(db, codeHash);
+    // Claimed (deleted) on first sight, valid or not: a replayed or concurrently retried code
+    // must fail even if this exchange does, and a wrong verifier burns the code.
+    const row = await claimCode(db, hashSecret(authorizationCode));
     if (!row || row.clientId !== client.client_id) {
       throw new InvalidGrantError("Invalid authorization code");
     }
     if (row.expiresAt.getTime() < Date.now()) {
       throw new InvalidGrantError("Authorization code has expired");
+    }
+    if (!pkceVerifies(codeVerifier, row.codeChallenge)) {
+      throw new InvalidGrantError("code_verifier does not match the code_challenge");
     }
     if (redirectUri && !redirectUriMatches(redirectUri, row.redirectUri)) {
       throw new InvalidGrantError("redirect_uri does not match the authorization request");
@@ -348,7 +378,7 @@ export class EngineOAuthProvider implements OAuthServerProvider {
     }
     void pruneExpired(db).catch((err: unknown) => logger.warn({ err }, "MCP OAuth prune failed"));
     void touchClient(db, client.client_id).catch(() => undefined);
-    return this.mint({
+    const minted = await this.mint({
       grantId: nanoid(),
       clientId: client.client_id,
       projectId: row.projectId,
@@ -357,6 +387,7 @@ export class EngineOAuthProvider implements OAuthServerProvider {
       scopes: row.scopes,
       resource: row.resource ?? resource?.href ?? null,
     });
+    return minted.tokens;
   }
 
   async exchangeRefreshToken(
@@ -366,29 +397,51 @@ export class EngineOAuthProvider implements OAuthServerProvider {
     resource?: URL
   ): Promise<OAuthTokens> {
     const db = getDb();
-    const row = await getToken(db, hashSecret(refreshToken));
+    const presentedHash = hashSecret(refreshToken);
+    const row = await getToken(db, presentedHash);
     if (!row || row.kind !== "refresh" || row.clientId !== client.client_id || row.revokedAt || row.expiresAt.getTime() < Date.now()) {
       throw new InvalidGrantError("Invalid refresh token");
     }
-    if (scopes && scopes.some(scope => !row.scopes.includes(scope))) {
+    // Rotation (OAuth 2.1 for public clients). A token already rotated out is either a retry
+    // inside the grace window - two conversations refreshing at once, or a response the client
+    // never saw - which gets another pair under the same grant, or a reuse after it, which is
+    // the replay signature the spec says to answer by killing the whole grant.
+    const retry = row.rotatedAt !== null;
+    if (retry && Date.now() - row.rotatedAt!.getTime() > REFRESH_ROTATION_GRACE_MS) {
+      await revokeGrant(db, row.grantId);
+      logger.warn({ clientId: row.clientId, projectId: row.projectId, grantId: row.grantId }, "MCP OAuth refresh token reuse; grant revoked");
+      throw new InvalidGrantError("Refresh token was already used");
+    }
+    const project = await getProjectRow(db, row.projectId);
+    if (!project || !(await this.grantStillAuthorized(row, project))) {
+      await revokeGrant(db, row.grantId);
+      throw new InvalidGrantError("The grant is no longer authorized");
+    }
+    const requested = scopes?.filter(Boolean) ?? [];
+    if (requested.some(scope => !row.scopes.includes(scope))) {
       throw new InvalidScopeError("Requested scope exceeds the original grant");
     }
     if (resource && !resourceMatches(resource, this.resource)) {
       throw new InvalidTargetError(`This MCP server's resource identifier is ${this.resource.href}`);
     }
-    // Rotation (OAuth 2.1 for public clients): the presented refresh token and every access
-    // token under the grant are retired before the replacement pair is written.
-    await retireForRotation(db, row.grantId);
     void touchClient(db, client.client_id).catch(() => undefined);
-    return this.mint({
+    // The replacement pair is written first, then the old tokens retired, so a failure between
+    // the two leaves the client with a working grant rather than none. RFC 6749 section 6: a
+    // narrowed scope applies to the new access token only; the refresh chain keeps the grant's.
+    const minted = await this.mint({
       grantId: row.grantId,
       clientId: row.clientId,
       projectId: row.projectId,
       organizationId: row.organizationId,
       userId: row.userId,
-      scopes: scopes && scopes.length > 0 ? scopes : row.scopes,
+      scopes: row.scopes,
+      accessScopes: requested.length > 0 ? requested : row.scopes,
       resource: row.resource,
     });
+    if (!retry) {
+      await retireForRotation(db, row.grantId, presentedHash, minted.hashes);
+    }
+    return minted.tokens;
   }
 
   private async mint(grant: {
@@ -397,11 +450,14 @@ export class EngineOAuthProvider implements OAuthServerProvider {
     projectId: string;
     organizationId: string | null;
     userId: string | null;
+    // The grant's scopes, carried by the refresh token; the access token may carry a subset.
     scopes: string[];
+    accessScopes?: string[];
     resource: string | null;
-  }): Promise<OAuthTokens> {
+  }): Promise<{ tokens: OAuthTokens; hashes: string[] }> {
     const accessToken = newAccessToken();
     const refreshToken = newRefreshToken();
+    const accessScopes = grant.accessScopes ?? grant.scopes;
     const now = new Date();
     const base = {
       grantId: grant.grantId,
@@ -409,23 +465,26 @@ export class EngineOAuthProvider implements OAuthServerProvider {
       projectId: grant.projectId,
       organizationId: grant.organizationId,
       userId: grant.userId,
-      scopes: grant.scopes,
       resource: grant.resource,
       revokedAt: null,
+      rotatedAt: null,
       createdAt: now,
       lastUsedAt: null,
     };
     const rows: TokenRow[] = [
-      { ...base, tokenHash: hashSecret(accessToken), kind: "access", expiresAt: new Date(now.getTime() + ACCESS_TOKEN_TTL_MS) },
-      { ...base, tokenHash: hashSecret(refreshToken), kind: "refresh", expiresAt: new Date(now.getTime() + REFRESH_TOKEN_TTL_MS) },
+      { ...base, tokenHash: hashSecret(accessToken), kind: "access", scopes: accessScopes, expiresAt: new Date(now.getTime() + ACCESS_TOKEN_TTL_MS) },
+      { ...base, tokenHash: hashSecret(refreshToken), kind: "refresh", scopes: grant.scopes, expiresAt: new Date(now.getTime() + REFRESH_TOKEN_TTL_MS) },
     ];
     await insertTokens(getDb(), rows);
     return {
-      access_token: accessToken,
-      token_type: "bearer",
-      expires_in: Math.floor(ACCESS_TOKEN_TTL_MS / 1000),
-      refresh_token: refreshToken,
-      scope: grant.scopes.join(" "),
+      tokens: {
+        access_token: accessToken,
+        token_type: "bearer",
+        expires_in: Math.floor(ACCESS_TOKEN_TTL_MS / 1000),
+        refresh_token: refreshToken,
+        scope: accessScopes.join(" "),
+      },
+      hashes: rows.map(row => row.tokenHash),
     };
   }
 
@@ -444,8 +503,13 @@ export class EngineOAuthProvider implements OAuthServerProvider {
     if (!resourceMatches(row.resource, this.resource)) {
       throw new InvalidTokenError("Access token was not issued for this resource");
     }
-    if (!(await getProjectRow(db, row.projectId))) {
+    const project = await getProjectRow(db, row.projectId);
+    if (!project) {
       throw new InvalidTokenError("The project this token was issued for no longer exists");
+    }
+    if (!(await this.grantStillAuthorized(row, project))) {
+      await revokeGrant(db, row.grantId);
+      throw new InvalidTokenError("The user who approved this connection can no longer access the project");
     }
     void touchToken(db, row.tokenHash).catch(() => undefined);
     return {

--- a/engine/src/core/mcp/oauthProvider.ts
+++ b/engine/src/core/mcp/oauthProvider.ts
@@ -1,0 +1,461 @@
+import { createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import type { Request, Response } from "express";
+import { nanoid } from "nanoid";
+import type { AuthorizationParams, OAuthServerProvider } from "@modelcontextprotocol/sdk/server/auth/provider.js";
+import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type {
+  OAuthClientInformationFull,
+  OAuthTokenRevocationRequest,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import {
+  InvalidClientMetadataError,
+  InvalidGrantError,
+  InvalidScopeError,
+  InvalidTargetError,
+  InvalidTokenError,
+} from "@modelcontextprotocol/sdk/server/auth/errors.js";
+import { redirectUriMatches } from "@modelcontextprotocol/sdk/server/auth/handlers/authorize.js";
+import { getDb } from "../../storage/db.js";
+import { authMode } from "../../auth/mode.js";
+import { getSessionUser, getUserOrganizationIds, resolveAuthSecret } from "../../auth/betterAuth.js";
+import { getProjectRow, listProjectsWireForOrgs, resolveProjectByApiKey } from "../project/projects.js";
+import { logger } from "../../log.js";
+import {
+  ACCESS_TOKEN_TTL_MS,
+  AUTHORIZATION_CODE_TTL_MS,
+  AUTHORIZE_REQUEST_TTL_MS,
+  MCP_READ_SCOPE,
+  MCP_SCOPES_SUPPORTED,
+  REFRESH_TOKEN_TTL_MS,
+  redirectUriAllowed,
+  resourceMatches,
+} from "./config.js";
+import {
+  deleteCode,
+  getClient,
+  getCode,
+  getToken,
+  hashSecret,
+  insertClient,
+  insertCode,
+  insertTokens,
+  newAccessToken,
+  newAuthorizationCode,
+  newRefreshToken,
+  pruneExpired,
+  retireForRotation,
+  revokeGrant,
+  touchClient,
+  touchToken,
+  type TokenRow,
+} from "./oauthStore.js";
+import { renderAuthorizePage, renderMessagePage, type AuthorizeField } from "./authorizePage.js";
+
+// The engine as an OAuth 2.1 authorization server for its own /mcp endpoint. The SDK's
+// mcpAuthRouter owns the wire protocol (metadata documents, PKCE verification, dynamic client
+// registration parsing, token endpoint grammar); this class owns storage and the one thing the
+// protocol cannot know: who the resource owner is on THIS instance and which project they are
+// granting. That step follows the instance's auth mode -
+//
+//   AGENTX_AUTH=enabled   the dashboard session identifies the user; they pick a project of
+//                         their organization on the consent page.
+//   AGENTX_AUTH=disabled  there are no users. The consent page asks for the project API key,
+//                         which is the same credential the instance already hands to anything
+//                         that can reach its port - the flow adds a real browser-mediated grant
+//                         (claude.ai can only do OAuth) without inventing a second identity.
+//
+// A minted access token is therefore a short-lived, audience-bound stand-in for a project API
+// key, and requireMcpAuth (routes/mcp.ts) treats it as exactly that.
+
+type Bundle = {
+  client_id: string;
+  redirect_uri: string;
+  code_challenge: string;
+  state: string;
+  scope: string;
+  resource: string;
+  exp: string;
+};
+
+const BUNDLE_FIELDS: (keyof Bundle)[] = ["client_id", "redirect_uri", "code_challenge", "state", "scope", "resource", "exp"];
+
+// The consent form carries the authorization request back as hidden fields signed with the
+// instance secret (the same one better-auth sessions use, generated and persisted on first use
+// in both auth modes), so a multi-replica deployment needs no shared pending-request table and a
+// tampered form is rejected before any principal check runs.
+let secretCache: string | null = null;
+async function bundleSecret(): Promise<string> {
+  if (!secretCache) secretCache = await resolveAuthSecret(getDb());
+  return secretCache;
+}
+
+function bundleSignature(bundle: Bundle, secret: string): string {
+  const canonical = BUNDLE_FIELDS.map(field => bundle[field]).join("\n");
+  return createHmac("sha256", secret).update(canonical).digest("hex");
+}
+
+function normalizeScopes(requested: string[] | undefined): string[] {
+  if (!requested || requested.length === 0) return [MCP_READ_SCOPE];
+  const unknown = requested.filter(scope => !MCP_SCOPES_SUPPORTED.includes(scope));
+  if (unknown.length > 0) {
+    throw new InvalidScopeError(`Unknown scope(s): ${unknown.join(", ")}. Supported: ${MCP_SCOPES_SUPPORTED.join(", ")}`);
+  }
+  return [...new Set(requested)];
+}
+
+function redirectWith(res: Response, redirectUri: string, params: Record<string, string | undefined>): void {
+  const url = new URL(redirectUri);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== "") url.searchParams.set(key, value);
+  }
+  res.redirect(302, url.href);
+}
+
+function pageHeaders(res: Response): string {
+  const nonce = randomBytes(16).toString("base64");
+  res.set("Cache-Control", "no-store");
+  res.set("X-Frame-Options", "DENY");
+  res.set("Referrer-Policy", "no-referrer");
+  res.type("html");
+  return nonce;
+}
+
+export class EngineOAuthProvider implements OAuthServerProvider {
+  readonly clientsStore: OAuthRegisteredClientsStore;
+
+  constructor(
+    private readonly resource: URL,
+    private readonly dashboardUrl: string
+  ) {
+    this.clientsStore = {
+      getClient: clientId => getClient(getDb(), clientId),
+      registerClient: async client => {
+        if (client.redirect_uris.length === 0) {
+          throw new InvalidClientMetadataError("At least one redirect_uri is required");
+        }
+        for (const uri of client.redirect_uris) {
+          if (!redirectUriAllowed(uri)) {
+            throw new InvalidClientMetadataError(
+              `redirect_uri ${uri} is not allowed on this instance (set AGENTX_MCP_REDIRECT_ALLOWLIST to add it)`
+            );
+          }
+        }
+        // The SDK generates the id before calling this (clientIdGeneration defaults to true);
+        // the fallback only guards a future option change.
+        const withId = client as OAuthClientInformationFull;
+        const info: OAuthClientInformationFull = {
+          ...withId,
+          client_id: withId.client_id || randomUUID(),
+          client_id_issued_at: withId.client_id_issued_at ?? Math.floor(Date.now() / 1000),
+        };
+        await insertClient(getDb(), info);
+        logger.info({ clientId: info.client_id, clientName: info.client_name ?? null }, "MCP OAuth client registered");
+        return info;
+      },
+    };
+  }
+
+  // GET /authorize after the SDK validated client_id, redirect_uri, PKCE method and response_type.
+  async authorize(client: OAuthClientInformationFull, params: AuthorizationParams, res: Response): Promise<void> {
+    if (params.resource && !resourceMatches(params.resource, this.resource)) {
+      throw new InvalidTargetError(`This MCP server's resource identifier is ${this.resource.href}`);
+    }
+    const scopes = normalizeScopes(params.scopes);
+    const bundle: Bundle = {
+      client_id: client.client_id,
+      redirect_uri: params.redirectUri,
+      code_challenge: params.codeChallenge,
+      state: params.state ?? "",
+      scope: scopes.join(" "),
+      resource: params.resource?.href ?? "",
+      exp: String(Date.now() + AUTHORIZE_REQUEST_TTL_MS),
+    };
+    await this.renderConsent(res.req as Request, res, client, bundle, null, 200);
+  }
+
+  private async renderConsent(
+    req: Request,
+    res: Response,
+    client: OAuthClientInformationFull,
+    bundle: Bundle,
+    error: string | null,
+    status: number
+  ): Promise<void> {
+    const sig = bundleSignature(bundle, await bundleSecret());
+    const hidden: AuthorizeField[] = [...BUNDLE_FIELDS.map(name => ({ name, value: bundle[name] })), { name: "sig", value: sig }];
+    let mode: Parameters<typeof renderAuthorizePage>[0]["mode"];
+    if (authMode() === "enabled") {
+      const user = await getSessionUser(req);
+      if (!user) {
+        mode = { kind: "enabled", signedIn: false };
+      } else {
+        const projects = await listProjectsWireForOrgs(getDb(), await getUserOrganizationIds(user.id));
+        mode = {
+          kind: "enabled",
+          signedIn: true,
+          email: user.email,
+          projects: projects.map(p => ({ id: p._id, name: p.name })),
+        };
+      }
+    } else {
+      mode = { kind: "disabled" };
+    }
+    const nonce = pageHeaders(res);
+    res.status(status).send(
+      renderAuthorizePage(
+        {
+          clientName: client.client_name ?? client.client_id,
+          clientUri: client.client_uri ?? null,
+          scopes: bundle.scope.split(" ").filter(Boolean),
+          redirectHost: new URL(bundle.redirect_uri).host,
+          hidden,
+          mode,
+          error,
+          dashboardUrl: this.dashboardUrl,
+        },
+        nonce
+      )
+    );
+  }
+
+  // POST /authorize/decision - the consent form. Verifies the signed bundle, identifies the
+  // resource owner per auth mode, mints a single-use code, and redirects back to the client.
+  async decision(req: Request, res: Response): Promise<void> {
+    // A cross-site form post cannot be a consent click. Browsers that send the header make this
+    // exact; the session cookie's SameSite=Lax covers the ones that do not.
+    const site = req.header("sec-fetch-site");
+    if (site && site !== "same-origin" && site !== "none") {
+      res.status(403).send(renderMessagePage("Request refused", "The consent form must be submitted from this site.", pageHeaders(res)));
+      return;
+    }
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const field = (name: string) => (typeof body[name] === "string" ? (body[name] as string) : "");
+    const bundle = Object.fromEntries(BUNDLE_FIELDS.map(name => [name, field(name)])) as Bundle;
+    const expected = bundleSignature(bundle, await bundleSecret());
+    const provided = field("sig");
+    const signatureOk =
+      provided.length === expected.length && timingSafeEqual(Buffer.from(provided, "utf8"), Buffer.from(expected, "utf8"));
+    if (!signatureOk || !Number.isFinite(Number(bundle.exp)) || Number(bundle.exp) < Date.now()) {
+      res
+        .status(400)
+        .send(renderMessagePage("Authorization request expired", "Start the connection again from your MCP client.", pageHeaders(res)));
+      return;
+    }
+    const client = await getClient(getDb(), bundle.client_id);
+    if (!client || !client.redirect_uris.some(registered => redirectUriMatches(bundle.redirect_uri, registered))) {
+      res.status(400).send(renderMessagePage("Unknown client", "This client is not registered with this instance.", pageHeaders(res)));
+      return;
+    }
+    if (field("action") !== "approve") {
+      redirectWith(res, bundle.redirect_uri, { error: "access_denied", error_description: "The user declined", state: bundle.state });
+      return;
+    }
+
+    // Who is granting, and for which project.
+    let projectId: string;
+    let organizationId: string | null = null;
+    let userId: string | null = null;
+    if (authMode() === "enabled") {
+      const user = await getSessionUser(req);
+      if (!user) {
+        await this.renderConsent(req, res, client, bundle, "Sign in to approve this connection.", 401);
+        return;
+      }
+      const orgs = await getUserOrganizationIds(user.id);
+      const requested = field("project_id");
+      const project = requested ? await getProjectRow(getDb(), requested) : null;
+      if (!project || !project.organizationId || !orgs.includes(project.organizationId)) {
+        await this.renderConsent(req, res, client, bundle, "Pick a project you are a member of.", 403);
+        return;
+      }
+      projectId = project.id;
+      organizationId = project.organizationId;
+      userId = user.id;
+    } else {
+      const project = await resolveProjectByApiKey(getDb(), field("api_key"));
+      if (!project) {
+        await this.renderConsent(req, res, client, bundle, "That project API key was not recognized.", 401);
+        return;
+      }
+      projectId = project.id;
+      organizationId = project.organizationId ?? null;
+    }
+
+    const code = newAuthorizationCode();
+    const now = new Date();
+    await insertCode(getDb(), {
+      codeHash: hashSecret(code),
+      clientId: client.client_id,
+      projectId,
+      organizationId,
+      userId,
+      scopes: bundle.scope.split(" ").filter(Boolean),
+      codeChallenge: bundle.code_challenge,
+      redirectUri: bundle.redirect_uri,
+      resource: bundle.resource || null,
+      expiresAt: new Date(now.getTime() + AUTHORIZATION_CODE_TTL_MS),
+      createdAt: now,
+    });
+    logger.info({ clientId: client.client_id, projectId, userId }, "MCP OAuth grant approved");
+    redirectWith(res, bundle.redirect_uri, { code, state: bundle.state });
+  }
+
+  async challengeForAuthorizationCode(client: OAuthClientInformationFull, authorizationCode: string): Promise<string> {
+    const row = await getCode(getDb(), hashSecret(authorizationCode));
+    if (!row || row.clientId !== client.client_id) {
+      throw new InvalidGrantError("Invalid authorization code");
+    }
+    return row.codeChallenge;
+  }
+
+  async exchangeAuthorizationCode(
+    client: OAuthClientInformationFull,
+    authorizationCode: string,
+    _codeVerifier?: string,
+    redirectUri?: string,
+    resource?: URL
+  ): Promise<OAuthTokens> {
+    const db = getDb();
+    const codeHash = hashSecret(authorizationCode);
+    const row = await getCode(db, codeHash);
+    // Consumed on first sight, valid or not: a replayed code must fail even if this exchange does.
+    if (row) await deleteCode(db, codeHash);
+    if (!row || row.clientId !== client.client_id) {
+      throw new InvalidGrantError("Invalid authorization code");
+    }
+    if (row.expiresAt.getTime() < Date.now()) {
+      throw new InvalidGrantError("Authorization code has expired");
+    }
+    if (redirectUri && !redirectUriMatches(redirectUri, row.redirectUri)) {
+      throw new InvalidGrantError("redirect_uri does not match the authorization request");
+    }
+    if (resource && !resourceMatches(resource, this.resource)) {
+      throw new InvalidTargetError(`This MCP server's resource identifier is ${this.resource.href}`);
+    }
+    void pruneExpired(db).catch((err: unknown) => logger.warn({ err }, "MCP OAuth prune failed"));
+    void touchClient(db, client.client_id).catch(() => undefined);
+    return this.mint({
+      grantId: nanoid(),
+      clientId: client.client_id,
+      projectId: row.projectId,
+      organizationId: row.organizationId,
+      userId: row.userId,
+      scopes: row.scopes,
+      resource: row.resource ?? resource?.href ?? null,
+    });
+  }
+
+  async exchangeRefreshToken(
+    client: OAuthClientInformationFull,
+    refreshToken: string,
+    scopes?: string[],
+    resource?: URL
+  ): Promise<OAuthTokens> {
+    const db = getDb();
+    const row = await getToken(db, hashSecret(refreshToken));
+    if (!row || row.kind !== "refresh" || row.clientId !== client.client_id || row.revokedAt || row.expiresAt.getTime() < Date.now()) {
+      throw new InvalidGrantError("Invalid refresh token");
+    }
+    if (scopes && scopes.some(scope => !row.scopes.includes(scope))) {
+      throw new InvalidScopeError("Requested scope exceeds the original grant");
+    }
+    if (resource && !resourceMatches(resource, this.resource)) {
+      throw new InvalidTargetError(`This MCP server's resource identifier is ${this.resource.href}`);
+    }
+    // Rotation (OAuth 2.1 for public clients): the presented refresh token and every access
+    // token under the grant are retired before the replacement pair is written.
+    await retireForRotation(db, row.grantId);
+    void touchClient(db, client.client_id).catch(() => undefined);
+    return this.mint({
+      grantId: row.grantId,
+      clientId: row.clientId,
+      projectId: row.projectId,
+      organizationId: row.organizationId,
+      userId: row.userId,
+      scopes: scopes && scopes.length > 0 ? scopes : row.scopes,
+      resource: row.resource,
+    });
+  }
+
+  private async mint(grant: {
+    grantId: string;
+    clientId: string;
+    projectId: string;
+    organizationId: string | null;
+    userId: string | null;
+    scopes: string[];
+    resource: string | null;
+  }): Promise<OAuthTokens> {
+    const accessToken = newAccessToken();
+    const refreshToken = newRefreshToken();
+    const now = new Date();
+    const base = {
+      grantId: grant.grantId,
+      clientId: grant.clientId,
+      projectId: grant.projectId,
+      organizationId: grant.organizationId,
+      userId: grant.userId,
+      scopes: grant.scopes,
+      resource: grant.resource,
+      revokedAt: null,
+      createdAt: now,
+      lastUsedAt: null,
+    };
+    const rows: TokenRow[] = [
+      { ...base, tokenHash: hashSecret(accessToken), kind: "access", expiresAt: new Date(now.getTime() + ACCESS_TOKEN_TTL_MS) },
+      { ...base, tokenHash: hashSecret(refreshToken), kind: "refresh", expiresAt: new Date(now.getTime() + REFRESH_TOKEN_TTL_MS) },
+    ];
+    await insertTokens(getDb(), rows);
+    return {
+      access_token: accessToken,
+      token_type: "bearer",
+      expires_in: Math.floor(ACCESS_TOKEN_TTL_MS / 1000),
+      refresh_token: refreshToken,
+      scope: grant.scopes.join(" "),
+    };
+  }
+
+  // Resource-server side: every /mcp request with an OAuth bearer lands here (via the SDK's
+  // requireBearerAuth). Audience, expiry, revocation and the project's continued existence are
+  // all checked per request - there is no cached verdict to go stale.
+  async verifyAccessToken(token: string): Promise<AuthInfo> {
+    const db = getDb();
+    const row = await getToken(db, hashSecret(token));
+    if (!row || row.kind !== "access" || row.revokedAt) {
+      throw new InvalidTokenError("Invalid access token");
+    }
+    if (row.expiresAt.getTime() < Date.now()) {
+      throw new InvalidTokenError("Access token has expired");
+    }
+    if (!resourceMatches(row.resource, this.resource)) {
+      throw new InvalidTokenError("Access token was not issued for this resource");
+    }
+    if (!(await getProjectRow(db, row.projectId))) {
+      throw new InvalidTokenError("The project this token was issued for no longer exists");
+    }
+    void touchToken(db, row.tokenHash).catch(() => undefined);
+    return {
+      token,
+      clientId: row.clientId,
+      scopes: row.scopes,
+      expiresAt: Math.floor(row.expiresAt.getTime() / 1000),
+      resource: row.resource ? new URL(row.resource) : undefined,
+      extra: {
+        projectId: row.projectId,
+        organizationId: row.organizationId,
+        userId: row.userId,
+        grantId: row.grantId,
+      },
+    };
+  }
+
+  async revokeToken(client: OAuthClientInformationFull, request: OAuthTokenRevocationRequest): Promise<void> {
+    const row = await getToken(getDb(), hashSecret(request.token));
+    // Unknown or foreign tokens are a silent no-op per RFC 7009 - the response must not reveal
+    // whether the token ever existed.
+    if (!row || row.clientId !== client.client_id) return;
+    await revokeGrant(getDb(), row.grantId);
+  }
+}

--- a/engine/src/core/mcp/oauthProvider.ts
+++ b/engine/src/core/mcp/oauthProvider.ts
@@ -113,6 +113,18 @@ function redirectWith(res: Response, redirectUri: string, params: Record<string,
   res.redirect(302, url.href);
 }
 
+// Registered client metadata is attacker-supplied (anyone can call /register), and HTML escaping
+// does not neutralize a `javascript:` href - only an http(s) client_uri becomes a link.
+function httpUrlOrNull(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:" ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
 function pageHeaders(res: Response): string {
   const nonce = randomBytes(16).toString("base64");
   res.set("Cache-Control", "no-store");
@@ -207,7 +219,7 @@ export class EngineOAuthProvider implements OAuthServerProvider {
       renderAuthorizePage(
         {
           clientName: client.client_name ?? client.client_id,
-          clientUri: client.client_uri ?? null,
+          clientUri: httpUrlOrNull(client.client_uri),
           scopes: bundle.scope.split(" ").filter(Boolean),
           redirectHost: new URL(bundle.redirect_uri).host,
           hidden,

--- a/engine/src/core/mcp/oauthStore.ts
+++ b/engine/src/core/mcp/oauthStore.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
-import { and, eq, isNull, lt } from "drizzle-orm";
+import { and, eq, isNull, lt, notInArray } from "drizzle-orm";
 import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { Db } from "../../storage/db.js";
 
@@ -22,6 +22,7 @@ export type TokenRow = {
   resource: string | null;
   expiresAt: Date;
   revokedAt: Date | null;
+  rotatedAt: Date | null;
   createdAt: Date;
   lastUsedAt: Date | null;
 };
@@ -136,14 +137,16 @@ export async function getCode(db: Db, codeHash: string): Promise<CodeRow | undef
   return row ? normalizeCode(row as Record<string, unknown>) : undefined;
 }
 
-// Single use: the row is gone the moment it is exchanged, so a replayed code fails as unknown.
-export async function deleteCode(db: Db, codeHash: string): Promise<void> {
+// Single use, atomically: DELETE ... RETURNING hands the row to exactly one caller, so two
+// exchanges racing on the same code (a client retrying after a timeout) cannot both mint. The
+// row is gone whether or not the exchange then succeeds - a replayed code fails as unknown.
+export async function claimCode(db: Db, codeHash: string): Promise<CodeRow | undefined> {
   const cond = eq(db.schema.mcpOauthCodes.codeHash, codeHash);
-  if (db.kind === "sqlite") {
-    await db.db.delete(db.schema.mcpOauthCodes).where(cond);
-  } else {
-    await db.db.delete(db.schema.mcpOauthCodes).where(cond);
-  }
+  const deleted =
+    db.kind === "sqlite"
+      ? db.db.delete(db.schema.mcpOauthCodes).where(cond).returning().all()
+      : await db.db.delete(db.schema.mcpOauthCodes).where(cond).returning();
+  return deleted[0] ? normalizeCode(deleted[0] as Record<string, unknown>) : undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -191,10 +194,26 @@ export async function revokeGrant(db: Db, grantId: string): Promise<void> {
   }
 }
 
-// Refresh rotation: the used refresh token and the access tokens it covered die together; the
-// caller inserts the replacement pair under the same grant id.
-export async function retireForRotation(db: Db, grantId: string): Promise<void> {
-  await revokeGrant(db, grantId);
+// Refresh rotation, run AFTER the replacement pair is written so a failed insert leaves the old
+// tokens usable: every other live access token under the grant is revoked, and the presented
+// refresh token is marked rotated (not revoked) so a retry inside REFRESH_ROTATION_GRACE_MS can
+// be recognized as such by the provider.
+export async function retireForRotation(db: Db, grantId: string, presentedHash: string, keepHashes: string[]): Promise<void> {
+  const others = and(
+    eq(db.schema.mcpOauthTokens.grantId, grantId),
+    eq(db.schema.mcpOauthTokens.kind, "access"),
+    isNull(db.schema.mcpOauthTokens.revokedAt),
+    notInArray(db.schema.mcpOauthTokens.tokenHash, keepHashes)
+  );
+  const presented = and(eq(db.schema.mcpOauthTokens.tokenHash, presentedHash), isNull(db.schema.mcpOauthTokens.rotatedAt));
+  const now = new Date();
+  if (db.kind === "sqlite") {
+    await db.db.update(db.schema.mcpOauthTokens).set({ revokedAt: now }).where(others);
+    await db.db.update(db.schema.mcpOauthTokens).set({ rotatedAt: now }).where(presented);
+  } else {
+    await db.db.update(db.schema.mcpOauthTokens).set({ revokedAt: now }).where(others);
+    await db.db.update(db.schema.mcpOauthTokens).set({ rotatedAt: now }).where(presented);
+  }
 }
 
 // Every live grant on a project - the "connected apps" list, and the cascade when the project's
@@ -222,7 +241,8 @@ export async function listGrants(db: Db, projectId: string): Promise<GrantSummar
   const cond = and(
     eq(db.schema.mcpOauthTokens.projectId, projectId),
     eq(db.schema.mcpOauthTokens.kind, "refresh"),
-    isNull(db.schema.mcpOauthTokens.revokedAt)
+    isNull(db.schema.mcpOauthTokens.revokedAt),
+    isNull(db.schema.mcpOauthTokens.rotatedAt)
   );
   const rows = (
     db.kind === "sqlite"
@@ -295,6 +315,7 @@ function normalizeToken(row: Record<string, unknown>): TokenRow {
     resource: (row.resource as string | null) ?? null,
     expiresAt: row.expiresAt as Date,
     revokedAt: (row.revokedAt as Date | null) ?? null,
+    rotatedAt: (row.rotatedAt as Date | null) ?? null,
     createdAt: row.createdAt as Date,
     lastUsedAt: (row.lastUsedAt as Date | null) ?? null,
   };

--- a/engine/src/core/mcp/oauthStore.ts
+++ b/engine/src/core/mcp/oauthStore.ts
@@ -1,0 +1,317 @@
+import { createHash, randomBytes } from "node:crypto";
+import { and, eq, isNull, lt } from "drizzle-orm";
+import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { Db } from "../../storage/db.js";
+
+// Persistence for the MCP OAuth provider (oauthProvider.ts): registered clients, pending
+// authorization codes, and issued tokens. Every function takes the UNSCOPED Db - these rows are
+// instance-wide (a client registers once, a grant names its project explicitly), the same
+// posture as core/project/projects.ts. Per-dialect select branches per CONTRIBUTING.md.
+
+export type TokenKind = "access" | "refresh";
+
+export type TokenRow = {
+  tokenHash: string;
+  kind: TokenKind;
+  grantId: string;
+  clientId: string;
+  projectId: string;
+  organizationId: string | null;
+  userId: string | null;
+  scopes: string[];
+  resource: string | null;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  createdAt: Date;
+  lastUsedAt: Date | null;
+};
+
+export type CodeRow = {
+  codeHash: string;
+  clientId: string;
+  projectId: string;
+  organizationId: string | null;
+  userId: string | null;
+  scopes: string[];
+  codeChallenge: string;
+  redirectUri: string;
+  resource: string | null;
+  expiresAt: Date;
+  createdAt: Date;
+};
+
+type ClientRow = {
+  id: string;
+  clientSecret: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: Date;
+  lastUsedAt: Date | null;
+};
+
+// Tokens and codes are looked up by the hash of the secret the client holds, never by the
+// secret itself: a read of this table yields nothing presentable to /mcp.
+export function hashSecret(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+// Prefixed so requireMcpAuth can tell an OAuth access token from a project API key without a
+// database round trip, and so a token pasted into the wrong place is recognizable in a log.
+export function newAccessToken(): string {
+  return `agtx_mcp_at_${randomBytes(32).toString("hex")}`;
+}
+
+export function newRefreshToken(): string {
+  return `agtx_mcp_rt_${randomBytes(32).toString("hex")}`;
+}
+
+export function newAuthorizationCode(): string {
+  return randomBytes(32).toString("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Clients
+// ---------------------------------------------------------------------------
+
+function clientToInfo(row: ClientRow): OAuthClientInformationFull {
+  return {
+    ...(row.metadata as Omit<OAuthClientInformationFull, "client_id" | "client_secret">),
+    client_id: row.id,
+    ...(row.clientSecret ? { client_secret: row.clientSecret } : {}),
+  } as OAuthClientInformationFull;
+}
+
+export async function insertClient(db: Db, info: OAuthClientInformationFull): Promise<void> {
+  const { client_id, client_secret, ...metadata } = info;
+  const row: ClientRow = {
+    id: client_id,
+    clientSecret: client_secret ?? null,
+    metadata: metadata as Record<string, unknown>,
+    createdAt: new Date(),
+    lastUsedAt: null,
+  };
+  if (db.kind === "sqlite") {
+    await db.db.insert(db.schema.mcpOauthClients).values(row);
+  } else {
+    await db.db.insert(db.schema.mcpOauthClients).values(row);
+  }
+}
+
+export async function getClient(db: Db, clientId: string): Promise<OAuthClientInformationFull | undefined> {
+  const cond = eq(db.schema.mcpOauthClients.id, clientId);
+  const row =
+    db.kind === "sqlite"
+      ? (db.db.select().from(db.schema.mcpOauthClients).where(cond).all()[0] as ClientRow | undefined)
+      : ((await db.db.select().from(db.schema.mcpOauthClients).where(cond))[0] as ClientRow | undefined);
+  return row ? clientToInfo(row) : undefined;
+}
+
+export async function touchClient(db: Db, clientId: string): Promise<void> {
+  const cond = eq(db.schema.mcpOauthClients.id, clientId);
+  const values = { lastUsedAt: new Date() };
+  if (db.kind === "sqlite") {
+    await db.db.update(db.schema.mcpOauthClients).set(values).where(cond);
+  } else {
+    await db.db.update(db.schema.mcpOauthClients).set(values).where(cond);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Authorization codes
+// ---------------------------------------------------------------------------
+
+export async function insertCode(db: Db, row: CodeRow): Promise<void> {
+  if (db.kind === "sqlite") {
+    await db.db.insert(db.schema.mcpOauthCodes).values(row);
+  } else {
+    await db.db.insert(db.schema.mcpOauthCodes).values(row);
+  }
+}
+
+export async function getCode(db: Db, codeHash: string): Promise<CodeRow | undefined> {
+  const cond = eq(db.schema.mcpOauthCodes.codeHash, codeHash);
+  const row =
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.mcpOauthCodes).where(cond).all()[0]
+      : (await db.db.select().from(db.schema.mcpOauthCodes).where(cond))[0];
+  return row ? normalizeCode(row as Record<string, unknown>) : undefined;
+}
+
+// Single use: the row is gone the moment it is exchanged, so a replayed code fails as unknown.
+export async function deleteCode(db: Db, codeHash: string): Promise<void> {
+  const cond = eq(db.schema.mcpOauthCodes.codeHash, codeHash);
+  if (db.kind === "sqlite") {
+    await db.db.delete(db.schema.mcpOauthCodes).where(cond);
+  } else {
+    await db.db.delete(db.schema.mcpOauthCodes).where(cond);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tokens
+// ---------------------------------------------------------------------------
+
+export async function insertTokens(db: Db, rows: TokenRow[]): Promise<void> {
+  if (rows.length === 0) return;
+  if (db.kind === "sqlite") {
+    await db.db.insert(db.schema.mcpOauthTokens).values(rows);
+  } else {
+    await db.db.insert(db.schema.mcpOauthTokens).values(rows);
+  }
+}
+
+export async function getToken(db: Db, tokenHash: string): Promise<TokenRow | undefined> {
+  const cond = eq(db.schema.mcpOauthTokens.tokenHash, tokenHash);
+  const row =
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.mcpOauthTokens).where(cond).all()[0]
+      : (await db.db.select().from(db.schema.mcpOauthTokens).where(cond))[0];
+  return row ? normalizeToken(row as Record<string, unknown>) : undefined;
+}
+
+export async function touchToken(db: Db, tokenHash: string): Promise<void> {
+  const cond = eq(db.schema.mcpOauthTokens.tokenHash, tokenHash);
+  const values = { lastUsedAt: new Date() };
+  if (db.kind === "sqlite") {
+    await db.db.update(db.schema.mcpOauthTokens).set(values).where(cond);
+  } else {
+    await db.db.update(db.schema.mcpOauthTokens).set(values).where(cond);
+  }
+}
+
+// Revoking any token of a grant revokes the whole grant: the refresh chain and every access
+// token minted from it. That is what a user means by "disconnect", and it is what OAuth 2.1
+// requires when a refresh token is revoked.
+export async function revokeGrant(db: Db, grantId: string): Promise<void> {
+  const cond = and(eq(db.schema.mcpOauthTokens.grantId, grantId), isNull(db.schema.mcpOauthTokens.revokedAt));
+  const values = { revokedAt: new Date() };
+  if (db.kind === "sqlite") {
+    await db.db.update(db.schema.mcpOauthTokens).set(values).where(cond);
+  } else {
+    await db.db.update(db.schema.mcpOauthTokens).set(values).where(cond);
+  }
+}
+
+// Refresh rotation: the used refresh token and the access tokens it covered die together; the
+// caller inserts the replacement pair under the same grant id.
+export async function retireForRotation(db: Db, grantId: string): Promise<void> {
+  await revokeGrant(db, grantId);
+}
+
+// Every live grant on a project - the "connected apps" list, and the cascade when the project's
+// API key is regenerated (an MCP token is a stand-in for that key, so it dies with it).
+export async function revokeProjectGrants(db: Db, projectId: string): Promise<number> {
+  const grants = await listGrants(db, projectId);
+  for (const grant of grants) {
+    await revokeGrant(db, grant.grantId);
+  }
+  return grants.length;
+}
+
+export type GrantSummary = {
+  grantId: string;
+  clientId: string;
+  clientName: string | null;
+  userId: string | null;
+  scopes: string[];
+  createdAt: Date;
+  lastUsedAt: Date | null;
+  expiresAt: Date;
+};
+
+export async function listGrants(db: Db, projectId: string): Promise<GrantSummary[]> {
+  const cond = and(
+    eq(db.schema.mcpOauthTokens.projectId, projectId),
+    eq(db.schema.mcpOauthTokens.kind, "refresh"),
+    isNull(db.schema.mcpOauthTokens.revokedAt)
+  );
+  const rows = (
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.mcpOauthTokens).where(cond).all()
+      : await db.db.select().from(db.schema.mcpOauthTokens).where(cond)
+  ).map(row => normalizeToken(row as Record<string, unknown>));
+  const now = Date.now();
+  const live = rows.filter(row => row.expiresAt.getTime() > now);
+  const byGrant = new Map<string, TokenRow>();
+  for (const row of live) {
+    const existing = byGrant.get(row.grantId);
+    if (!existing || existing.createdAt < row.createdAt) byGrant.set(row.grantId, row);
+  }
+  const clientNames = new Map<string, string | null>();
+  const result: GrantSummary[] = [];
+  for (const row of byGrant.values()) {
+    if (!clientNames.has(row.clientId)) {
+      const client = await getClient(db, row.clientId);
+      clientNames.set(row.clientId, client?.client_name ?? null);
+    }
+    result.push({
+      grantId: row.grantId,
+      clientId: row.clientId,
+      clientName: clientNames.get(row.clientId) ?? null,
+      userId: row.userId,
+      scopes: row.scopes,
+      createdAt: row.createdAt,
+      lastUsedAt: row.lastUsedAt,
+      expiresAt: row.expiresAt,
+    });
+  }
+  result.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  return result;
+}
+
+// Housekeeping run opportunistically from the token endpoint: expired codes go immediately,
+// tokens a week past expiry go too (kept a little so a "connected app" that just expired still
+// shows why it stopped working). Never fails the request that triggered it.
+export async function pruneExpired(db: Db): Promise<void> {
+  const now = new Date();
+  const tokenCutoff = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  if (db.kind === "sqlite") {
+    await db.db.delete(db.schema.mcpOauthCodes).where(lt(db.schema.mcpOauthCodes.expiresAt, now));
+    await db.db.delete(db.schema.mcpOauthTokens).where(lt(db.schema.mcpOauthTokens.expiresAt, tokenCutoff));
+  } else {
+    await db.db.delete(db.schema.mcpOauthCodes).where(lt(db.schema.mcpOauthCodes.expiresAt, now));
+    await db.db.delete(db.schema.mcpOauthTokens).where(lt(db.schema.mcpOauthTokens.expiresAt, tokenCutoff));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Row normalization - both dialects hand back parsed JSON for the json columns, but the shape of
+// a json column is `unknown` to drizzle; this is the one place that trusts it.
+// ---------------------------------------------------------------------------
+
+function scopesOf(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((s): s is string => typeof s === "string") : [];
+}
+
+function normalizeToken(row: Record<string, unknown>): TokenRow {
+  return {
+    tokenHash: row.tokenHash as string,
+    kind: row.kind as TokenKind,
+    grantId: row.grantId as string,
+    clientId: row.clientId as string,
+    projectId: row.projectId as string,
+    organizationId: (row.organizationId as string | null) ?? null,
+    userId: (row.userId as string | null) ?? null,
+    scopes: scopesOf(row.scopes),
+    resource: (row.resource as string | null) ?? null,
+    expiresAt: row.expiresAt as Date,
+    revokedAt: (row.revokedAt as Date | null) ?? null,
+    createdAt: row.createdAt as Date,
+    lastUsedAt: (row.lastUsedAt as Date | null) ?? null,
+  };
+}
+
+function normalizeCode(row: Record<string, unknown>): CodeRow {
+  return {
+    codeHash: row.codeHash as string,
+    clientId: row.clientId as string,
+    projectId: row.projectId as string,
+    organizationId: (row.organizationId as string | null) ?? null,
+    userId: (row.userId as string | null) ?? null,
+    scopes: scopesOf(row.scopes),
+    codeChallenge: row.codeChallenge as string,
+    redirectUri: row.redirectUri as string,
+    resource: (row.resource as string | null) ?? null,
+    expiresAt: row.expiresAt as Date,
+    createdAt: row.createdAt as Date,
+  };
+}

--- a/engine/src/core/mcp/server.ts
+++ b/engine/src/core/mcp/server.ts
@@ -1,0 +1,23 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { engineVersion } from "../../version.js";
+import { registerTools, type McpContext } from "./tools.js";
+
+// One McpServer per request: the Streamable HTTP transport runs stateless (no session ids, so
+// any replica can answer any request), and the SDK requires a fresh server+transport pair per
+// request in that mode to keep JSON-RPC ids from colliding. Registering ~20 tools is
+// microseconds; the alternative (a shared server with per-request tenancy smuggled through
+// AsyncLocalStorage) is exactly the kind of cross-tenant footgun this engine avoids elsewhere.
+export function createMcpServer(ctx: McpContext): McpServer {
+  const server = new McpServer(
+    { name: "agentx-self-host", version: engineVersion() },
+    {
+      instructions:
+        "AgentX Trace & Eval, self-hosted. Read-only access to one project's traces, sessions, monitoring " +
+        "signals and KPIs, evaluation datasets and runs, the Prompt and Tool Schema registries, and dataset " +
+        "coverage insights. Start with agentx_whoami to see which project this connection is scoped to. List " +
+        "tools clip long payloads; the matching get tool returns the full record.",
+    }
+  );
+  registerTools(server, ctx);
+  return server;
+}

--- a/engine/src/core/mcp/tools.ts
+++ b/engine/src/core/mcp/tools.ts
@@ -1,0 +1,294 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { Db } from "../../storage/db.js";
+import { getDb } from "../../storage/db.js";
+import { engineVersion } from "../../version.js";
+import { authMode } from "../../auth/mode.js";
+import { logger } from "../../log.js";
+import { recordAuditEvent } from "../audit/auditLog.js";
+import { getProjectRow } from "../project/projects.js";
+import { getTraceRow, listSessionSpans, listTracesPaginated, toTraceDetailWireWithCost } from "../trace/ingest.js";
+import { listSessions } from "../monitor/sessions.js";
+import { listSessionScores } from "../monitor/sessionScores.js";
+import { getKpis, type MonitoringWindow } from "../monitor/events.js";
+import { getSignal, listSignals } from "../monitor/signals.js";
+import { listAgentsWire, resolveExistingAgentId } from "../monitor/agents.js";
+import { getTopIntents } from "../monitor/topics.js";
+import { getDataset, listDatasets } from "../evaluate/datasets.js";
+import { getRun, listRuns } from "../evaluate/runs.js";
+import { getPromptWithVersionsWire, listPromptsWire } from "../evaluate/prompts.js";
+import { listToolSchemasWire } from "../evaluate/toolSchemas.js";
+import { getCoverage } from "../insights/coverage.js";
+import { probe } from "../insights/probe.js";
+
+// The tool surface of the self-host MCP server. Names and argument shapes mirror the hosted
+// AgentX MCP wherever the same concept exists, so a prompt or skill written against one works
+// against the other. Every tool is read-only and calls the same core function the matching
+// dashboard route calls, with the same project-scoped Db - the MCP is another client of the
+// engine, never a side door.
+//
+// Results are returned as JSON text: Claude reads it fine, and structured output would demand a
+// second, duplicated schema per tool that nothing else consumes yet.
+
+export type McpPrincipal =
+  | { kind: "project-key" }
+  | { kind: "oauth"; clientId: string; userId: string | null; grantId: string };
+
+export type McpContext = {
+  db: Db;
+  projectId: string;
+  organizationId: string | null;
+  principal: McpPrincipal;
+  ip: string | null;
+};
+
+// Long payloads (a full agent transcript) blow past what a tool result should carry; list views
+// clip them and say so, detail views return everything.
+const CLIP = 600;
+function clip(value: unknown): unknown {
+  if (typeof value === "string" && value.length > CLIP) {
+    return `${value.slice(0, CLIP)}... [${value.length - CLIP} more chars, use the detail tool]`;
+  }
+  return value;
+}
+
+function compactTrace<T extends { input?: unknown; output?: unknown; metadata?: unknown }>(trace: T): T {
+  return { ...trace, input: clip(trace.input), output: clip(trace.output), metadata: undefined };
+}
+
+const window = z.enum(["24h", "7d", "30d"]).optional().describe("Time window (default 7d)");
+const limit = (max: number, fallback: number) =>
+  z.number().int().min(1).max(max).optional().describe(`Max rows (default ${fallback}, max ${max})`);
+
+function text(value: unknown): CallToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] };
+}
+
+function notFound(what: string, id: string): CallToolResult {
+  return { isError: true, content: [{ type: "text", text: `${what} ${id} was not found in this project` }] };
+}
+
+function actorOf(ctx: McpContext): { actor: string; actorType: "project-key" | "mcp-token" } {
+  return ctx.principal.kind === "project-key"
+    ? { actor: `project:${ctx.projectId}`, actorType: "project-key" }
+    : { actor: ctx.principal.userId ? `user:${ctx.principal.userId}` : `project:${ctx.projectId}`, actorType: "mcp-token" };
+}
+
+export function registerTools(server: McpServer, ctx: McpContext): void {
+  const { db } = ctx;
+
+  // One registration helper so every tool gets the same three things: read-only annotation,
+  // an error envelope instead of a protocol-level failure, and an audit row naming the tool,
+  // the project and the principal (routes/auditTap.ts cannot see inside a JSON-RPC body).
+  function tool<S extends z.ZodRawShape>(
+    name: string,
+    description: string,
+    shape: S,
+    handler: (args: z.infer<z.ZodObject<S>>) => Promise<CallToolResult>
+  ): void {
+    server.registerTool(
+      name,
+      { description, inputSchema: shape as unknown as ZodRawShapeCompat, annotations: { readOnlyHint: true, openWorldHint: false } },
+      (async (args: unknown) => {
+        let result: CallToolResult;
+        try {
+          result = await handler(args as z.infer<z.ZodObject<S>>);
+        } catch (err) {
+          logger.error({ err, tool: name, projectId: ctx.projectId }, "MCP tool failed");
+          result = { isError: true, content: [{ type: "text", text: err instanceof Error ? err.message : String(err) }] };
+        }
+        const { actor, actorType } = actorOf(ctx);
+        void recordAuditEvent(getDb(), {
+          actor,
+          actorType,
+          action: "mcp.tool_call",
+          method: "POST",
+          path: "/mcp",
+          status: result.isError ? 500 : 200,
+          entityType: "mcp_tool",
+          entityId: name,
+          summary: { tool: name, ...(ctx.principal.kind === "oauth" ? { clientId: ctx.principal.clientId } : {}) },
+          ip: ctx.ip,
+          projectId: ctx.projectId,
+        }).catch((err: unknown) => logger.error({ err }, "MCP audit write failed (call unaffected)"));
+        return result;
+      }) as Parameters<McpServer["registerTool"]>[2]
+    );
+  }
+
+  // ---- identity -------------------------------------------------------------------------
+
+  tool("agentx_whoami", "Which AgentX project this connection is scoped to, how it authenticated, and the engine version.", {}, async () => {
+    const project = await getProjectRow(db, ctx.projectId);
+    return text({
+      project: project ? { id: project.id, name: project.name } : null,
+      organizationId: ctx.organizationId,
+      authMode: authMode(),
+      authenticatedWith: ctx.principal.kind === "project-key" ? "project API key" : "OAuth access token",
+      engineVersion: engineVersion(),
+    });
+  });
+
+  // ---- trace ----------------------------------------------------------------------------
+
+  tool(
+    "agentx_list_traces",
+    "List recent traces (agent runs) in this project, newest first. Inputs/outputs are clipped; use agentx_get_trace for the full record.",
+    {
+      limit: limit(100, 20),
+      cursor: z.string().optional().describe("nextCursor from a previous page"),
+      search: z.string().optional().describe("Substring match on name, input or output"),
+      framework: z.string().optional().describe("Filter by framework label, e.g. langchain"),
+      source: z.enum(["production", "eval", "all"]).optional().describe("Traffic source (default all)"),
+    },
+    async args => {
+      const page = await listTracesPaginated(db, { ...args, limit: args.limit ?? 20 });
+      return text({ ...page, traces: page.traces.map(compactTrace) });
+    }
+  );
+
+  tool("agentx_get_trace", "Full detail of one trace: input, output, tool calls, tokens, latency, estimated cost.", { traceId: z.string() }, async ({ traceId }) => {
+    const row = await getTraceRow(db, traceId);
+    if (!row) return notFound("Trace", traceId);
+    return text(await toTraceDetailWireWithCost(db, row));
+  });
+
+  tool(
+    "agentx_list_sessions",
+    "Multi-turn sessions (traces sharing a session id) with turn counts and judge scores.",
+    { window },
+    async ({ window: w }) => text(await listSessions(db, (w ?? "7d") as MonitoringWindow))
+  );
+
+  tool(
+    "agentx_get_session",
+    "Every span of one session in order (clipped) plus the session-level judge verdicts.",
+    { sessionId: z.string() },
+    async ({ sessionId }) => {
+      const spans = await listSessionSpans(db, sessionId);
+      if (spans.length === 0) return notFound("Session", sessionId);
+      return text({ sessionId, spans: spans.map(compactTrace), scores: await listSessionScores(db, sessionId) });
+    }
+  );
+
+  // ---- monitor --------------------------------------------------------------------------
+
+  tool(
+    "agentx_get_kpis",
+    "Monitoring KPIs for the window: run volume, health/failure/downvote/tool-failure rates, p95 latency, deltas vs the previous window.",
+    { window },
+    async ({ window: w }) => text(await getKpis(db, (w ?? "7d") as MonitoringWindow))
+  );
+
+  tool(
+    "agentx_list_signals",
+    "Monitor signals (detected failure patterns, judge findings) with occurrence counts. Defaults to open failures.",
+    {
+      severity: z.enum(["low", "medium", "high", "critical"]).optional(),
+      status: z.string().optional().describe("e.g. open, acknowledged, resolved"),
+      agentId: z.string().optional().describe("Agent id or name"),
+      polarity: z.enum(["failure", "success", "all"]).optional(),
+      limit: limit(100, 20),
+    },
+    async args => {
+      const signals = await listSignals(
+        db,
+        {
+          severity: args.severity,
+          status: args.status,
+          agentId: args.agentId ? await resolveExistingAgentId(db, args.agentId) : undefined,
+          polarity: args.polarity,
+        },
+        args.limit ?? 20
+      );
+      return text({ signals });
+    }
+  );
+
+  tool("agentx_get_signal", "One signal with its occurrences and the evidence behind them.", { signalId: z.string() }, async ({ signalId }) => {
+    const signal = await getSignal(db, signalId);
+    return signal ? text(signal) : notFound("Signal", signalId);
+  });
+
+  tool("agentx_list_agents", "Agents that have reported traces into this project, with per-agent monitoring profile summary.", {}, async () =>
+    text({ agents: await listAgentsWire(db) })
+  );
+
+  tool(
+    "agentx_list_topics",
+    "What users actually ask about: top classified intents in the window (Topics must be enabled on the project).",
+    { window, limit: limit(50, 10) },
+    async ({ window: w, limit: n }) => text({ topics: await getTopIntents(db, (w ?? "7d") as MonitoringWindow, n ?? 10) })
+  );
+
+  // ---- evaluate -------------------------------------------------------------------------
+
+  tool("agentx_list_datasets", "Evaluation datasets in this project (case counts, scorer config; cases omitted).", {}, async () => {
+    const datasets = await listDatasets(db);
+    return text({
+      datasets: datasets.map(({ questions, ...rest }) => ({
+        ...rest,
+        caseCount: Array.isArray(questions) ? questions.length : 0,
+      })),
+    });
+  });
+
+  tool("agentx_get_dataset", "One dataset including every case (question, expected result, metadata).", { datasetId: z.string() }, async ({ datasetId }) => {
+    const dataset = await getDataset(db, datasetId);
+    return dataset ? text(dataset) : notFound("Dataset", datasetId);
+  });
+
+  tool(
+    "agentx_list_evaluations",
+    "Evaluation runs, newest first, with average ratings and per-scorer breakdown (results omitted).",
+    { limit: limit(100, 20) },
+    async ({ limit: n }) => {
+      const runs = await listRuns(db, n ?? 20);
+      return text({ evaluations: runs.map(run => ({ ...run, results: undefined })) });
+    }
+  );
+
+  tool(
+    "agentx_get_evaluation",
+    "One evaluation run: summary, scorer breakdown and (by default) every scored result.",
+    { evaluationId: z.string(), includeResults: z.boolean().optional().describe("Default true") },
+    async ({ evaluationId, includeResults }) => {
+      const run = await getRun(db, evaluationId);
+      if (!run) return notFound("Evaluation", evaluationId);
+      return text(includeResults === false ? { ...run, results: undefined } : run);
+    }
+  );
+
+  tool("agentx_list_prompts", "Prompt Registry entries (name, current version, timestamps).", {}, async () => text({ prompts: await listPromptsWire(db) }));
+
+  tool("agentx_get_prompt", "One prompt with every version's text, source and reasoning.", { promptId: z.string() }, async ({ promptId }) => {
+    const prompt = await getPromptWithVersionsWire(db, promptId);
+    return prompt ? text(prompt) : notFound("Prompt", promptId);
+  });
+
+  tool("agentx_list_tool_schemas", "Tool Schema registry entries with current version and quality signal counts.", {}, async () =>
+    text({ toolSchemas: await listToolSchemasWire(db) })
+  );
+
+  // ---- insights -------------------------------------------------------------------------
+
+  tool(
+    "agentx_get_coverage",
+    "How well the datasets cover production topics: traffic-weighted, breadth and risk-weighted coverage with per-topic state.",
+    { window, datasetIds: z.array(z.string()).optional().describe("Restrict to these datasets (default all)") },
+    async ({ window: w, datasetIds }) => text(await getCoverage(db, { window: (w ?? "30d") as MonitoringWindow, datasetIds }))
+  );
+
+  tool(
+    "agentx_probe_coverage",
+    "Ask whether the datasets already cover one specific user query: covered, adjacent, gap, or not asked in production.",
+    {
+      query: z.string().min(1),
+      window,
+      datasetIds: z.array(z.string()).optional(),
+    },
+    async ({ query, window: w, datasetIds }) => text(await probe(db, { query, window: (w ?? "30d") as MonitoringWindow, datasetIds }))
+  );
+}

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -183,7 +183,7 @@ async function main() {
   // MCP connector surface (routes/mcp.ts): POST /mcp plus the OAuth endpoints at the root.
   // Registered after the API and before the SPA fallback below, which would otherwise answer
   // /mcp and /.well-known/* with index.html.
-  registerMcp(app, { credentialLimit, dataPlaneLimit, apiKey, port: PORT });
+  registerMcp(app, { credentialLimit, dataPlaneLimit, port: PORT });
 
   // The dashboard bundle is AgentX's real, full frontend (see README's "Open source scope"), so
   // it still calls a handful of hosted-SaaS-only endpoints this engine doesn't implement

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -16,6 +16,7 @@ import { ensureMetricPackConfigs, metricPackBackfillDone, markMetricPackBackfill
 import { authMode, initAuth, resolveAuthSecret } from "./auth/betterAuth.js";
 import { mailerConfigured } from "./auth/mailer.js";
 import { registerAuthRoutes, registerApiV1 } from "./routes/apiV1.js";
+import { registerMcp } from "./routes/mcp.js";
 import { findWebIndexHtml, downloadWebBundle, webBundleCandidates, describeWebBundle } from "./web.js";
 import { startSessionSweep } from "./core/monitor/sessionSweep.js";
 import { startImprovementSweep } from "./core/evaluate/improvementSweep.js";
@@ -178,6 +179,11 @@ async function main() {
   const apiKey = asyncHandler(requireApiKey());
 
   registerApiV1(app, { credentialLimit, dataPlaneLimit, apiKey });
+
+  // MCP connector surface (routes/mcp.ts): POST /mcp plus the OAuth endpoints at the root.
+  // Registered after the API and before the SPA fallback below, which would otherwise answer
+  // /mcp and /.well-known/* with index.html.
+  registerMcp(app, { credentialLimit, dataPlaneLimit, apiKey, port: PORT });
 
   // The dashboard bundle is AgentX's real, full frontend (see README's "Open source scope"), so
   // it still calls a handful of hosted-SaaS-only endpoints this engine doesn't implement

--- a/engine/src/routes/agentMonitoringDashboard.ts
+++ b/engine/src/routes/agentMonitoringDashboard.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express";
 import { asyncRouter } from "./asyncRouter.js";
 import { getDb, type Db } from "../storage/db.js";
+import { revokeProjectGrants } from "../core/mcp/oauthStore.js";
 import { scopedDb } from "../auth/apiKey.js";
 import { createPattern, updatePattern, deletePattern, listPatternsWire, legacyPayloadToConditions } from "../core/monitor/patterns.js";
 import { BUILT_IN_MONITOR_PATTERNS, builtInPatternsWire } from "../core/monitor/detect.js";
@@ -1981,6 +1982,10 @@ agentMonitoringDashboardRouter.put("/settings/llm-keys", async (req: Request, re
 
 agentMonitoringDashboardRouter.post("/settings/api-key/regenerate", async (req: Request, res: Response) => {
   const project = await regenerateProjectApiKey(getDb(), req.projectId!);
+  // An MCP OAuth token is a stand-in for this key (core/mcp/oauthProvider.ts), so rotating the
+  // key revokes every connector grant with it - otherwise "regenerate" would leave a live path
+  // to the project's data that the new key never authorized.
+  await revokeProjectGrants(getDb(), req.projectId!);
   res.status(200).json({ apiKey: project?.apiKey ?? null });
 });
 

--- a/engine/src/routes/apiV1.ts
+++ b/engine/src/routes/apiV1.ts
@@ -45,6 +45,7 @@ import {
 } from "../auth/betterAuth.js";
 import { mailerConfigured } from "../auth/mailer.js";
 import { openapiRouter } from "./openapi.js";
+import { mcpGrantsRouter } from "./mcp.js";
 
 export type ApiV1Deps = {
   credentialLimit: RequestHandler;
@@ -232,6 +233,10 @@ export function registerApiV1(app: Express, deps: ApiV1Deps): void {
   }
   // Operator admin (inert without AGENTX_ADMIN_TOKEN - see routes/admin.ts).
   router.use("/admin", credentialLimit, adminRouter);
+  // OAuth grants issued to MCP clients for the caller's project (routes/mcp.ts) - the
+  // "connected apps" list and its revoke button. Key-authenticated like every other per-project
+  // read; the OAuth endpoints themselves live at the application root.
+  router.use("/mcp", credentialLimit, apiKey, mcpGrantsRouter);
   router.use("/agent-monitoring", dataPlaneLimit, apiKey, agentMonitoringDashboardRouter);
   router.use("/evaluate", dataPlaneLimit, apiKey, evaluateDashboardRouter);
   router.use("/insights", dataPlaneLimit, apiKey, insightsRouter);

--- a/engine/src/routes/mcp.ts
+++ b/engine/src/routes/mcp.ts
@@ -23,6 +23,7 @@ import { createMcpServer } from "../core/mcp/server.js";
 import type { McpPrincipal } from "../core/mcp/tools.js";
 import { listGrants, revokeGrant } from "../core/mcp/oauthStore.js";
 import { validateBody } from "./validateBody.js";
+import { rateLimitDisabled } from "../auth/rateLimit.js";
 
 // The consent form's fields: the signed request bundle (core/mcp/oauthProvider.ts verifies the
 // signature and expiry, which is the real gate) plus the user's decision and, per auth mode,
@@ -66,7 +67,6 @@ declare global {
 export type McpDeps = {
   credentialLimit: RequestHandler;
   dataPlaneLimit: RequestHandler;
-  apiKey: RequestHandler;
   port: number;
 };
 
@@ -167,11 +167,13 @@ export function registerMcp(app: Express, deps: McpDeps): void {
     // express-rate-limit directly (the same shape as apiV1.ts's projectMutationLimit) so the
     // guard is visible at the route, not hidden behind an injected handler. 60 decisions per 15
     // minutes per IP is far above any human consent flow and well below a key-guessing loop.
+    // Honours the same AGENTX_RATE_LIMIT=off switch as every other limiter.
     const consentLimit = rateLimit({
       windowMs: 15 * 60 * 1000,
       max: 60,
       standardHeaders: "draft-7",
       legacyHeaders: false,
+      skip: () => rateLimitDisabled(),
       handler: (_req, res) => {
         res.status(429).json({ statusCode: 429, message: "Too many requests" });
       },

--- a/engine/src/routes/mcp.ts
+++ b/engine/src/routes/mcp.ts
@@ -1,0 +1,252 @@
+import express, { type Express, type NextFunction, type Request, type RequestHandler, type Response } from "express";
+import { z } from "zod";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { mcpAuthRouter, getOAuthProtectedResourceMetadataUrl } from "@modelcontextprotocol/sdk/server/auth/router.js";
+import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
+import { asyncHandler, asyncRouter } from "./asyncRouter.js";
+import { getDb, withProjectId } from "../storage/db.js";
+import { currentTenancy, runWithTenancy } from "../auth/requestContext.js";
+import { resolveProjectByApiKey } from "../core/project/projects.js";
+import { logger } from "../log.js";
+import {
+  MCP_PATH,
+  MCP_READ_SCOPE,
+  MCP_SCOPES_SUPPORTED,
+  mcpEnabled,
+  mcpIssuerUrl,
+  mcpOauthAvailable,
+  mcpResourceUrl,
+} from "../core/mcp/config.js";
+import { EngineOAuthProvider } from "../core/mcp/oauthProvider.js";
+import { createMcpServer } from "../core/mcp/server.js";
+import type { McpPrincipal } from "../core/mcp/tools.js";
+import { listGrants, revokeGrant } from "../core/mcp/oauthStore.js";
+import { validateBody } from "./validateBody.js";
+
+// The consent form's fields: the signed request bundle (core/mcp/oauthProvider.ts verifies the
+// signature and expiry, which is the real gate) plus the user's decision and, per auth mode,
+// the credential proving who is deciding. Shape here, meaning in the provider.
+const decisionBodySchema = z
+  .object({
+    action: z.enum(["approve", "deny"]),
+    client_id: z.string().min(1),
+    redirect_uri: z.string().url(),
+    code_challenge: z.string().min(1),
+    state: z.string().default(""),
+    scope: z.string().default(""),
+    resource: z.string().default(""),
+    exp: z.string().regex(/^\d+$/),
+    sig: z.string().regex(/^[a-f0-9]{64}$/),
+    api_key: z.string().optional(),
+    project_id: z.string().optional(),
+  })
+  .strip();
+
+// The transport validates every JSON-RPC message in full; this only refuses bodies that are not
+// JSON-RPC at all before a server is built for them.
+const jsonRpcMessageSchema = z.object({ jsonrpc: z.literal("2.0") }).passthrough();
+const mcpBodySchema = z.union([jsonRpcMessageSchema, z.array(jsonRpcMessageSchema).min(1)]);
+
+// The MCP surface: POST /mcp (Streamable HTTP) plus, when the issuer allows it, the OAuth 2.1
+// authorization server that lets claude.ai connect without a project API key ever leaving the
+// box. See docs/self-hosted-mcp-plan.md for the design and core/mcp/oauthProvider.ts for the
+// grant model. Mounted at the application ROOT, not under /api/v1: the resource identifier
+// clients bind tokens to is <public URL>/mcp, and RFC 8414/9728 metadata documents live at
+// /.well-known/* on the origin.
+
+declare global {
+  namespace Express {
+    interface Request {
+      mcpPrincipal?: McpPrincipal;
+    }
+  }
+}
+
+export type McpDeps = {
+  credentialLimit: RequestHandler;
+  dataPlaneLimit: RequestHandler;
+  apiKey: RequestHandler;
+  port: number;
+};
+
+// Credential resolution for /mcp, in order: a project API key (x-api-key, or a bearer that is
+// not one of our OAuth tokens - Claude Code's `--header` path, the Agent SDK, CI), then an OAuth
+// access token through the SDK's bearer middleware so the 401 carries the WWW-Authenticate
+// resource_metadata hint that starts a client's OAuth discovery. Either way the request ends up
+// with req.projectId and the AsyncLocalStorage tenancy every core function reads.
+function requireMcpAuth(provider: EngineOAuthProvider | null, resourceMetadataUrl: string | null) {
+  const bearer = provider
+    ? requireBearerAuth({ verifier: provider, requiredScopes: [MCP_READ_SCOPE], resourceMetadataUrl: resourceMetadataUrl ?? undefined })
+    : null;
+  const unauthorized = (res: Response, description: string) => {
+    const hint = resourceMetadataUrl ? `, resource_metadata="${resourceMetadataUrl}"` : "";
+    res.set("WWW-Authenticate", `Bearer error="invalid_token", error_description="${description}"${hint}`);
+    res.status(401).json({ error: "invalid_token", error_description: description });
+  };
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const header = req.header("authorization") ?? "";
+    const [scheme, bearerValue] = header.split(" ");
+    const bearerToken = scheme?.toLowerCase() === "bearer" && bearerValue ? bearerValue.trim() : "";
+    const isOauthToken = bearerToken.startsWith("agtx_mcp_");
+    const candidateKey = req.header("x-api-key") || (!isOauthToken ? bearerToken : "");
+
+    if (candidateKey) {
+      const project = await resolveProjectByApiKey(getDb(), candidateKey);
+      if (!project) {
+        unauthorized(res, "Invalid project API key");
+        return;
+      }
+      req.projectId = project.id;
+      req.mcpPrincipal = { kind: "project-key" };
+      runWithTenancy({ projectId: project.id, organizationId: project.organizationId ?? null }, () => next());
+      return;
+    }
+    if (!bearer) {
+      unauthorized(res, "Provide a project API key as a bearer token or x-api-key header");
+      return;
+    }
+    bearer(req, res, err => {
+      if (err) {
+        next(err);
+        return;
+      }
+      const extra = (req.auth?.extra ?? {}) as { projectId?: string; organizationId?: string | null; userId?: string | null; grantId?: string };
+      if (!extra.projectId) {
+        unauthorized(res, "Token carries no project");
+        return;
+      }
+      req.projectId = extra.projectId;
+      req.mcpPrincipal = {
+        kind: "oauth",
+        clientId: req.auth?.clientId ?? "",
+        userId: extra.userId ?? null,
+        grantId: extra.grantId ?? "",
+      };
+      runWithTenancy({ projectId: extra.projectId, organizationId: extra.organizationId ?? null }, () => next());
+    });
+  };
+}
+
+async function handleMcpPost(req: Request, res: Response): Promise<void> {
+  const projectId = req.projectId!;
+  const server = createMcpServer({
+    db: withProjectId(getDb(), projectId),
+    projectId,
+    // Set by requireMcpAuth for both credential kinds (the project row's org for a key, the
+    // grant's org for a token).
+    organizationId: currentTenancy().organizationId ?? null,
+    principal: req.mcpPrincipal ?? { kind: "project-key" },
+    ip: req.ip ?? null,
+  });
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  res.on("close", () => {
+    void transport.close();
+    void server.close();
+  });
+  await server.connect(transport);
+  // express.json already consumed the body (index.ts mounts it globally); hand the parsed
+  // object over rather than letting the transport read an empty stream.
+  await transport.handleRequest(req, res, req.body);
+}
+
+export function registerMcp(app: Express, deps: McpDeps): void {
+  if (!mcpEnabled()) {
+    logger.info("MCP endpoint disabled (AGENTX_MCP=disabled).");
+    return;
+  }
+  const issuer = mcpIssuerUrl(deps.port);
+  const resource = mcpResourceUrl(issuer);
+  const oauth = mcpOauthAvailable(issuer);
+  const provider = oauth ? new EngineOAuthProvider(resource, issuer.href) : null;
+  const resourceMetadataUrl = oauth ? getOAuthProtectedResourceMetadataUrl(resource) : null;
+
+  if (provider) {
+    // Consent form submission - registered BEFORE the SDK router so `/authorize/decision` never
+    // reaches the SDK's `/authorize` prefix handler. The engine's own credential limiter guards
+    // the SDK endpoints; the SDK's built-in per-endpoint limiters are disabled so the two ceilings
+    // do not stack into surprising 429s.
+    app.post(
+      "/authorize/decision",
+      deps.credentialLimit,
+      express.urlencoded({ extended: false }),
+      validateBody(decisionBodySchema),
+      asyncHandler(async (req: Request, res: Response) => {
+        await provider.decision(req, res);
+      })
+    );
+    for (const path of ["/authorize", "/token", "/register", "/revoke"]) {
+      app.use(path, deps.credentialLimit);
+    }
+    app.use(
+      mcpAuthRouter({
+        provider,
+        issuerUrl: issuer,
+        resourceServerUrl: resource,
+        scopesSupported: [...MCP_SCOPES_SUPPORTED],
+        resourceName: "AgentX Trace & Eval (self-hosted)",
+        authorizationOptions: { rateLimit: false },
+        tokenOptions: { rateLimit: false },
+        revocationOptions: { rateLimit: false },
+        // A connector should not stop working because a registration secret aged out; the
+        // refresh token's own 30-day lifetime already bounds an idle grant.
+        clientRegistrationOptions: { rateLimit: false, clientSecretExpirySeconds: 0 },
+      })
+    );
+  }
+
+  app.post(
+    "/mcp",
+    deps.dataPlaneLimit,
+    asyncHandler(requireMcpAuth(provider, resourceMetadataUrl)),
+    validateBody(mcpBodySchema),
+    asyncHandler(async (req: Request, res: Response) => {
+      await handleMcpPost(req, res);
+    })
+  );
+  // Stateless transport: no server-initiated stream to GET, no session to DELETE.
+  app.all(MCP_PATH, (_req, res) => {
+    res
+      .status(405)
+      .set("Allow", "POST")
+      .json({ jsonrpc: "2.0", error: { code: -32000, message: "Method not allowed. POST JSON-RPC to this endpoint." }, id: null });
+  });
+
+  logger.info(`MCP endpoint: ${resource.href} (bearer project API key${oauth ? ", or OAuth via " + issuer.href : ""})`);
+  if (!oauth) {
+    logger.warn(
+      `MCP OAuth is off: the issuer ${issuer.href} is neither HTTPS nor loopback. Set AGENTX_PUBLIC_URL to an https:// URL to let claude.ai connect; project-key bearer access still works.`
+    );
+  }
+}
+
+// Key-authenticated view of the OAuth grants on the caller's project (the dashboard's
+// "connected apps"), mounted under /api/v1/mcp by apiV1.ts. Revoking a grant kills its refresh
+// chain and every access token minted from it.
+export const mcpGrantsRouter = asyncRouter();
+
+mcpGrantsRouter.get("/grants", async (req: Request, res: Response) => {
+  const grants = await listGrants(getDb(), req.projectId!);
+  res.status(200).json({
+    grants: grants.map(grant => ({
+      grantId: grant.grantId,
+      clientId: grant.clientId,
+      clientName: grant.clientName,
+      userId: grant.userId,
+      scopes: grant.scopes,
+      createdAt: grant.createdAt.toISOString(),
+      lastUsedAt: grant.lastUsedAt ? grant.lastUsedAt.toISOString() : null,
+      expiresAt: grant.expiresAt.toISOString(),
+    })),
+  });
+});
+
+mcpGrantsRouter.delete("/grants/:grantId", async (req: Request, res: Response) => {
+  const grants = await listGrants(getDb(), req.projectId!);
+  const target = grants.find(grant => grant.grantId === req.params.grantId);
+  if (!target) {
+    res.status(404).json({ error: "Grant not found" });
+    return;
+  }
+  await revokeGrant(getDb(), target.grantId);
+  res.status(204).end();
+});

--- a/engine/src/routes/mcp.ts
+++ b/engine/src/routes/mcp.ts
@@ -128,6 +128,45 @@ function requireMcpAuth(provider: EngineOAuthProvider | null, resourceMetadataUr
   };
 }
 
+// Accept-header negotiation for /mcp.
+//
+// The Streamable HTTP spec tells a client to send `Accept: application/json, text/event-stream`,
+// and the SDK transport answers 406 to anything else - including `*/*` and a missing header,
+// which is what a great many HTTP clients send by default. A wildcard does accept both, so
+// refusing it strands a working client at the handshake behind an error most clients never
+// surface: the connector simply registers no tools and the model is left to improvise.
+//
+// So: work out what the caller can actually read, answer in that shape (a plain JSON body for a
+// client that never said it understands an event stream), and hand the transport the explicit
+// pair it insists on. A caller that accepts neither type is left alone to get its 406, which is
+// the one case where the status is the truth.
+const JSON_TYPE = "application/json";
+const SSE_TYPE = "text/event-stream";
+
+type AcceptOffer = {
+  /** Either type is readable, wildcards included - i.e. this request can be served at all. */
+  serviceable: boolean;
+  /** The client named the event-stream type outright, so it is ready to parse SSE frames. */
+  wantsStream: boolean;
+};
+
+function acceptOffer(header: string | undefined): AcceptOffer {
+  const raw = (header ?? "").trim();
+  // No Accept header means "anything is acceptable" (RFC 9110 section 12.5.1).
+  if (raw === "") return { serviceable: true, wantsStream: false };
+  const offered = raw
+    .split(",")
+    .map(entry => entry.trim().toLowerCase())
+    // `q=0` is an explicit refusal of that type, not an offer of it.
+    .filter(entry => entry !== "" && !/;\s*q=0(\.0+)?\s*(;|$)/.test(entry))
+    .map(entry => entry.split(";")[0]!.trim());
+  const readable = (type: string) => {
+    const group = type.split("/")[0];
+    return offered.some(entry => entry === type || entry === "*/*" || entry === `${group}/*`);
+  };
+  return { serviceable: readable(JSON_TYPE) || readable(SSE_TYPE), wantsStream: offered.includes(SSE_TYPE) };
+}
+
 async function handleMcpPost(req: Request, res: Response): Promise<void> {
   const projectId = req.projectId!;
   const server = createMcpServer({
@@ -139,7 +178,16 @@ async function handleMcpPost(req: Request, res: Response): Promise<void> {
     principal: req.mcpPrincipal ?? { kind: "project-key" },
     ip: req.ip ?? null,
   });
-  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  const offer = acceptOffer(req.header("accept"));
+  if (offer.serviceable) {
+    req.headers.accept = `${JSON_TYPE}, ${SSE_TYPE}`;
+  }
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+    // Only a client that asked for an event stream gets one; everyone else gets a single JSON
+    // body, which both the spec and every such client can read.
+    enableJsonResponse: !offer.wantsStream,
+  });
   res.on("close", () => {
     void transport.close();
     void server.close();

--- a/engine/src/routes/mcp.ts
+++ b/engine/src/routes/mcp.ts
@@ -1,4 +1,5 @@
 import express, { type Express, type NextFunction, type Request, type RequestHandler, type Response } from "express";
+import rateLimit from "express-rate-limit";
 import { z } from "zod";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { mcpAuthRouter, getOAuthProtectedResourceMetadataUrl } from "@modelcontextprotocol/sdk/server/auth/router.js";
@@ -161,6 +162,20 @@ export function registerMcp(app: Express, deps: McpDeps): void {
   const resourceMetadataUrl = oauth ? getOAuthProtectedResourceMetadataUrl(resource) : null;
 
   if (provider) {
+    // The consent decision verifies a session or a project API key per submission, so it gets a
+    // ceiling of its own on top of the shared credential limiter - built here with
+    // express-rate-limit directly (the same shape as apiV1.ts's projectMutationLimit) so the
+    // guard is visible at the route, not hidden behind an injected handler. 60 decisions per 15
+    // minutes per IP is far above any human consent flow and well below a key-guessing loop.
+    const consentLimit = rateLimit({
+      windowMs: 15 * 60 * 1000,
+      max: 60,
+      standardHeaders: "draft-7",
+      legacyHeaders: false,
+      handler: (_req, res) => {
+        res.status(429).json({ statusCode: 429, message: "Too many requests" });
+      },
+    });
     // Consent form submission - registered BEFORE the SDK router so `/authorize/decision` never
     // reaches the SDK's `/authorize` prefix handler. The engine's own credential limiter guards
     // the SDK endpoints; the SDK's built-in per-endpoint limiters are disabled so the two ceilings
@@ -168,6 +183,7 @@ export function registerMcp(app: Express, deps: McpDeps): void {
     app.post(
       "/authorize/decision",
       deps.credentialLimit,
+      consentLimit,
       express.urlencoded({ extended: false }),
       validateBody(decisionBodySchema),
       asyncHandler(async (req: Request, res: Response) => {

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -1038,6 +1038,46 @@ export function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean }
       created_at INTEGER,
       inviter_id TEXT NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS mcp_oauth_clients (
+      id TEXT PRIMARY KEY,
+      client_secret TEXT,
+      metadata TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      last_used_at INTEGER
+    );
+
+    CREATE TABLE IF NOT EXISTS mcp_oauth_codes (
+      code_hash TEXT PRIMARY KEY,
+      client_id TEXT NOT NULL,
+      project_id TEXT NOT NULL,
+      organization_id TEXT,
+      user_id TEXT,
+      scopes TEXT NOT NULL,
+      code_challenge TEXT NOT NULL,
+      redirect_uri TEXT NOT NULL,
+      resource TEXT,
+      expires_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS mcp_oauth_tokens (
+      token_hash TEXT PRIMARY KEY,
+      kind TEXT NOT NULL,
+      grant_id TEXT NOT NULL,
+      client_id TEXT NOT NULL,
+      project_id TEXT NOT NULL,
+      organization_id TEXT,
+      user_id TEXT,
+      scopes TEXT NOT NULL,
+      resource TEXT,
+      expires_at INTEGER NOT NULL,
+      revoked_at INTEGER,
+      created_at INTEGER NOT NULL,
+      last_used_at INTEGER
+    );
+    CREATE INDEX IF NOT EXISTS mcp_oauth_tokens_grant_id ON mcp_oauth_tokens (grant_id);
+    CREATE INDEX IF NOT EXISTS mcp_oauth_tokens_project_id ON mcp_oauth_tokens (project_id);
   `);
 
   // Columns added after the tables above already shipped: CREATE TABLE IF NOT EXISTS doesn't
@@ -2398,6 +2438,46 @@ export async function bootstrapPostgres(pool: Pool): Promise<{ freshInstall: boo
       created_at TIMESTAMP,
       inviter_id TEXT NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS mcp_oauth_clients (
+      id TEXT PRIMARY KEY,
+      client_secret TEXT,
+      metadata JSONB NOT NULL,
+      created_at TIMESTAMP NOT NULL,
+      last_used_at TIMESTAMP
+    );
+
+    CREATE TABLE IF NOT EXISTS mcp_oauth_codes (
+      code_hash TEXT PRIMARY KEY,
+      client_id TEXT NOT NULL,
+      project_id TEXT NOT NULL,
+      organization_id TEXT,
+      user_id TEXT,
+      scopes JSONB NOT NULL,
+      code_challenge TEXT NOT NULL,
+      redirect_uri TEXT NOT NULL,
+      resource TEXT,
+      expires_at TIMESTAMP NOT NULL,
+      created_at TIMESTAMP NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS mcp_oauth_tokens (
+      token_hash TEXT PRIMARY KEY,
+      kind TEXT NOT NULL,
+      grant_id TEXT NOT NULL,
+      client_id TEXT NOT NULL,
+      project_id TEXT NOT NULL,
+      organization_id TEXT,
+      user_id TEXT,
+      scopes JSONB NOT NULL,
+      resource TEXT,
+      expires_at TIMESTAMP NOT NULL,
+      revoked_at TIMESTAMP,
+      created_at TIMESTAMP NOT NULL,
+      last_used_at TIMESTAMP
+    );
+    CREATE INDEX IF NOT EXISTS mcp_oauth_tokens_grant_id ON mcp_oauth_tokens (grant_id);
+    CREATE INDEX IF NOT EXISTS mcp_oauth_tokens_project_id ON mcp_oauth_tokens (project_id);
 
     -- Postgres supports IF NOT EXISTS on ADD COLUMN natively, unlike SQLite (see
     -- bootstrapSqlite's columnMigrations for the equivalent there), so pre-existing databases

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -1073,6 +1073,7 @@ export function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean }
       resource TEXT,
       expires_at INTEGER NOT NULL,
       revoked_at INTEGER,
+      rotated_at INTEGER,
       created_at INTEGER NOT NULL,
       last_used_at INTEGER
     );
@@ -2473,6 +2474,7 @@ export async function bootstrapPostgres(pool: Pool): Promise<{ freshInstall: boo
       resource TEXT,
       expires_at TIMESTAMP NOT NULL,
       revoked_at TIMESTAMP,
+      rotated_at TIMESTAMP,
       created_at TIMESTAMP NOT NULL,
       last_used_at TIMESTAMP
     );

--- a/engine/src/storage/schema.pg.ts
+++ b/engine/src/storage/schema.pg.ts
@@ -834,3 +834,42 @@ export const improvementReports = pgTable("improvement_reports", {
   report: jsonb("report").notNull(),
   createdAt: timestamp("created_at", { mode: "date" }).notNull(),
 });
+
+// MCP connector authorization - see schema.sqlite.ts's mcp_oauth_* block for the full comment.
+export const mcpOauthClients = pgTable("mcp_oauth_clients", {
+  id: text("id").primaryKey(),
+  clientSecret: text("client_secret"),
+  metadata: jsonb("metadata").notNull(),
+  createdAt: timestamp("created_at", { mode: "date" }).notNull(),
+  lastUsedAt: timestamp("last_used_at", { mode: "date" }),
+});
+
+export const mcpOauthCodes = pgTable("mcp_oauth_codes", {
+  codeHash: text("code_hash").primaryKey(),
+  clientId: text("client_id").notNull(),
+  projectId: text("project_id").notNull(),
+  organizationId: text("organization_id"),
+  userId: text("user_id"),
+  scopes: jsonb("scopes").notNull(),
+  codeChallenge: text("code_challenge").notNull(),
+  redirectUri: text("redirect_uri").notNull(),
+  resource: text("resource"),
+  expiresAt: timestamp("expires_at", { mode: "date" }).notNull(),
+  createdAt: timestamp("created_at", { mode: "date" }).notNull(),
+});
+
+export const mcpOauthTokens = pgTable("mcp_oauth_tokens", {
+  tokenHash: text("token_hash").primaryKey(),
+  kind: text("kind").notNull(),
+  grantId: text("grant_id").notNull(),
+  clientId: text("client_id").notNull(),
+  projectId: text("project_id").notNull(),
+  organizationId: text("organization_id"),
+  userId: text("user_id"),
+  scopes: jsonb("scopes").notNull(),
+  resource: text("resource"),
+  expiresAt: timestamp("expires_at", { mode: "date" }).notNull(),
+  revokedAt: timestamp("revoked_at", { mode: "date" }),
+  createdAt: timestamp("created_at", { mode: "date" }).notNull(),
+  lastUsedAt: timestamp("last_used_at", { mode: "date" }),
+});

--- a/engine/src/storage/schema.pg.ts
+++ b/engine/src/storage/schema.pg.ts
@@ -870,6 +870,7 @@ export const mcpOauthTokens = pgTable("mcp_oauth_tokens", {
   resource: text("resource"),
   expiresAt: timestamp("expires_at", { mode: "date" }).notNull(),
   revokedAt: timestamp("revoked_at", { mode: "date" }),
+  rotatedAt: timestamp("rotated_at", { mode: "date" }),
   createdAt: timestamp("created_at", { mode: "date" }).notNull(),
   lastUsedAt: timestamp("last_used_at", { mode: "date" }),
 });

--- a/engine/src/storage/schema.sqlite.ts
+++ b/engine/src/storage/schema.sqlite.ts
@@ -1271,3 +1271,53 @@ export const improvementReports = sqliteTable("improvement_reports", {
   report: text("report", { mode: "json" }).notNull(),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
 });
+
+// MCP connector authorization (core/mcp/*): the engine acts as a small OAuth 2.1 authorization
+// server so claude.ai / Claude Code can connect to /mcp without a project API key ever leaving
+// the box. Tokens are opaque and stored HASHED (sha256) - unlike project keys they are derived,
+// short-lived credentials, so hashing them costs nothing and bounds a database leak. Clients
+// are the output of Dynamic Client Registration (RFC 7591); the secret stays plaintext because
+// the SDK's token endpoint compares it directly (PKCE is mandatory, so a leaked secret alone
+// mints nothing). No project_id on clients: a registered client is instance-wide, it is the
+// GRANT (code/token rows) that names the project.
+export const mcpOauthClients = sqliteTable("mcp_oauth_clients", {
+  id: text("id").primaryKey(),
+  clientSecret: text("client_secret"),
+  // The full RFC 7591 metadata document as registered (redirect_uris, client_name, ...), minus
+  // the id/secret columns above - returned verbatim to the SDK's client store.
+  metadata: text("metadata", { mode: "json" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  lastUsedAt: integer("last_used_at", { mode: "timestamp_ms" }),
+});
+
+export const mcpOauthCodes = sqliteTable("mcp_oauth_codes", {
+  codeHash: text("code_hash").primaryKey(),
+  clientId: text("client_id").notNull(),
+  projectId: text("project_id").notNull(),
+  organizationId: text("organization_id"),
+  userId: text("user_id"),
+  scopes: text("scopes", { mode: "json" }).notNull(),
+  codeChallenge: text("code_challenge").notNull(),
+  redirectUri: text("redirect_uri").notNull(),
+  resource: text("resource"),
+  expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+});
+
+export const mcpOauthTokens = sqliteTable("mcp_oauth_tokens", {
+  tokenHash: text("token_hash").primaryKey(),
+  // "access" | "refresh". A grant (one approved authorization) owns one refresh chain and the
+  // access tokens minted from it; revoking the grant revokes every row sharing grant_id.
+  kind: text("kind").notNull(),
+  grantId: text("grant_id").notNull(),
+  clientId: text("client_id").notNull(),
+  projectId: text("project_id").notNull(),
+  organizationId: text("organization_id"),
+  userId: text("user_id"),
+  scopes: text("scopes", { mode: "json" }).notNull(),
+  resource: text("resource"),
+  expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+  revokedAt: integer("revoked_at", { mode: "timestamp_ms" }),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  lastUsedAt: integer("last_used_at", { mode: "timestamp_ms" }),
+});

--- a/engine/src/storage/schema.sqlite.ts
+++ b/engine/src/storage/schema.sqlite.ts
@@ -1318,6 +1318,10 @@ export const mcpOauthTokens = sqliteTable("mcp_oauth_tokens", {
   resource: text("resource"),
   expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
   revokedAt: integer("revoked_at", { mode: "timestamp_ms" }),
+  // Refresh tokens only: set when the token was rotated out by a successful refresh. Distinct
+  // from revoked_at so a retry inside the rotation grace window can be told apart from a token
+  // that was deliberately revoked.
+  rotatedAt: integer("rotated_at", { mode: "timestamp_ms" }),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
   lastUsedAt: integer("last_used_at", { mode: "timestamp_ms" }),
 });

--- a/engine/src/test/mcp.integration.test.ts
+++ b/engine/src/test/mcp.integration.test.ts
@@ -496,6 +496,37 @@ describe("MCP endpoint, AGENTX_AUTH=disabled", () => {
     await claude.text();
   });
 
+  it("only links an http(s) client_uri on the consent page", async () => {
+    // The SDK's registration schema already refuses javascript: and data: URIs; anything else
+    // with a scheme that is not http(s) is stored but must not become an anchor.
+    const res = await fetch(`${originOf(engine)}/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        client_name: "Sneaky",
+        client_uri: "file:///etc/passwd",
+        redirect_uris: ["http://localhost:4444/cb"],
+        token_endpoint_auth_method: "none",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const { client_id } = (await res.json()) as { client_id: string };
+    const url = new URL(`${originOf(engine)}/authorize`);
+    url.search = new URLSearchParams({
+      response_type: "code",
+      client_id,
+      redirect_uri: "http://localhost:4444/cb",
+      code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      code_challenge_method: "S256",
+    }).toString();
+    const page = await fetch(url);
+    const html = await page.text();
+    expect(page.status).toBe(200);
+    expect(html).toContain("Sneaky");
+    expect(html).not.toContain("file:");
+    expect(html).not.toContain("<a href");
+  });
+
   it("binds the grant to this server's resource identifier", async () => {
     const { provider } = await beginOAuth(engine);
     const url = new URL(provider.authorizationUrl!);

--- a/engine/src/test/mcp.integration.test.ts
+++ b/engine/src/test/mcp.integration.test.ts
@@ -1,0 +1,649 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { UnauthorizedError, type OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { OAuthClientInformationMixed, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { mcpGrantsResponseSchema } from "../contract/wire.js";
+import { postJson, postgresAvailable, startEngine, type TestEngine } from "./server.js";
+
+// The MCP connector surface (routes/mcp.ts, core/mcp/*), driven by the real MCP SDK client the
+// way Claude Code and claude.ai drive it: bearer project key for local clients, and the full
+// OAuth 2.1 dance - discovery, dynamic client registration, consent page, PKCE code exchange,
+// refresh rotation, revocation - for hosted ones. Both auth modes, because the consent page is
+// where they differ.
+
+// The engine's issuer defaults to http://localhost:<port> when AGENTX_PUBLIC_URL is unset, and
+// the SDK client refuses a protected-resource document whose origin differs from the URL it was
+// given, so the tests speak to localhost rather than the harness's 127.0.0.1.
+function mcpUrl(engine: TestEngine): URL {
+  return new URL(engine.baseUrl.replace("127.0.0.1", "localhost") + "/mcp");
+}
+
+function originOf(engine: TestEngine): string {
+  return engine.baseUrl.replace("127.0.0.1", "localhost");
+}
+
+type ToolResult = { isError?: boolean; content?: { type: string; text?: string }[] };
+
+function textOf(result: unknown): string {
+  return ((result as ToolResult).content ?? []).map(c => c.text ?? "").join("\n");
+}
+
+function parsed<T = Record<string, unknown>>(result: unknown): T {
+  return JSON.parse(textOf(result)) as T;
+}
+
+async function keyClient(engine: TestEngine, key: string, header: "authorization" | "x-api-key" = "authorization"): Promise<Client> {
+  const headers = header === "authorization" ? { Authorization: `Bearer ${key}` } : { "x-api-key": key };
+  const transport = new StreamableHTTPClientTransport(mcpUrl(engine), { requestInit: { headers } });
+  const client = new Client({ name: "mcp-test", version: "0" });
+  await client.connect(transport);
+  return client;
+}
+
+// Raw JSON-RPC over fetch, for the cases where the interesting part is the HTTP status.
+async function rawToolsList(engine: TestEngine, headers: Record<string, string>): Promise<Response> {
+  return fetch(mcpUrl(engine), {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json, text/event-stream", ...headers },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+  });
+}
+
+// What Claude Code / claude.ai keep on their side of the flow.
+class MemoryOAuthProvider implements OAuthClientProvider {
+  info?: OAuthClientInformationMixed;
+  toks?: OAuthTokens;
+  verifier = "";
+  authorizationUrl?: URL;
+  get redirectUrl() {
+    return "http://localhost:9999/callback";
+  }
+  get clientMetadata() {
+    return {
+      client_name: "Test connector",
+      redirect_uris: [this.redirectUrl],
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+    };
+  }
+  clientInformation() {
+    return this.info;
+  }
+  saveClientInformation(info: OAuthClientInformationMixed) {
+    this.info = info;
+  }
+  tokens() {
+    return this.toks;
+  }
+  saveTokens(tokens: OAuthTokens) {
+    this.toks = tokens;
+  }
+  redirectToAuthorization(url: URL) {
+    this.authorizationUrl = url;
+  }
+  saveCodeVerifier(verifier: string) {
+    this.verifier = verifier;
+  }
+  codeVerifier() {
+    return this.verifier;
+  }
+}
+
+// Kicks off the flow the way a client does: connect, get bounced, capture the authorization URL.
+async function beginOAuth(engine: TestEngine): Promise<{ provider: MemoryOAuthProvider; transport: StreamableHTTPClientTransport }> {
+  const provider = new MemoryOAuthProvider();
+  const transport = new StreamableHTTPClientTransport(mcpUrl(engine), { authProvider: provider });
+  const client = new Client({ name: "mcp-test-oauth", version: "0" });
+  await expect(client.connect(transport)).rejects.toBeInstanceOf(UnauthorizedError);
+  expect(provider.authorizationUrl, "no authorization URL captured").toBeDefined();
+  expect(provider.info?.client_id, "dynamic client registration did not happen").toBeTruthy();
+  return { provider, transport };
+}
+
+// The consent page's hidden fields (the signed request bundle) as a form body.
+function hiddenFields(html: string): URLSearchParams {
+  const form = new URLSearchParams();
+  for (const match of html.matchAll(/<input type="hidden" name="([^"]+)" value="([^"]*)">/g)) {
+    form.set(match[1]!, match[2]!.replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&amp;/g, "&"));
+  }
+  return form;
+}
+
+async function consentPage(engine: TestEngine, authorizationUrl: URL, cookie?: string): Promise<{ status: number; html: string; form: URLSearchParams }> {
+  const res = await fetch(authorizationUrl, { headers: cookie ? { cookie } : {}, redirect: "manual" });
+  const html = await res.text();
+  return { status: res.status, html, form: hiddenFields(html) };
+}
+
+async function decide(
+  engine: TestEngine,
+  form: URLSearchParams,
+  extra: Record<string, string>,
+  cookie?: string
+): Promise<{ status: number; location: string | null; body: string }> {
+  const body = new URLSearchParams(form);
+  for (const [k, v] of Object.entries(extra)) body.set(k, v);
+  const res = await fetch(`${originOf(engine)}/authorize/decision`, {
+    method: "POST",
+    body,
+    headers: cookie ? { cookie } : {},
+    redirect: "manual",
+  });
+  return { status: res.status, location: res.headers.get("location"), body: await res.text() };
+}
+
+async function tokenRequest(engine: TestEngine, params: Record<string, string>): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(`${originOf(engine)}/token`, { method: "POST", body: new URLSearchParams(params) });
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+// End-to-end grant in disabled mode: returns a connected client plus everything needed to poke
+// at the tokens afterwards.
+async function grantWithKey(engine: TestEngine, key: string) {
+  const { provider, transport } = await beginOAuth(engine);
+  const page = await consentPage(engine, provider.authorizationUrl!);
+  expect(page.status).toBe(200);
+  const decision = await decide(engine, page.form, { action: "approve", api_key: key });
+  expect(decision.status, decision.body).toBe(302);
+  const code = new URL(decision.location!).searchParams.get("code")!;
+  expect(code).toBeTruthy();
+  await transport.finishAuth(code);
+  const client = new Client({ name: "mcp-test-oauth", version: "0" });
+  await client.connect(new StreamableHTTPClientTransport(mcpUrl(engine), { authProvider: provider }));
+  return { provider, client, code };
+}
+
+const EXPECTED_TOOLS = [
+  "agentx_whoami",
+  "agentx_list_traces",
+  "agentx_get_trace",
+  "agentx_list_sessions",
+  "agentx_get_session",
+  "agentx_get_kpis",
+  "agentx_list_signals",
+  "agentx_get_signal",
+  "agentx_list_agents",
+  "agentx_list_topics",
+  "agentx_list_datasets",
+  "agentx_get_dataset",
+  "agentx_list_evaluations",
+  "agentx_get_evaluation",
+  "agentx_list_prompts",
+  "agentx_get_prompt",
+  "agentx_list_tool_schemas",
+  "agentx_get_coverage",
+  "agentx_probe_coverage",
+];
+
+describe("MCP endpoint, AGENTX_AUTH=disabled", () => {
+  let engine: TestEngine;
+  let otherKey = "";
+  let sessionId = "";
+
+  beforeAll(async () => {
+    engine = await startEngine();
+    sessionId = `mcp-session-${Date.now()}`;
+    for (const turn of ["first turn", "second turn"]) {
+      const res = await engine.json("/api/v1/ingest/traces", postJson({ name: "mcp-agent", input: turn, output: `answer to ${turn}`, session_id: sessionId }));
+      expect(res.status).toBe(200);
+    }
+    const long = await engine.json("/api/v1/ingest/traces", postJson({ name: "mcp-agent", input: "long", output: "x".repeat(2000) }));
+    expect(long.status).toBe(200);
+    const dataset = await engine.json(
+      "/api/v1/custom-agent-evaluations/datasets",
+      postJson({ name: "mcp dataset", questions: [{ main_question: { question: "How do I cancel?", expectedResults: "From settings." } }] })
+    );
+    expect(dataset.status, JSON.stringify(dataset.body)).toBeLessThan(300);
+
+    // A second project with its own trace, for the isolation cases below.
+    const other = await engine.json("/api/v1/projects", postJson({ name: "Other project" }));
+    expect(other.status).toBe(201);
+    otherKey = (other.body as { project: { apiKey: string } }).project.apiKey;
+    const otherTrace = await engine.json("/api/v1/ingest/traces", { ...postJson({ name: "other-agent", input: "secret q", output: "secret a" }), apiKey: otherKey });
+    expect(otherTrace.status).toBe(200);
+  }, 90_000);
+
+  afterAll(async () => {
+    await engine?.stop();
+  });
+
+  it("answers 401 with the protected-resource hint when no credential is sent", async () => {
+    const res = await rawToolsList(engine, {});
+    expect(res.status).toBe(401);
+    const challenge = res.headers.get("www-authenticate") ?? "";
+    expect(challenge).toMatch(/^Bearer /);
+    expect(challenge).toContain(`resource_metadata="${originOf(engine)}/.well-known/oauth-protected-resource/mcp"`);
+    await res.text();
+  });
+
+  it("rejects an unknown project key and an unknown OAuth token alike", async () => {
+    expect((await rawToolsList(engine, { Authorization: "Bearer agtx_local_nope" })).status).toBe(401);
+    expect((await rawToolsList(engine, { "x-api-key": "agtx_local_nope" })).status).toBe(401);
+    expect((await rawToolsList(engine, { Authorization: "Bearer agtx_mcp_at_nope" })).status).toBe(401);
+  });
+
+  it("only speaks POST (stateless transport)", async () => {
+    const res = await fetch(mcpUrl(engine));
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toBe("POST");
+    await res.text();
+  });
+
+  it("publishes RFC 9728 and RFC 8414 discovery documents", async () => {
+    const prm = (await (await fetch(`${originOf(engine)}/.well-known/oauth-protected-resource/mcp`)).json()) as Record<string, unknown>;
+    expect(prm).toMatchObject({ resource: `${originOf(engine)}/mcp`, authorization_servers: [`${originOf(engine)}/`], scopes_supported: ["mcp:read"] });
+    const as = (await (await fetch(`${originOf(engine)}/.well-known/oauth-authorization-server`)).json()) as Record<string, unknown>;
+    expect(as).toMatchObject({
+      issuer: `${originOf(engine)}/`,
+      authorization_endpoint: `${originOf(engine)}/authorize`,
+      token_endpoint: `${originOf(engine)}/token`,
+      registration_endpoint: `${originOf(engine)}/register`,
+      code_challenge_methods_supported: ["S256"],
+    });
+  });
+
+  it("lists every read tool, all annotated read-only, with a bearer project key", async () => {
+    const client = await keyClient(engine, engine.apiKey);
+    const { tools } = await client.listTools();
+    expect(tools.map(t => t.name).sort()).toEqual([...EXPECTED_TOOLS].sort());
+    for (const tool of tools) {
+      expect(tool.annotations?.readOnlyHint, `${tool.name} is not marked read-only`).toBe(true);
+      expect(tool.description, `${tool.name} has no description`).toBeTruthy();
+    }
+    await client.close();
+  });
+
+  it("accepts the key on x-api-key too, and whoami names the project and the credential kind", async () => {
+    const client = await keyClient(engine, engine.apiKey, "x-api-key");
+    const whoami = parsed<{ project: { name: string }; authMode: string; authenticatedWith: string }>(await client.callTool({ name: "agentx_whoami", arguments: {} }));
+    expect(whoami.project.name).toBe("Default");
+    expect(whoami.authMode).toBe("disabled");
+    expect(whoami.authenticatedWith).toBe("project API key");
+    await client.close();
+  });
+
+  it("lists and reads traces: clipped in the list, complete in the detail, not-found as a tool error", async () => {
+    const client = await keyClient(engine, engine.apiKey);
+    const list = parsed<{ traces: { _id: string; name: string; output: string }[]; totalCount: number }>(
+      await client.callTool({ name: "agentx_list_traces", arguments: { limit: 10 } })
+    );
+    expect(list.totalCount).toBeGreaterThanOrEqual(3);
+    const long = list.traces.find(t => t.output.includes("more chars"));
+    expect(long, "the 2000-char output should be clipped in the list").toBeDefined();
+    expect(long!.output.length).toBeLessThan(700);
+
+    const detail = parsed<{ _id: string; output: string; toolCalls?: unknown }>(await client.callTool({ name: "agentx_get_trace", arguments: { traceId: long!._id } }));
+    expect(detail._id).toBe(long!._id);
+    expect(detail.output).toBe("x".repeat(2000));
+
+    const missing = (await client.callTool({ name: "agentx_get_trace", arguments: { traceId: "does-not-exist" } })) as ToolResult;
+    expect(missing.isError).toBe(true);
+    expect(textOf(missing)).toContain("not found");
+    await client.close();
+  });
+
+  it("groups the session's turns and returns them in order", async () => {
+    const client = await keyClient(engine, engine.apiKey);
+    const sessions = parsed<{ sessions: { sessionId: string; turnCount: number }[] }>(await client.callTool({ name: "agentx_list_sessions", arguments: { window: "24h" } }));
+    const mine = sessions.sessions.find(s => s.sessionId === sessionId);
+    expect(mine?.turnCount).toBe(2);
+    const detail = parsed<{ spans: { input: string }[]; scores: unknown[] }>(await client.callTool({ name: "agentx_get_session", arguments: { sessionId } }));
+    expect(detail.spans.map(s => s.input)).toEqual(["first turn", "second turn"]);
+    expect(Array.isArray(detail.scores)).toBe(true);
+    await client.close();
+  });
+
+  it("covers the evaluate, monitor and insights surfaces without errors", async () => {
+    const client = await keyClient(engine, engine.apiKey);
+    const datasets = parsed<{ datasets: { _id: string; name: string; caseCount: number; questions?: unknown }[] }>(await client.callTool({ name: "agentx_list_datasets", arguments: {} }));
+    const dataset = datasets.datasets.find(d => d.name === "mcp dataset");
+    expect(dataset?.caseCount).toBe(1);
+    expect(dataset?.questions, "list view must not carry the cases").toBeUndefined();
+    const full = parsed<{ questions: unknown[] }>(await client.callTool({ name: "agentx_get_dataset", arguments: { datasetId: dataset!._id } }));
+    expect(full.questions).toHaveLength(1);
+
+    for (const [name, args] of [
+      ["agentx_get_kpis", { window: "7d" }],
+      ["agentx_list_signals", { limit: 5 }],
+      ["agentx_list_agents", {}],
+      ["agentx_list_topics", {}],
+      ["agentx_list_evaluations", { limit: 5 }],
+      ["agentx_list_prompts", {}],
+      ["agentx_list_tool_schemas", {}],
+      ["agentx_get_coverage", {}],
+      ["agentx_probe_coverage", { query: "how do I cancel my plan" }],
+    ] as const) {
+      const result = (await client.callTool({ name, arguments: args as Record<string, unknown> })) as ToolResult;
+      expect(result.isError, `${name}: ${textOf(result)}`).toBeFalsy();
+      expect(() => JSON.parse(textOf(result)), `${name} did not return JSON`).not.toThrow();
+    }
+    const agents = parsed<{ agents: { name: string }[] }>(await client.callTool({ name: "agentx_list_agents", arguments: {} }));
+    expect(agents.agents.map(a => a.name)).toContain("mcp-agent");
+    await client.close();
+  });
+
+  it("rejects arguments outside the schema at the protocol level", async () => {
+    const client = await keyClient(engine, engine.apiKey);
+    // The SDK surfaces schema failures as an error result (the server never ran the tool), so a
+    // model sees why its arguments were refused instead of a bare protocol failure.
+    const result = (await client.callTool({ name: "agentx_list_traces", arguments: { limit: 500 } })) as ToolResult;
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toMatch(/validation|Invalid arguments/i);
+    await client.close();
+  });
+
+  it("scopes everything to the key's project", async () => {
+    const client = await keyClient(engine, engine.apiKey);
+    const other = await keyClient(engine, otherKey);
+    const mine = parsed<{ traces: { _id: string; name: string }[] }>(await client.callTool({ name: "agentx_list_traces", arguments: {} }));
+    const theirs = parsed<{ traces: { _id: string; name: string }[] }>(await other.callTool({ name: "agentx_list_traces", arguments: {} }));
+    expect(theirs.traces.map(t => t.name)).toEqual(["other-agent"]);
+    expect(mine.traces.map(t => t.name)).not.toContain("other-agent");
+    const crossRead = (await client.callTool({ name: "agentx_get_trace", arguments: { traceId: theirs.traces[0]!._id } })) as ToolResult;
+    expect(crossRead.isError).toBe(true);
+    const whoami = parsed<{ project: { name: string } }>(await other.callTool({ name: "agentx_whoami", arguments: {} }));
+    expect(whoami.project.name).toBe("Other project");
+    await client.close();
+    await other.close();
+  });
+
+  it("registers a client, renders the consent page, and mints tokens that reach the tools", async () => {
+    const { provider, client } = await grantWithKey(engine, engine.apiKey);
+    expect(provider.toks?.access_token).toMatch(/^agtx_mcp_at_/);
+    expect(provider.toks?.refresh_token).toMatch(/^agtx_mcp_rt_/);
+    expect(provider.toks?.scope).toBe("mcp:read");
+    const whoami = parsed<{ project: { name: string }; authenticatedWith: string }>(await client.callTool({ name: "agentx_whoami", arguments: {} }));
+    expect(whoami.project.name).toBe("Default");
+    expect(whoami.authenticatedWith).toBe("OAuth access token");
+    await client.close();
+  });
+
+  it("renders a locked-down consent page in disabled mode", async () => {
+    const { provider } = await beginOAuth(engine);
+    const page = await consentPage(engine, provider.authorizationUrl!);
+    expect(page.status).toBe(200);
+    expect(page.html).toContain('name="api_key"');
+    expect(page.html).toContain("Test connector");
+    expect(page.html).toContain("frame-ancestors 'none'");
+    expect(page.html).not.toContain(engine.apiKey);
+    expect(page.form.get("client_id")).toBe(provider.info!.client_id);
+    expect(page.form.get("sig")).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("refuses a wrong key, honours a denial, and rejects a tampered bundle", async () => {
+    const { provider } = await beginOAuth(engine);
+    const { form } = await consentPage(engine, provider.authorizationUrl!);
+
+    const wrongKey = await decide(engine, form, { action: "approve", api_key: "agtx_local_wrong" });
+    expect(wrongKey.status).toBe(401);
+    expect(wrongKey.body).toContain("not recognized");
+
+    const denied = await decide(engine, form, { action: "deny", api_key: engine.apiKey });
+    expect(denied.status).toBe(302);
+    expect(new URL(denied.location!).searchParams.get("error")).toBe("access_denied");
+
+    const tampered = await decide(engine, form, { action: "approve", api_key: engine.apiKey, scope: "mcp:write" });
+    expect(tampered.status).toBe(400);
+
+    const malformed = await decide(engine, form, { action: "approve", api_key: engine.apiKey, sig: "zzz" });
+    expect(malformed.status).toBe(400);
+  });
+
+  it("makes codes single-use and verifies PKCE", async () => {
+    const { provider, code } = await grantWithKey(engine, engine.apiKey);
+    const replay = await tokenRequest(engine, {
+      grant_type: "authorization_code",
+      code,
+      code_verifier: provider.verifier,
+      client_id: provider.info!.client_id,
+      redirect_uri: provider.redirectUrl,
+    });
+    expect(replay.status).toBe(400);
+    expect(replay.body.error).toBe("invalid_grant");
+
+    // A fresh code with the wrong verifier: the PKCE check must fail before any token exists.
+    const second = await beginOAuth(engine);
+    const page = await consentPage(engine, second.provider.authorizationUrl!);
+    const decision = await decide(engine, page.form, { action: "approve", api_key: engine.apiKey });
+    const freshCode = new URL(decision.location!).searchParams.get("code")!;
+    const badVerifier = await tokenRequest(engine, {
+      grant_type: "authorization_code",
+      code: freshCode,
+      code_verifier: "not-the-verifier-not-the-verifier-not-the-verifier",
+      client_id: second.provider.info!.client_id,
+      redirect_uri: second.provider.redirectUrl,
+    });
+    expect(badVerifier.status).toBe(400);
+    expect(badVerifier.body.error).toBe("invalid_grant");
+  });
+
+  it("rotates on refresh, lists the grant, and revokes it end to end", async () => {
+    const { provider } = await grantWithKey(engine, engine.apiKey);
+    const oldAccess = provider.toks!.access_token;
+
+    const refreshed = await tokenRequest(engine, { grant_type: "refresh_token", refresh_token: provider.toks!.refresh_token!, client_id: provider.info!.client_id });
+    expect(refreshed.status).toBe(200);
+    const newAccess = refreshed.body.access_token as string;
+    expect(newAccess).not.toBe(oldAccess);
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${oldAccess}` })).status).toBe(401);
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${newAccess}` })).status).toBe(200);
+
+    // The used refresh token is dead too.
+    const reuse = await tokenRequest(engine, { grant_type: "refresh_token", refresh_token: provider.toks!.refresh_token!, client_id: provider.info!.client_id });
+    expect(reuse.status).toBe(400);
+
+    const grants = await engine.json("/api/v1/mcp/grants");
+    expect(grants.status).toBe(200);
+    const contract = mcpGrantsResponseSchema.safeParse(grants.body);
+    expect(contract.success, JSON.stringify(contract.success ? null : contract.error.issues)).toBe(true);
+    const mine = (grants.body as { grants: { grantId: string; clientId: string; clientName: string }[] }).grants.find(g => g.clientId === provider.info!.client_id);
+    expect(mine?.clientName).toBe("Test connector");
+
+    // The other project sees none of this.
+    const otherGrants = await engine.json("/api/v1/mcp/grants", { apiKey: otherKey });
+    expect((otherGrants.body as { grants: unknown[] }).grants).toEqual([]);
+
+    const revoked = await engine.request(`/api/v1/mcp/grants/${mine!.grantId}`, { method: "DELETE" });
+    expect(revoked.status).toBe(204);
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${newAccess}` })).status).toBe(401);
+    const after = await engine.json("/api/v1/mcp/grants");
+    expect((after.body as { grants: { grantId: string }[] }).grants.some(g => g.grantId === mine!.grantId)).toBe(false);
+  });
+
+  it("supports RFC 7009 revocation from the client side", async () => {
+    const { provider } = await grantWithKey(engine, engine.apiKey);
+    const res = await fetch(`${originOf(engine)}/revoke`, {
+      method: "POST",
+      body: new URLSearchParams({ token: provider.toks!.refresh_token!, client_id: provider.info!.client_id }),
+    });
+    expect(res.status).toBe(200);
+    await res.text();
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${provider.toks!.access_token}` })).status).toBe(401);
+  });
+
+  it("revokes every grant when the project API key is regenerated", async () => {
+    const { provider } = await grantWithKey(engine, otherKey);
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${provider.toks!.access_token}` })).status).toBe(200);
+    const regenerated = await engine.json("/api/v1/agent-monitoring/settings/api-key/regenerate", { method: "POST", apiKey: otherKey });
+    expect(regenerated.status).toBe(200);
+    const newKey = (regenerated.body as { apiKey: string }).apiKey;
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${provider.toks!.access_token}` })).status).toBe(401);
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${newKey}` })).status).toBe(200);
+    const grants = await engine.json("/api/v1/mcp/grants", { apiKey: newKey });
+    expect((grants.body as { grants: unknown[] }).grants).toEqual([]);
+    otherKey = newKey;
+  });
+
+  it("refuses to register a client with a redirect outside the allow-list", async () => {
+    const res = await fetch(`${originOf(engine)}/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ client_name: "evil", redirect_uris: ["https://evil.example.com/cb"], token_endpoint_auth_method: "none" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("invalid_client_metadata");
+    expect(body.error_description).toContain("evil.example.com");
+
+    const claude = await fetch(`${originOf(engine)}/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ client_name: "Claude", redirect_uris: ["https://claude.ai/api/mcp/auth_callback"], token_endpoint_auth_method: "none" }),
+    });
+    expect(claude.status).toBe(201);
+    await claude.text();
+  });
+
+  it("binds the grant to this server's resource identifier", async () => {
+    const { provider } = await beginOAuth(engine);
+    const url = new URL(provider.authorizationUrl!);
+    url.searchParams.set("resource", "https://some-other-server.example.com/mcp");
+    const res = await fetch(url, { redirect: "manual" });
+    expect(res.status).toBe(302);
+    expect(new URL(res.headers.get("location")!).searchParams.get("error")).toBe("invalid_target");
+    await res.text();
+  });
+});
+
+describe("MCP OAuth, AGENTX_AUTH=enabled", () => {
+  let engine: TestEngine;
+  let ownerCookie = "";
+  let strangerCookie = "";
+  let defaultProject: { _id: string; apiKey: string };
+  let secondProject: { _id: string; apiKey: string };
+
+  function cookieHeader(res: Response): string {
+    return (res.headers.getSetCookie?.() ?? []).map(c => c.split(";")[0]).join("; ");
+  }
+
+  beforeAll(async () => {
+    engine = await startEngine({ AGENTX_AUTH: "enabled" });
+    const owner = await engine.request("/api/v1/auth/sign-up/email", { ...postJson({ email: "owner@example.com", password: "correct-horse-battery", name: "Owner" }), apiKey: null });
+    expect(owner.status).toBeLessThan(300);
+    ownerCookie = cookieHeader(owner);
+    await owner.text();
+    const stranger = await engine.request("/api/v1/auth/sign-up/email", { ...postJson({ email: "stranger@example.com", password: "correct-horse-battery", name: "Stranger" }), apiKey: null });
+    expect(stranger.status).toBeLessThan(300);
+    strangerCookie = cookieHeader(stranger);
+    await stranger.text();
+
+    const projects = await engine.json("/api/v1/projects", { apiKey: null, headers: { cookie: ownerCookie } });
+    defaultProject = (projects.body as { projects: { _id: string; apiKey: string; name: string }[] }).projects.find(p => p.name === "Default")!;
+    const created = await engine.json("/api/v1/projects", { ...postJson({ name: "Team project" }), apiKey: null, headers: { cookie: ownerCookie, "content-type": "application/json" } });
+    expect(created.status).toBe(201);
+    secondProject = (created.body as { project: { _id: string; apiKey: string } }).project;
+    const trace = await engine.json("/api/v1/ingest/traces", { ...postJson({ name: "team-agent", input: "q", output: "a" }), apiKey: secondProject.apiKey });
+    expect(trace.status).toBe(200);
+  }, 90_000);
+
+  afterAll(async () => {
+    await engine?.stop();
+  });
+
+  it("still takes a bearer project key on /mcp", async () => {
+    const client = await keyClient(engine, secondProject.apiKey);
+    const whoami = parsed<{ project: { name: string }; organizationId: string | null }>(await client.callTool({ name: "agentx_whoami", arguments: {} }));
+    expect(whoami.project.name).toBe("Team project");
+    expect(whoami.organizationId).toBeTruthy();
+    await client.close();
+  });
+
+  it("asks for a dashboard sign-in before showing the project picker", async () => {
+    const { provider } = await beginOAuth(engine);
+    const anonymous = await consentPage(engine, provider.authorizationUrl!);
+    expect(anonymous.status).toBe(200);
+    expect(anonymous.html).toContain('id="signin"');
+    expect(anonymous.html).not.toContain('name="project_id"');
+    expect(anonymous.html).not.toContain('name="api_key"');
+
+    const signedIn = await consentPage(engine, provider.authorizationUrl!, ownerCookie);
+    expect(signedIn.status).toBe(200);
+    expect(signedIn.html).toContain("owner@example.com");
+    expect(signedIn.html).toContain(`value="${secondProject._id}"`);
+    expect(signedIn.html).toContain(`value="${defaultProject._id}"`);
+
+    // A valid signed form replayed without the session behind it approves nothing.
+    const blind = await decide(engine, signedIn.form, { action: "approve", project_id: secondProject._id });
+    expect(blind.status).toBe(401);
+    expect(blind.location).toBeNull();
+  });
+
+  it("grants the picked project to the signed-in member and scopes the token to it", async () => {
+    const { provider, transport } = await beginOAuth(engine);
+    const page = await consentPage(engine, provider.authorizationUrl!, ownerCookie);
+    const decision = await decide(engine, page.form, { action: "approve", project_id: secondProject._id }, ownerCookie);
+    expect(decision.status, decision.body).toBe(302);
+    const code = new URL(decision.location!).searchParams.get("code")!;
+    await transport.finishAuth(code);
+
+    const client = new Client({ name: "mcp-test-oauth", version: "0" });
+    await client.connect(new StreamableHTTPClientTransport(mcpUrl(engine), { authProvider: provider }));
+    const whoami = parsed<{ project: { name: string }; authenticatedWith: string; organizationId: string | null }>(await client.callTool({ name: "agentx_whoami", arguments: {} }));
+    expect(whoami.project.name).toBe("Team project");
+    expect(whoami.authenticatedWith).toBe("OAuth access token");
+    expect(whoami.organizationId).toBeTruthy();
+    const traces = parsed<{ traces: { name: string }[] }>(await client.callTool({ name: "agentx_list_traces", arguments: {} }));
+    expect(traces.traces.map(t => t.name)).toEqual(["team-agent"]);
+    await client.close();
+
+    // The grant is visible to the project's key holder and records who approved it.
+    const grants = await engine.json("/api/v1/mcp/grants", { apiKey: secondProject.apiKey });
+    const mine = (grants.body as { grants: { clientId: string; userId: string | null }[] }).grants.find(g => g.clientId === provider.info!.client_id);
+    expect(mine?.userId).toBeTruthy();
+  });
+
+  it("refuses a signed-in user who is not a member of the project's organization", async () => {
+    const { provider } = await beginOAuth(engine);
+    const page = await consentPage(engine, provider.authorizationUrl!, strangerCookie);
+    expect(page.html).toContain("no projects to grant");
+    const decision = await decide(engine, page.form, { action: "approve", project_id: secondProject._id }, strangerCookie);
+    expect(decision.status).toBe(403);
+    expect(decision.location).toBeNull();
+  });
+});
+
+// The three mcp_oauth_* tables have a hand-written Postgres DDL twin (storage/db.ts); this
+// exercises every column of it through the same flow, not just CREATE TABLE. Opt-in like every
+// Postgres suite (AGENTX_TEST_DB_URL).
+describe.skipIf(!postgresAvailable)("MCP on Postgres", () => {
+  let engine: TestEngine;
+
+  beforeAll(async () => {
+    engine = await startEngine({}, { postgres: true });
+    const res = await engine.json("/api/v1/ingest/traces", postJson({ name: "pg-agent", input: "q", output: "a" }));
+    expect(res.status).toBe(200);
+  }, 90_000);
+
+  afterAll(async () => {
+    await engine?.stop();
+  });
+
+  it("runs the key path and the whole OAuth grant lifecycle on Postgres", async () => {
+    const keyed = await keyClient(engine, engine.apiKey);
+    const traces = parsed<{ traces: { name: string }[] }>(await keyed.callTool({ name: "agentx_list_traces", arguments: {} }));
+    expect(traces.traces.map(t => t.name)).toContain("pg-agent");
+    await keyed.close();
+
+    const { provider, client, code } = await grantWithKey(engine, engine.apiKey);
+    const whoami = parsed<{ authenticatedWith: string }>(await client.callTool({ name: "agentx_whoami", arguments: {} }));
+    expect(whoami.authenticatedWith).toBe("OAuth access token");
+    await client.close();
+
+    const replay = await tokenRequest(engine, { grant_type: "authorization_code", code, code_verifier: provider.verifier, client_id: provider.info!.client_id, redirect_uri: provider.redirectUrl });
+    expect(replay.status).toBe(400);
+
+    const refreshed = await tokenRequest(engine, { grant_type: "refresh_token", refresh_token: provider.toks!.refresh_token!, client_id: provider.info!.client_id });
+    expect(refreshed.status).toBe(200);
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${provider.toks!.access_token}` })).status).toBe(401);
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${refreshed.body.access_token as string}` })).status).toBe(200);
+
+    const grants = await engine.json("/api/v1/mcp/grants");
+    expect(mcpGrantsResponseSchema.safeParse(grants.body).success).toBe(true);
+    const grant = (grants.body as { grants: { grantId: string; clientName: string }[] }).grants[0]!;
+    expect(grant.clientName).toBe("Test connector");
+    expect((await engine.request(`/api/v1/mcp/grants/${grant.grantId}`, { method: "DELETE" })).status).toBe(204);
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${refreshed.body.access_token as string}` })).status).toBe(401);
+  });
+});

--- a/engine/src/test/mcp.integration.test.ts
+++ b/engine/src/test/mcp.integration.test.ts
@@ -177,13 +177,17 @@ const EXPECTED_TOOLS = [
   "agentx_probe_coverage",
 ];
 
+const ROTATION_GRACE_MS = 1500;
+
 describe("MCP endpoint, AGENTX_AUTH=disabled", () => {
   let engine: TestEngine;
   let otherKey = "";
   let sessionId = "";
 
   beforeAll(async () => {
-    engine = await startEngine();
+    // A short rotation grace window (default 60s) so the reuse-after-grace path below runs in
+    // test time; everything else is the production configuration.
+    engine = await startEngine({ AGENTX_MCP_REFRESH_GRACE_MS: String(ROTATION_GRACE_MS) });
     sessionId = `mcp-session-${Date.now()}`;
     for (const turn of ["first turn", "second turn"]) {
       const res = await engine.json("/api/v1/ingest/traces", postJson({ name: "mcp-agent", input: turn, output: `answer to ${turn}`, session_id: sessionId }));
@@ -367,6 +371,9 @@ describe("MCP endpoint, AGENTX_AUTH=disabled", () => {
     expect(page.html).toContain('name="api_key"');
     expect(page.html).toContain("Test connector");
     expect(page.html).toContain("frame-ancestors 'none'");
+    // Chromium applies form-action to the redirect that follows the submit, so the client's
+    // callback origin must be listed or the approval never leaves the consent page.
+    expect(page.html).toContain(`form-action 'self' ${new URL(provider.redirectUrl).origin};`);
     expect(page.html).not.toContain(engine.apiKey);
     expect(page.form.get("client_id")).toBe(provider.info!.client_id);
     expect(page.form.get("sig")).toMatch(/^[a-f0-9]{64}$/);
@@ -417,6 +424,18 @@ describe("MCP endpoint, AGENTX_AUTH=disabled", () => {
     });
     expect(badVerifier.status).toBe(400);
     expect(badVerifier.body.error).toBe("invalid_grant");
+
+    // ...and burned the code: the right verifier no longer helps, so a stolen code cannot be
+    // brute-forced against its challenge for the rest of its lifetime.
+    const rightVerifierTooLate = await tokenRequest(engine, {
+      grant_type: "authorization_code",
+      code: freshCode,
+      code_verifier: second.provider.verifier,
+      client_id: second.provider.info!.client_id,
+      redirect_uri: second.provider.redirectUrl,
+    });
+    expect(rightVerifierTooLate.status).toBe(400);
+    expect(rightVerifierTooLate.body.error).toBe("invalid_grant");
   });
 
   it("rotates on refresh, lists the grant, and revokes it end to end", async () => {
@@ -425,14 +444,20 @@ describe("MCP endpoint, AGENTX_AUTH=disabled", () => {
 
     const refreshed = await tokenRequest(engine, { grant_type: "refresh_token", refresh_token: provider.toks!.refresh_token!, client_id: provider.info!.client_id });
     expect(refreshed.status).toBe(200);
+    expect(refreshed.body.scope).toBe("mcp:read");
     const newAccess = refreshed.body.access_token as string;
     expect(newAccess).not.toBe(oldAccess);
     expect((await rawToolsList(engine, { Authorization: `Bearer ${oldAccess}` })).status).toBe(401);
     expect((await rawToolsList(engine, { Authorization: `Bearer ${newAccess}` })).status).toBe(200);
 
-    // The used refresh token is dead too.
-    const reuse = await tokenRequest(engine, { grant_type: "refresh_token", refresh_token: provider.toks!.refresh_token!, client_id: provider.info!.client_id });
-    expect(reuse.status).toBe(400);
+    // Presenting the rotated-out token again inside the grace window is a retry (two
+    // conversations refreshing at once), not an attack: it gets a pair of its own and the first
+    // successor keeps working.
+    const retry = await tokenRequest(engine, { grant_type: "refresh_token", refresh_token: provider.toks!.refresh_token!, client_id: provider.info!.client_id });
+    expect(retry.status, JSON.stringify(retry.body)).toBe(200);
+    expect(retry.body.access_token).not.toBe(newAccess);
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${newAccess}` })).status).toBe(200);
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${retry.body.access_token as string}` })).status).toBe(200);
 
     const grants = await engine.json("/api/v1/mcp/grants");
     expect(grants.status).toBe(200);
@@ -450,6 +475,38 @@ describe("MCP endpoint, AGENTX_AUTH=disabled", () => {
     expect((await rawToolsList(engine, { Authorization: `Bearer ${newAccess}` })).status).toBe(401);
     const after = await engine.json("/api/v1/mcp/grants");
     expect((after.body as { grants: { grantId: string }[] }).grants.some(g => g.grantId === mine!.grantId)).toBe(false);
+  });
+
+  it("treats a refresh token reused after the grace window as theft and revokes the grant", async () => {
+    const { provider } = await grantWithKey(engine, engine.apiKey);
+    const original = provider.toks!.refresh_token!;
+    const first = await tokenRequest(engine, { grant_type: "refresh_token", refresh_token: original, client_id: provider.info!.client_id });
+    expect(first.status).toBe(200);
+    const liveAccess = first.body.access_token as string;
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${liveAccess}` })).status).toBe(200);
+
+    await new Promise(resolve => setTimeout(resolve, ROTATION_GRACE_MS + 200));
+    const reuse = await tokenRequest(engine, { grant_type: "refresh_token", refresh_token: original, client_id: provider.info!.client_id });
+    expect(reuse.status).toBe(400);
+    expect(reuse.body.error).toBe("invalid_grant");
+    // OAuth 2.1 section 4.3.1: the whole grant goes, successor tokens included.
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${liveAccess}` })).status).toBe(401);
+    const successor = await tokenRequest(engine, { grant_type: "refresh_token", refresh_token: first.body.refresh_token as string, client_id: provider.info!.client_id });
+    expect(successor.status).toBe(400);
+  });
+
+  it("survives two concurrent refreshes of the same token", async () => {
+    const { provider } = await grantWithKey(engine, engine.apiKey);
+    const params = { grant_type: "refresh_token", refresh_token: provider.toks!.refresh_token!, client_id: provider.info!.client_id };
+    const [a, b] = await Promise.all([tokenRequest(engine, params), tokenRequest(engine, params)]);
+    expect([a.status, b.status], JSON.stringify([a.body, b.body])).toEqual([200, 200]);
+    for (const result of [a, b]) {
+      expect((await rawToolsList(engine, { Authorization: `Bearer ${result.body.access_token as string}` })).status).toBe(200);
+    }
+    // One grant, not two: the connected-apps list still shows a single entry for this client.
+    const grants = await engine.json("/api/v1/mcp/grants");
+    const mine = (grants.body as { grants: { clientId: string }[] }).grants.filter(g => g.clientId === provider.info!.client_id);
+    expect(mine).toHaveLength(1);
   });
 
   it("supports RFC 7009 revocation from the client side", async () => {
@@ -632,6 +689,46 @@ describe("MCP OAuth, AGENTX_AUTH=enabled", () => {
     const decision = await decide(engine, page.form, { action: "approve", project_id: secondProject._id }, strangerCookie);
     expect(decision.status).toBe(403);
     expect(decision.location).toBeNull();
+  });
+
+  it("cuts a member's grant off when they are removed from the organization", async () => {
+    const orgs = await engine.json("/api/v1/auth-org/organizations", { apiKey: null, headers: { cookie: ownerCookie } });
+    const orgId = (orgs.body as { organizations: { _id: string }[] }).organizations[0]!._id;
+    const invited = await engine.json(`/api/v1/auth-org/organizations/${orgId}/invitations`, {
+      ...postJson({ email: "stranger@example.com", role: "member" }),
+      apiKey: null,
+      headers: { cookie: ownerCookie, "content-type": "application/json" },
+    });
+    expect(invited.status, JSON.stringify(invited.body)).toBe(201);
+    const invitationId = (invited.body as { invitation: { _id: string } }).invitation._id;
+    const accepted = await engine.json(`/api/v1/auth-org/invitations/${invitationId}/accept`, { method: "POST", apiKey: null, headers: { cookie: strangerCookie } });
+    expect(accepted.status, JSON.stringify(accepted.body)).toBe(200);
+
+    // Now a member: the grant goes through and the token works.
+    const { provider, transport } = await beginOAuth(engine);
+    const page = await consentPage(engine, provider.authorizationUrl!, strangerCookie);
+    const decision = await decide(engine, page.form, { action: "approve", project_id: secondProject._id }, strangerCookie);
+    expect(decision.status, decision.body).toBe(302);
+    await transport.finishAuth(new URL(decision.location!).searchParams.get("code")!);
+    const client = new Client({ name: "mcp-test-oauth", version: "0" });
+    await client.connect(new StreamableHTTPClientTransport(mcpUrl(engine), { authProvider: provider }));
+    await client.close();
+    const access = provider.toks!.access_token;
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${access}` })).status).toBe(200);
+
+    // Removed from the org: the still-unexpired access token and the refresh chain both die on
+    // their next use, not at the 30-day mark.
+    const members = await engine.json(`/api/v1/auth-org/organizations/${orgId}/members`, { apiKey: null, headers: { cookie: ownerCookie } });
+    const membership = (members.body as { members: { _id: string; email: string }[] }).members.find(m => m.email === "stranger@example.com");
+    expect(membership).toBeDefined();
+    const removed = await engine.request(`/api/v1/auth-org/organizations/${orgId}/members/${membership!._id}`, { method: "DELETE", apiKey: null, headers: { cookie: ownerCookie } });
+    expect(removed.status).toBe(200);
+    expect((await rawToolsList(engine, { Authorization: `Bearer ${access}` })).status).toBe(401);
+    const refresh = await tokenRequest(engine, { grant_type: "refresh_token", refresh_token: provider.toks!.refresh_token!, client_id: provider.info!.client_id });
+    expect(refresh.status).toBe(400);
+    expect(refresh.body.error).toBe("invalid_grant");
+    const grants = await engine.json("/api/v1/mcp/grants", { apiKey: secondProject.apiKey });
+    expect((grants.body as { grants: { clientId: string }[] }).grants.some(g => g.clientId === provider.info!.client_id)).toBe(false);
   });
 });
 

--- a/engine/src/test/mcp.integration.test.ts
+++ b/engine/src/test/mcp.integration.test.ts
@@ -228,6 +228,56 @@ describe("MCP endpoint, AGENTX_AUTH=disabled", () => {
     expect((await rawToolsList(engine, { Authorization: "Bearer agtx_mcp_at_nope" })).status).toBe(401);
   });
 
+  it("serves clients whatever Accept header they send, streaming only when asked", async () => {
+    // A connector that sends `*/*` (or nothing) used to be refused at the handshake with a 406
+    // it never surfaced, so it registered no tools at all and the model improvised around it.
+    const init = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "accept-probe", version: "0" } },
+    };
+    const handshake = (accept: string) =>
+      fetch(mcpUrl(engine), {
+        method: "POST",
+        headers: { "content-type": "application/json", accept, authorization: `Bearer ${engine.apiKey}` },
+        body: JSON.stringify(init),
+      });
+
+    // Spec-compliant client: an event stream, exactly as before.
+    const both = await handshake("application/json, text/event-stream");
+    expect(both.status).toBe(200);
+    expect(both.headers.get("content-type")).toContain("text/event-stream");
+    expect(await both.text()).toContain("event: message");
+
+    // Wildcard and JSON-only clients: a single JSON body they can actually parse.
+    for (const accept of ["*/*", "application/json", "application/*", "application/json;q=1, */*;q=0.1"]) {
+      const res = await handshake(accept);
+      expect(res.status, `Accept: ${accept}`).toBe(200);
+      expect(res.headers.get("content-type"), `Accept: ${accept}`).toContain("application/json");
+      const body = (await res.json()) as { result?: { serverInfo?: { name?: string } } };
+      expect(body.result?.serverInfo?.name, `Accept: ${accept}`).toBe("agentx-self-host");
+    }
+
+    // A client that named the stream type alone still gets the stream.
+    const streamOnly = await handshake("text/event-stream");
+    expect(streamOnly.status).toBe(200);
+    expect(streamOnly.headers.get("content-type")).toContain("text/event-stream");
+
+    // Nothing we can serve, and nothing to guess at: the 406 stands.
+    const unusable = await handshake("text/plain");
+    expect(unusable.status).toBe(406);
+
+    // And the negotiated JSON path carries real tool results, not just the handshake.
+    const tools = await fetch(mcpUrl(engine), {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "*/*", authorization: `Bearer ${engine.apiKey}` },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+    });
+    const listed = (await tools.json()) as { result: { tools: { name: string }[] } };
+    expect(listed.result.tools.map(t => t.name).sort()).toEqual([...EXPECTED_TOOLS].sort());
+  });
+
   it("only speaks POST (stateless transport)", async () => {
     const res = await fetch(mcpUrl(engine));
     expect(res.status).toBe(405);

--- a/engine/src/test/mcpConfig.test.ts
+++ b/engine/src/test/mcpConfig.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mcpIssuerUrl, mcpOauthAvailable, redirectUriAllowed, resourceMatches } from "../core/mcp/config.js";
+
+// The env-driven decisions in core/mcp/config.ts, pinned because two of them gate whether the
+// OAuth router mounts at all and which redirect URIs an unauthenticated /register may claim.
+
+describe("MCP config", () => {
+  const saved = { publicUrl: process.env.AGENTX_PUBLIC_URL, allowlist: process.env.AGENTX_MCP_REDIRECT_ALLOWLIST };
+  afterEach(() => {
+    if (saved.publicUrl === undefined) delete process.env.AGENTX_PUBLIC_URL;
+    else process.env.AGENTX_PUBLIC_URL = saved.publicUrl;
+    if (saved.allowlist === undefined) delete process.env.AGENTX_MCP_REDIRECT_ALLOWLIST;
+    else process.env.AGENTX_MCP_REDIRECT_ALLOWLIST = saved.allowlist;
+  });
+
+  it("offers OAuth exactly where the SDK's issuer check would accept it", () => {
+    expect(mcpOauthAvailable(new URL("https://agentx.example.com/"))).toBe(true);
+    expect(mcpOauthAvailable(new URL("http://localhost:3000/"))).toBe(true);
+    expect(mcpOauthAvailable(new URL("http://127.0.0.1:3000/"))).toBe(true);
+    // The SDK's checkIssuerUrl does not exempt IPv6 loopback; accepting it here would crash boot.
+    expect(mcpOauthAvailable(new URL("http://[::1]:3000/"))).toBe(false);
+    expect(mcpOauthAvailable(new URL("http://agentx.internal:3000/"))).toBe(false);
+  });
+
+  it("derives the issuer from AGENTX_PUBLIC_URL's origin, else loopback on the port", () => {
+    delete process.env.AGENTX_PUBLIC_URL;
+    expect(mcpIssuerUrl(4321).href).toBe("http://localhost:4321/");
+    process.env.AGENTX_PUBLIC_URL = "https://agentx.example.com/some/path?x=1";
+    expect(mcpIssuerUrl(4321).href).toBe("https://agentx.example.com/");
+  });
+
+  it("matches the resource identifier on origin and path only", () => {
+    const canonical = new URL("https://agentx.example.com/mcp");
+    expect(resourceMatches("https://agentx.example.com/mcp/", canonical)).toBe(true);
+    expect(resourceMatches("HTTPS://AGENTX.EXAMPLE.COM/mcp", canonical)).toBe(true);
+    expect(resourceMatches(null, canonical)).toBe(true);
+    expect(resourceMatches("https://agentx.example.com/mcp?x=1", canonical)).toBe(false);
+    expect(resourceMatches("https://other.example.com/mcp", canonical)).toBe(false);
+    expect(resourceMatches("not a url", canonical)).toBe(false);
+  });
+
+  it("allows claude.ai, loopback on any port, and operator entries; nothing else", () => {
+    delete process.env.AGENTX_MCP_REDIRECT_ALLOWLIST;
+    expect(redirectUriAllowed("https://claude.ai/api/mcp/auth_callback")).toBe(true);
+    expect(redirectUriAllowed("http://localhost:51234/callback")).toBe(true);
+    expect(redirectUriAllowed("http://127.0.0.1:51234/callback")).toBe(true);
+    expect(redirectUriAllowed("https://claude.ai/api/mcp/auth_callback#frag")).toBe(false);
+    expect(redirectUriAllowed("https://claude.ai.evil.example/api/mcp/auth_callback")).toBe(false);
+    expect(redirectUriAllowed("https://localhost.evil.example/callback")).toBe(false);
+    expect(redirectUriAllowed("https://evil.example/callback")).toBe(false);
+    process.env.AGENTX_MCP_REDIRECT_ALLOWLIST = "https://ide.example.com/oauth/*, https://exact.example.com/cb";
+    expect(redirectUriAllowed("https://ide.example.com/oauth/callback")).toBe(true);
+    expect(redirectUriAllowed("https://exact.example.com/cb")).toBe(true);
+    expect(redirectUriAllowed("https://exact.example.com/cb2")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The engine becomes a remote MCP server so Claude (claude.ai connectors, Claude Code, the Agent SDK) can talk to a self-hosted instance's data. The design is in `docs/self-hosted-mcp-plan.md`; this PR ships its Phase 1 and Phase 2.

**Endpoint.** `POST /mcp`, Streamable HTTP in stateless mode (no session table, any replica answers any request). Nineteen read-only `agentx_*` tools mirroring the hosted connector's names: traces, sessions, KPIs, signals, agents, topics, datasets, evaluation runs, prompts, tool schemas, coverage, probe. Each is a thin adapter over the same project-scoped core function the matching dashboard route calls, with list views clipping long payloads. Every call lands in the audit trail as `mcp.tool_call`.

**Authorization: the self-host has no accounts by default, so what does the MCP accept?**

- A bearer project API key (or `x-api-key`) for anything running locally: Claude Code (`--header`), `mcp-remote` for Claude Desktop/Cursor, the Agent SDK, CI.
- OAuth 2.1 for claude.ai, which can only do OAuth. The engine is its own authorization server on top of the MCP SDK's `mcpAuthRouter`: RFC 9728 protected-resource metadata, RFC 8414 discovery, dynamic client registration restricted to an allow-list (claude.ai's callback, loopback, `AGENTX_MCP_REDIRECT_ALLOWLIST`), PKCE, single-use 10-minute codes, opaque tokens hashed at rest (1h access, 30d refresh, rotated on use), RFC 7009 revocation, and audience binding to `<AGENTX_PUBLIC_URL>/mcp`. An access token is a short-lived stand-in for a project API key.
- The server-rendered consent page follows the instance's auth mode: `AGENTX_AUTH=enabled` asks for a dashboard sign-in and a project pick; disabled mode asks for the project API key (same trust posture as the rest of that mode, which is what lets a laptop connect to claude.ai through a tunnel).

**Housekeeping.** Regenerating a project key revokes every grant on it. Grants are listed and revoked at `GET/DELETE /api/v1/mcp/grants` (under wire contract). The issuer defaults to `http://localhost:<port>` when `AGENTX_PUBLIC_URL` is unset (loopback is spec-legal and lets Claude Code run the real flow locally); a non-loopback `http://` public URL disables OAuth with a boot warning while the key path keeps working. `AGENTX_MCP=disabled` turns the whole surface off.

**Hardening pass (after code + security review).** Authorization codes are claimed atomically (`DELETE ... RETURNING`) and PKCE is verified by the engine after the claim, so a wrong verifier burns the code. Refresh rotation writes the new pair before retiring the old; a rotated-out token reused within a 60s grace window is a retry (another pair, same grant), reused later it is theft (whole grant revoked). A scope-narrowed refresh narrows only the access token. A dashboard user's grant is re-checked against their organization membership on every refresh and token verification. The consent page CSP lists the client callback origin in `form-action` (Chromium applies it to the post-submit redirect). `http://[::1]` no longer mounts OAuth (the SDK's issuer check would crash boot); the consent limiter honours `AGENTX_RATE_LIMIT=off`.

Rejected alternatives (authless flag, `@better-auth/mcp`, delegating to the customer's IdP) and the Phase 3 roadmap (write tools behind `mcp:write`, dashboard "connected apps" card, `agentx mcp` stdio proxy) are in the plan doc.

## Changes

- `engine/src/routes/mcp.ts`: `/mcp` route, `requireMcpAuth`, OAuth router mount, consent decision route, grants router.
- `engine/src/core/mcp/`: `config.ts` (issuer/resource/allow-list), `oauthStore.ts` (clients/codes/tokens, both dialects), `oauthProvider.ts` (`OAuthServerProvider` + consent flow), `authorizePage.ts` (CSP-locked server-rendered page), `tools.ts`, `server.ts`.
- `engine/src/storage/`: `mcp_oauth_clients`, `mcp_oauth_codes`, `mcp_oauth_tokens` (with `rotated_at`) in both schemas and both bootstraps.
- `engine/src/contract/wire.ts`: `McpGrantsResponse`.
- `engine/src/routes/agentMonitoringDashboard.ts`: key regeneration revokes grants. `apiV1.ts`, `index.ts`: mounts. `auditLog.ts`: `mcp-token` actor type. `auth/rateLimit.ts`: exported kill-switch predicate.
- `README.md` (new "Connect Claude (MCP)" section, two config rows), `CHANGELOG.md`, `docs/self-hosted-mcp-plan.md` (status, localhost section, security checklist).

## Test plan

- [x] `engine/src/test/mcp.integration.test.ts` (28 cases) drives the real MCP SDK client against a booted engine: 401 with `WWW-Authenticate` hint, key on both headers, all tools listed read-only, clipping vs detail, sessions, cross-project isolation, discovery documents, DCR + consent + PKCE exchange, code replay, wrong verifier (and the code burned by it), refresh rotation, in-grace retry, two concurrent refreshes, reuse after the grace window revoking the grant, grants list (contract-checked) and revoke, RFC 7009 revoke, key-regeneration cascade, disallowed redirect, resource mismatch, tampered/denied/wrong-key consent, `form-action` in the consent CSP, enabled mode (sign-in gate, project pick, non-member refused, member removal cutting the grant off), and the same lifecycle on Postgres (opt-in via `AGENTX_TEST_DB_URL`).
- [x] `engine/src/test/mcpConfig.test.ts` pins the issuer, resource-match and redirect allow-list decisions.
- [x] Full engine suite green on SQLite; MCP + dialect suites green against a local Postgres 16.
- [x] `yarn typecheck`, `yarn lint`, route-validation ratchet, wire-contract and better-auth schema-parity suites.
- [x] `bun build --compile` still produces a working single binary; `/mcp`, discovery and registration verified against it.
- [ ] Not verified here: an actual claude.ai connector through a tunnel (needs a public HTTPS URL). The SDK's own OAuth client, which implements the same spec, passes end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yjcgossRBo7PCDKQc5T63

---
_Generated by [Claude Code](https://claude.ai/code/session_011yjcgossRBo7PCDKQc5T63)_