### PR TITLE
fix cache token drop, security fix for multi-tenant

### DIFF
--- a/engine/docs/runbook.md
+++ b/engine/docs/runbook.md
@@ -39,3 +39,9 @@ Control plane: normal Postgres/SQLite backups, plus the NDJSON export surface (R
 ClickHouse: `clickhouse-backup` or filesystem snapshots of /var/lib/clickhouse; spans are
 append-only, so incremental strategies work well. Restore drill: boot the compose profile
 against restored volumes and check `/metrics` plus a trace list.
+
+Restoring from the NDJSON export by re-POSTing traces to `/ingest` is LOSSY: rows get new ids
+and restore-time timestamps, and everything keyed on the old trace ids (outcome reports, review
+labels, monitor events) ends up orphaned. Treat the export as portability/offline-analysis
+data; database-level restore (pg_dump / SQLite file copy / ClickHouse backup) is the fidelity
+path.

--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -332,7 +332,8 @@ export const judgeScorerSchema = z
         sampleRate: z.number(),
         scopeMode: z.string(),
         agentIds: z.array(z.string()),
-        alertThreshold: z.number(),
+        // Null = chart-only, never raises a Signal - a first-class state, not an absence.
+        alertThreshold: z.number().nullable(),
         severity: z.string(),
         scope: z.string(),
         idleSeconds: z.number(),
@@ -639,6 +640,112 @@ export const modelCatalogSchema = z
   })
   .strict();
 
+// ---- Scorer groups + session scores + coverage map (added with the features; the sibling
+// /insights/coverage being contracted while /coverage/map was not is exactly the drift this
+// file exists to prevent) ------------------------------------------------------------------
+
+export const scorerGroupWireSchema = z
+  .object({
+    _id: z.string(),
+    name: z.string(),
+    description: z.string().optional(),
+    members: z.array(
+      z
+        .object({
+          kind: z.enum(["judge", "pattern", "custom"]),
+          refId: z.string(),
+          weight: z.number(),
+          gate: z.boolean(),
+        })
+        .strict()
+    ),
+    online: z
+      .object({
+        enabled: z.boolean(),
+        sampleRate: z.number(),
+        alertThreshold: z.number().nullable(),
+        severity: z.string(),
+        scope: z.enum(["trace", "session"]).optional(),
+        idleSeconds: z.number().optional(),
+      })
+      .strict()
+      .nullable(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .strict();
+
+export const scorerGroupsResponseSchema = z.object({ scorerGroups: z.array(scorerGroupWireSchema) }).strict();
+
+export const scorerGroupRatingsResponseSchema = z
+  .object({
+    window: z.string(),
+    points: z.array(
+      z
+        .object({ label: z.string(), ts: z.number(), averageRating: z.number().nullable(), count: z.number() })
+        .strict()
+    ),
+  })
+  .strict();
+
+export const sessionScoresResponseSchema = z
+  .object({
+    scores: z.array(
+      z
+        .object({
+          _id: z.string(),
+          sessionId: z.string(),
+          kind: z.string(),
+          rating: z.number().nullable(),
+          justification: z.string().nullable(),
+          driftSpanId: z.string().nullable(),
+          findings: z.array(
+            z
+              .object({
+                spanId: z.string().nullable(),
+                spanIndex: z.number(),
+                text: z.string(),
+                tag: z.string(),
+              })
+              .strict()
+          ),
+          spanCount: z.number(),
+          judgeModel: z.string(),
+          createdAt: z.string(),
+        })
+        .strict()
+    ),
+  })
+  .strict();
+
+export const insightsCoverageMapResponseSchema = z
+  .object({
+    window: z.string(),
+    datasetIds: z.array(z.string()),
+    insufficientData: z.boolean(),
+    degradedReason: z.string().nullable(),
+    caseEmbeddingsPending: z.number(),
+    traceEmbeddingsPending: z.number(),
+    points: z.array(
+      z
+        .object({
+          x: z.number(),
+          y: z.number(),
+          source: z.enum(["production", "dataset"]),
+          topic: z.string(),
+          query: z.string(),
+          traceId: z.string().nullable().optional(),
+          datasetId: z.string().optional(),
+          caseIndex: z.number().optional(),
+        })
+        .strict()
+    ),
+    topics: z.array(
+      z.object({ topic: z.string(), productionCount: z.number(), datasetCount: z.number() }).strict()
+    ),
+  })
+  .strict();
+
 export const WIRE_CONTRACT = [
   {
     method: "get" as const,
@@ -773,6 +880,34 @@ export const WIRE_CONTRACT = [
     summary: "Dataset coverage of the topics production actually produces",
     response: insightsCoverageResponseSchema,
     name: "InsightsCoverageResponse",
+  },
+  {
+    method: "get" as const,
+    path: "/insights/coverage/map",
+    summary: "Production traffic and dataset cases in one joint question-space projection",
+    response: insightsCoverageMapResponseSchema,
+    name: "InsightsCoverageMap",
+  },
+  {
+    method: "get" as const,
+    path: "/agent-monitoring/scorer-groups",
+    summary: "Composed scorers - one weighted 0-10 score with must-pass gates",
+    response: scorerGroupsResponseSchema,
+    name: "ScorerGroupsList",
+  },
+  {
+    method: "get" as const,
+    path: "/agent-monitoring/scorer-groups/:id/ratings",
+    summary: "A scorer group's score history (trace and session verdicts)",
+    response: scorerGroupRatingsResponseSchema,
+    name: "ScorerGroupRatings",
+  },
+  {
+    method: "get" as const,
+    path: "/agent-monitoring/sessions/:sessionId/scores",
+    summary: "Session-level verdicts - evaluators, scorer groups, legacy coherence",
+    response: sessionScoresResponseSchema,
+    name: "SessionScores",
   },
   {
     method: "post" as const,

--- a/engine/src/core/evaluate/analysis.ts
+++ b/engine/src/core/evaluate/analysis.ts
@@ -1,7 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import { getRunRowFull, getRunResults, type RunResultRow } from "./runs.js";
-import { resolvePlatformModel, callJudgeJson, DEFAULT_JUDGE_MODEL } from "./judge.js";
+import { resolvePlatformModel, callJudgeJson } from "./judge.js";
 import { analysisNarrativeSchemaProperties, type AnalysisNarrative } from "@agentx/judge-core";
 
 // Self-host's own "Analyze" (AI Analysis) feature - see the plan's Context section for why this
@@ -82,8 +82,10 @@ function computeStatistics(results: RunResultRow[]): EvaluationAnalysisStatistic
   return {
     numberOfRuns,
     averageRating,
-    minRating: numberOfRuns ? Math.min(...ratings) : 0,
-    maxRating: numberOfRuns ? Math.max(...ratings) : 0,
+    // reduce, not Math.min(...ratings): the spread puts every rating on the call stack, which
+    // overflows on large runs.
+    minRating: numberOfRuns ? ratings.reduce((min, r) => (r < min ? r : min)) : 0,
+    maxRating: numberOfRuns ? ratings.reduce((max, r) => (r > max ? r : max)) : 0,
     ratingVariance: variance,
   };
 }
@@ -306,14 +308,33 @@ export async function runEvaluationAnalysis(
     return { evaluationId, status: "failed", judgeModel };
   }
 
-  const judgeEvidence = await scoreSampleWithJudges(sample, judgeModels);
-
-  const judgeResult = await callJudgeJson({
-    model: judgeModel,
-    jsonSchema: ANALYSIS_JSON_SCHEMA,
-    userMessage: buildJudgePrompt(judgeEvidence, statistics, judgeModels.length),
-    maxTokens: 3000,
-  });
+  // Judge calls can throw outright (missing key, provider outage) - persist the failure on the
+  // existing failed-row path instead of letting the request 500 with nothing recorded.
+  let judgeEvidence: JudgeEvidenceSampleItem[] = [];
+  let judgeResult: Awaited<ReturnType<typeof callJudgeJson>>;
+  try {
+    judgeEvidence = await scoreSampleWithJudges(sample, judgeModels);
+    judgeResult = await callJudgeJson({
+      model: judgeModel,
+      jsonSchema: ANALYSIS_JSON_SCHEMA,
+      userMessage: buildJudgePrompt(judgeEvidence, statistics, judgeModels.length),
+      maxTokens: 3000,
+    });
+  } catch (err) {
+    const row: EvaluationAnalysisRow = {
+      evaluationId,
+      status: "failed",
+      judgeModel,
+      judgeModels,
+      analysis: null,
+      statistics,
+      judgeEvidence,
+      error: err instanceof Error ? err.message : String(err),
+      createdAt: now,
+    };
+    await upsertEvaluationAnalysisRow(db, row);
+    return { evaluationId, status: "failed", judgeModel };
+  }
   // judgeResult.payload's own type (judge-core's JudgeCallResult) is `unknown` - a parsed JSON
   // object on success, or null on failure - never actually guaranteed to be the right shape at
   // runtime (the judge model's raw response only *should* match jsonSchema, an LLM call can always

--- a/engine/src/core/evaluate/curation.ts
+++ b/engine/src/core/evaluate/curation.ts
@@ -3,7 +3,7 @@ import { traceStoreFor } from "../trace/store/index.js";
 import { getTraceRow, type TraceRow } from "../trace/ingest.js";
 import { reconstructMessages } from "./portability.js";
 import { getDataset, updateDataset, extractSimilarityConfig, extractCodeScorers } from "./datasets.js";
-import { resolvePlatformModel, callJudgeJson, computeEmbedding, computeEmbeddings, DEFAULT_JUDGE_MODEL } from "./judge.js";
+import { resolvePlatformModel, callJudgeJson, computeEmbedding, computeEmbeddings } from "./judge.js";
 import { extractText } from "../monitor/events.js";
 import { cosine, normalizeText } from "../shared/vector.js";
 

--- a/engine/src/core/evaluate/pairwise.ts
+++ b/engine/src/core/evaluate/pairwise.ts
@@ -64,6 +64,8 @@ export type PairwiseCaseWire = {
 };
 
 export type PairwiseSummary = {
+  // Judged cases only - errored cases are excluded from every count here and reported in
+  // `errors` instead.
   total: number;
   aWins: number;
   bWins: number;
@@ -73,6 +75,9 @@ export type PairwiseSummary = {
   // Share of cases whose winner flipped with the presentation order (bothOrders only). High flip
   // rate means the judge is reading position, not quality - treat the whole batch as inconclusive.
   flipRate: number | null;
+  // Cases the judge call itself failed on (provider outage, unusable output) - stored with the
+  // JUDGE_ERROR justification marker, never counted as real ties.
+  errors: number;
 };
 
 export type PairwiseBatch = {
@@ -120,18 +125,29 @@ function toCaseWire(row: Row): PairwiseCaseWire {
   };
 }
 
+// The schema has no errored column, so an errored case is persisted as winner "tie" (the safe
+// stored value) with this justification prefix marking it - summarize() reads the marker back
+// to keep judge failures out of the win/tie/flip math.
+export const JUDGE_ERROR_PREFIX = "JUDGE_ERROR:";
+
+function isErroredCase(c: PairwiseCaseWire): boolean {
+  return c.justification?.startsWith(JUDGE_ERROR_PREFIX) ?? false;
+}
+
 export function summarize(cases: PairwiseCaseWire[], bothOrders: boolean): PairwiseSummary {
-  const aWins = cases.filter(c => c.winner === "a").length;
-  const bWins = cases.filter(c => c.winner === "b").length;
-  const ties = cases.filter(c => c.winner === "tie").length;
+  const scored = cases.filter(c => !isErroredCase(c));
+  const aWins = scored.filter(c => c.winner === "a").length;
+  const bWins = scored.filter(c => c.winner === "b").length;
+  const ties = scored.filter(c => c.winner === "tie").length;
   return {
-    total: cases.length,
+    total: scored.length,
     aWins,
     bWins,
     ties,
     winner: aWins > bWins ? "a" : bWins > aWins ? "b" : "tie",
     flipRate:
-      bothOrders && cases.length ? Math.round((cases.filter(c => c.flipped).length / cases.length) * 100) / 100 : null,
+      bothOrders && scored.length ? Math.round((scored.filter(c => c.flipped).length / scored.length) * 100) / 100 : null,
+    errors: cases.length - scored.length,
   };
 }
 
@@ -291,16 +307,21 @@ export async function runPairwise(db: Db, input: RunPairwiseInput): Promise<Pair
         );
         const swappedWinner = toSide(swapped.winner, !aFirst);
         if (swappedWinner !== winner) {
-          // Opposite verdicts from the same pair: the order decided it, not the answers.
-          flipped = true;
+          // Any disagreement between the passes scores as a tie, but only OPPOSITE verdicts
+          // (a vs b) count as a position flip - the order decided it, not the answers. A
+          // tie-vs-a disagreement is ordinary judge wobble, not evidence of position bias.
+          const opposite = winner !== "tie" && swappedWinner !== "tie";
+          flipped = opposite;
           winner = "tie";
-          justification = `Verdict flipped when the answers were swapped, so this pair is scored as a tie. First pass: ${primary.justification} Second pass: ${swapped.justification}`;
+          justification = opposite
+            ? `Verdict flipped when the answers were swapped, so this pair is scored as a tie. First pass: ${primary.justification} Second pass: ${swapped.justification}`
+            : `The two passes disagreed (one saw a tie), so this pair is scored as a tie. First pass: ${primary.justification} Second pass: ${swapped.justification}`;
         }
       }
     } catch (err) {
       logger.error({ err, questionIndex: c.questionIndex }, "Pairwise judge call failed");
       winner = "tie";
-      justification = `Judging failed for this pair: ${(err as Error).message}`;
+      justification = `${JUDGE_ERROR_PREFIX} ${(err as Error).message}`;
     }
 
     return {
@@ -346,20 +367,21 @@ export async function runPairwise(db: Db, input: RunPairwiseInput): Promise<Pair
 const scope = (db: Db) =>
   or(eq(db.schema.pairwiseComparisons.projectId, db.projectId), isNull(db.schema.pairwiseComparisons.projectId));
 
-async function rowsFor(db: Db, where: ReturnType<typeof scope>): Promise<Row[]> {
+async function rowsFor(db: Db, where: ReturnType<typeof scope>, limit?: number): Promise<Row[]> {
   if (db.kind === "sqlite") {
-    return db.db
+    const query = db.db
       .select()
       .from(db.schema.pairwiseComparisons)
       .where(where)
-      .orderBy(desc(db.schema.pairwiseComparisons.createdAt), asc(db.schema.pairwiseComparisons.questionIndex))
-      .all() as Row[];
+      .orderBy(desc(db.schema.pairwiseComparisons.createdAt), asc(db.schema.pairwiseComparisons.questionIndex));
+    return (limit ? query.limit(limit).all() : query.all()) as Row[];
   }
-  return (await db.db
+  const query = db.db
     .select()
     .from(db.schema.pairwiseComparisons)
     .where(where)
-    .orderBy(desc(db.schema.pairwiseComparisons.createdAt), asc(db.schema.pairwiseComparisons.questionIndex))) as Row[];
+    .orderBy(desc(db.schema.pairwiseComparisons.createdAt), asc(db.schema.pairwiseComparisons.questionIndex));
+  return (await (limit ? query.limit(limit) : query)) as Row[];
 }
 
 export async function getPairwiseBatch(db: Db, batchId: string): Promise<PairwiseBatch | null> {
@@ -390,6 +412,10 @@ export type PairwiseBatchSummaryWire = {
   createdAt: string;
 };
 
+// Newest-first ordering means the SQL row cap sheds the OLDEST history, never recent
+// comparisons: 20 max-size batches' worth of rows, far more in typical use.
+const BATCH_LIST_ROW_LIMIT = 20 * MAX_PAIRWISE_CASES;
+
 // Batches for one pair of runs (or every batch when no pair is given), newest first.
 export async function listPairwiseBatches(
   db: Db,
@@ -398,7 +424,7 @@ export async function listPairwiseBatches(
   const conditions = [scope(db)];
   if (filter.runAId) conditions.push(eq(db.schema.pairwiseComparisons.runAId, filter.runAId));
   if (filter.runBId) conditions.push(eq(db.schema.pairwiseComparisons.runBId, filter.runBId));
-  const rows = await rowsFor(db, and(...conditions));
+  const rows = await rowsFor(db, and(...conditions), BATCH_LIST_ROW_LIMIT);
 
   const byBatch = new Map<string, Row[]>();
   for (const row of rows) {
@@ -406,7 +432,13 @@ export async function listPairwiseBatches(
     list.push(row);
     byBatch.set(row.batchId, list);
   }
-  return [...byBatch.entries()].map(([batchId, batchRows]) => {
+  const batches = [...byBatch.entries()];
+  // A cap hit can truncate the oldest batch mid-group (its rows sort contiguously, so only the
+  // last group is at risk) - drop it rather than summarize a partial batch as a clean sweep.
+  if (rows.length === BATCH_LIST_ROW_LIMIT && batches.length > 1) {
+    batches.pop();
+  }
+  return batches.map(([batchId, batchRows]) => {
     const cases = batchRows.map(toCaseWire);
     const bothOrders = batchRows[0]!.bothOrders;
     return {

--- a/engine/src/core/evaluate/runs.ts
+++ b/engine/src/core/evaluate/runs.ts
@@ -350,7 +350,10 @@ async function scoreOneResult(
   // actually run - lets a code scorer assert on tool behavior (see codeScorer.ts's ScorerArgs).
   // One cheap local row read, skipped entirely for the common no-scorers case.
   let toolCalls: unknown;
-  if (item.traceId && config.codeScorers.length > 0) {
+  // Group pattern/custom members read toolCalls too - fetching only for the dataset's own
+  // code scorers left a group's tool-call conditions evaluating against nothing (a gated
+  // "must call escalate_to_human" pattern silently passed on every case).
+  if (item.traceId && (config.codeScorers.length > 0 || scorerGroup)) {
     const trace = await getTraceRowForScoring(db, item.traceId);
     if (trace && Array.isArray(trace.toolCalls) && trace.toolCalls.length > 0) {
       toolCalls = trace.toolCalls;
@@ -576,7 +579,9 @@ export async function appendResults(
     return null;
   }
   if (run.status === "completed" || run.status === "failed") {
-    throw new Error("Run is already in a terminal state");
+    const terminalErr = new Error("Run is already in a terminal state") as Error & { code?: string };
+    terminalErr.code = "conflict";
+    throw terminalErr;
   }
 
   const config = await resolveRunConfig(db, run.datasetId, run.evaluationSettingsId);
@@ -590,7 +595,9 @@ export async function appendResults(
   if (runGroupId && !scorerGroup) {
     // Falling through to the dataset's own config would grade half the run on a different
     // rubric than the half scored before the deletion - refuse loudly instead.
-    throw new Error("The scorer group grading this run no longer exists");
+    const err = new Error("The scorer group grading this run no longer exists") as Error & { code?: string };
+    err.code = "conflict";
+    throw err;
   }
 
   let accepted = 0;

--- a/engine/src/core/evaluate/synthesize.ts
+++ b/engine/src/core/evaluate/synthesize.ts
@@ -1,5 +1,5 @@
 import type { Db } from "../../storage/db.js";
-import { resolvePlatformModel, callJudgeJson, DEFAULT_JUDGE_MODEL } from "./judge.js";
+import { resolvePlatformModel, callJudgeJson } from "./judge.js";
 import { getDataset } from "./datasets.js";
 
 // Synthetic golden-case generation: paste a source document (policy text, API docs, FAQ, spec)
@@ -72,8 +72,11 @@ Rules:
 SOURCE:
 ${sourceText}`;
 
+  // Resolved once and reused in the return value, so the reported judgeModel is always the
+  // model that actually generated (a settings change mid-call can't desync the two).
+  const judgeModel = await resolvePlatformModel(db);
   const result = await callJudgeJson({
-    model: await resolvePlatformModel(db),
+    model: judgeModel,
     jsonSchema: SYNTHESIS_SCHEMA,
     userMessage,
     maxTokens: 4000,
@@ -91,5 +94,5 @@ ${sourceText}`;
   if (cases.length === 0) {
     return { error: "The generator returned no usable cases - try a longer or more specific source" };
   }
-  return { cases, judgeModel: await resolvePlatformModel(db) };
+  return { cases, judgeModel };
 }

--- a/engine/src/core/export/exportData.ts
+++ b/engine/src/core/export/exportData.ts
@@ -1,4 +1,5 @@
 import { and, asc, count, eq, gt, gte, type SQL } from "drizzle-orm";
+import { traceStoreFor } from "../trace/store/index.js";
 import type { Db } from "../../storage/db.js";
 
 // Bulk data egress (P2.1 of the enterprise improvement plan): every project-scoped table an
@@ -114,6 +115,11 @@ function buildWhere(db: Db, entity: ExportEntity, since: Date | null, cursor: st
 }
 
 export async function countExportRows(db: Db, entity: ExportEntity, since: Date | null = null): Promise<number> {
+  if (entity === "traces") {
+    // Spans live behind the trace store - on the ClickHouse tier the relational table is
+    // empty, and counting it reported a "successful" backup of zero spans.
+    return traceStoreFor(db).countAll(since);
+  }
   const t = entityTable(db, entity);
   const q = (db.db as any).select({ n: count() }).from(t).where(buildWhere(db, entity, since, null));
   const rows: { n: number | string }[] = db.kind === "sqlite" ? q.all() : await q;
@@ -126,6 +132,12 @@ export async function fetchExportBatch(
   since: Date | null,
   cursor: string | null
 ): Promise<Record<string, unknown>[]> {
+  if (entity === "traces") {
+    return (await traceStoreFor(db).listForExport({ since, cursor, limit: EXPORT_BATCH })) as unknown as Record<
+      string,
+      unknown
+    >[];
+  }
   const t = entityTable(db, entity);
   const q = (db.db as any)
     .select()

--- a/engine/src/core/insights/coverageMap.ts
+++ b/engine/src/core/insights/coverageMap.ts
@@ -92,7 +92,11 @@ export async function getCoverageMap(
   // The window converges anyway - each request backfills up to 100, so the considered slice
   // drains front-to-back across requests.
   const MAX_UNEMBEDDED_CONSIDERED = 500;
-  const unembedded = withTrace.filter(r => !hasVector(r)).slice(0, MAX_UNEMBEDDED_CONSIDERED);
+  const unembeddedAll = withTrace.filter(r => !hasVector(r));
+  const unembedded = unembeddedAll.slice(0, MAX_UNEMBEDDED_CONSIDERED);
+  // Rows beyond the window are pending-unknown (their traces were not fetched to check) - they
+  // count toward the "still indexing" number rather than silently vanishing from it.
+  const pendingBeyondWindow = unembeddedAll.length - unembedded.length;
 
   // Texts for point labels (and the backfill) - fetched only for rows that might be plotted
   // or backfilled this request.
@@ -143,7 +147,7 @@ export async function getCoverageMap(
     .filter((r): r is ClassificationRow & { inputEmbedding: number[] } => hasVector(r))
     .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
     .slice(0, MAX_POINTS_PER_SOURCE);
-  const tracePending = backfillable.filter(r => !hasVector(r)).length;
+  const tracePending = backfillable.filter(r => !hasVector(r)).length + pendingBeyondWindow;
 
   const datasetRows = await listDatasetRows(db);
   const cases = await listDatasetCases(db, options.datasetIds, datasetRows);
@@ -183,6 +187,14 @@ export async function getCoverageMap(
   // allGroups check keeps it out of off-map.
   const allGroups: TopicGroup[] = groupByIntent(allRows);
   const groups: TopicGroup[] = allGroups.filter(g => g.rows.length >= MIN_TRACES_PER_TOPIC);
+  // Raw classification label -> the group's canonical topic (groupByIntent normalizes AND
+  // merges synonymous topics). Production points must use the same canonical strings the
+  // dataset side's topicOf returns, or one merged topic renders as two - half of it a
+  // phantom uncovered gap.
+  const canonicalTopic = new Map<string, string>();
+  for (const group of allGroups) {
+    for (const row of group.rows) canonicalTopic.set(row.intent, group.topic);
+  }
   const sim = embeddingSimilarity();
   const bestIn = (item: DatasetCase, pool: TopicGroup[]): { topic: string | null; matched: boolean } => {
     let bestTopic: string | null = null;
@@ -217,7 +229,7 @@ export async function getCoverageMap(
       x: projected[i]![0]!,
       y: projected[i]![1]!,
       source: "production" as const,
-      topic: row.intent,
+      topic: canonicalTopic.get(row.intent) ?? row.intent,
       query: inputTextOf(row).slice(0, 140),
       traceId: row.traceId,
     })),
@@ -226,7 +238,7 @@ export async function getCoverageMap(
       y: projected[traceRows.length + i]![1]!,
       source: "dataset" as const,
       topic: topicOf(item),
-      query: item.query,
+      query: item.query.slice(0, 140),
       datasetId: item.datasetId,
       caseIndex: item.index,
     })),

--- a/engine/src/core/monitor/attention.ts
+++ b/engine/src/core/monitor/attention.ts
@@ -48,11 +48,16 @@ type EventRow = {
 };
 
 export async function getAttentionDigest(db: Db): Promise<AttentionDigest> {
-  const signals = (await listSignalRows(db)).filter(row => row.polarity === "failure" && row.status === "open");
+  // "open" plus "reopened": upsertSignal moves a resolved/archived signal to "reopened" when it
+  // recurs, and a recurring signal is exactly what needs attention (signalCountsByPatternKey
+  // already counts both as open).
+  const signals = (await listSignalRows(db)).filter(
+    row => row.polarity === "failure" && (row.status === "open" || row.status === "reopened")
+  );
   const openSignalCount = signals.length;
   const totalOccurrences = signals.reduce((sum, row) => sum + (row.occurrenceCount ?? 1), 0);
 
-  // Rank by recent volume first so the digest (capped) carries the busiest signals; the
+  // Rank by lifetime occurrence volume so the digest (capped) carries the busiest signals; the
   // dashboard re-sorts within these for its "Lowest score" view.
   const top = [...signals]
     .sort((a, b) => (b.occurrenceCount ?? 1) - (a.occurrenceCount ?? 1))

--- a/engine/src/core/monitor/events.ts
+++ b/engine/src/core/monitor/events.ts
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { and, eq, gte, inArray, isNotNull, isNull, lt } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNotNull, isNull, lt } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import { traceStoreFor } from "../trace/store/index.js";
 import { getTraceRow } from "../trace/ingest.js";
@@ -221,15 +221,28 @@ export async function pruneRetentionData(db: Db, agentId: string | null, retenti
 // One row per detection is already recorded here (recordEvent, called from detect.ts on every
 // match) - this is the real per-occurrence history AgentX-web-front's SignalRow.tsx expects on
 // `signal.occurrences[]`, which core/monitor/signals.ts's toWire() never populated (only the
-// aggregate occurrenceCount). Newest-last (chronological), matching the frontend's own
-// `[...recorded].reverse()` to display newest-first.
-export async function listOccurrencesForSignal(db: Db, signalId: string): Promise<EventRow[]> {
+// aggregate occurrenceCount). The limit keeps the NEWEST rows (applied in SQL - a long-lived
+// signal can have thousands of occurrences and no caller renders more than a page); the returned
+// order stays newest-last (chronological), matching the frontend's own `[...recorded].reverse()`
+// to display newest-first and the callers that read the newest occurrence at the array's end.
+export async function listOccurrencesForSignal(db: Db, signalId: string, limit = 50): Promise<EventRow[]> {
   const cond = and(eq(db.schema.monitorEvents.signalId, signalId), eq(db.schema.monitorEvents.projectId, db.projectId));
   const rows =
     db.kind === "sqlite"
-      ? db.db.select().from(db.schema.monitorEvents).where(cond).orderBy(db.schema.monitorEvents.createdAt).all()
-      : await db.db.select().from(db.schema.monitorEvents).where(cond).orderBy(db.schema.monitorEvents.createdAt);
-  return rows as EventRow[];
+      ? db.db
+          .select()
+          .from(db.schema.monitorEvents)
+          .where(cond)
+          .orderBy(desc(db.schema.monitorEvents.createdAt))
+          .limit(limit)
+          .all()
+      : await db.db
+          .select()
+          .from(db.schema.monitorEvents)
+          .where(cond)
+          .orderBy(desc(db.schema.monitorEvents.createdAt))
+          .limit(limit);
+  return (rows as EventRow[]).reverse();
 }
 
 // Every detection check recorded against one trace - the join surface
@@ -246,9 +259,25 @@ export async function listEventsForTrace(db: Db, traceId: string): Promise<Event
   return rows as EventRow[];
 }
 
-// Exported for judgeTuning.ts, which joins an evaluator's rating events against ground truth.
 export async function listEventsSince(db: Db, since: Date): Promise<EventRow[]> {
   const cond = and(gte(db.schema.monitorEvents.createdAt, since), eq(db.schema.monitorEvents.projectId, db.projectId));
+  const rows =
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.monitorEvents).where(cond).all()
+      : await db.db.select().from(db.schema.monitorEvents).where(cond);
+  return rows as EventRow[];
+}
+
+// One evaluator's scored events in the window, filtered in SQL - judgeTuning.ts joins these
+// against ground truth per evaluator, and loading EVERY monitor event just to keep one
+// evaluator's ratings scaled with total traffic instead of with that evaluator's own volume.
+export async function listScoreEventsForEvaluatorSince(db: Db, evaluatorId: string, since: Date): Promise<EventRow[]> {
+  const cond = and(
+    gte(db.schema.monitorEvents.createdAt, since),
+    eq(db.schema.monitorEvents.projectId, db.projectId),
+    eq(db.schema.monitorEvents.onlineEvaluatorId, evaluatorId),
+    isNotNull(db.schema.monitorEvents.rating)
+  );
   const rows =
     db.kind === "sqlite"
       ? db.db.select().from(db.schema.monitorEvents).where(cond).all()

--- a/engine/src/core/monitor/judgeTuning.ts
+++ b/engine/src/core/monitor/judgeTuning.ts
@@ -1,6 +1,6 @@
 import { and, eq, gte } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
-import { listEventsSince, windowConfig, type MonitoringWindow, type EventRow } from "./events.js";
+import { listScoreEventsForEvaluatorSince, windowConfig, type MonitoringWindow, type EventRow } from "./events.js";
 import { getOnlineEvaluatorRow } from "./onlineEvaluators.js";
 import { krippendorffAlpha, alphaBand, MIN_ALPHA_ITEMS } from "./agreement.js";
 import { getEvaluationSettingsRow } from "../evaluate/evaluationSettings.js";
@@ -214,9 +214,10 @@ export async function getEvaluatorCalibration(
     const { days } = windowConfig(window);
     since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
   }
-  const events = (await listEventsSince(db, since)).filter(
-    (e): e is EventRow & { rating: number; traceId: string } =>
-      e.onlineEvaluatorId === evaluatorId && e.rating !== null && e.traceId !== null
+  // Evaluator + rating filters run in SQL (listScoreEventsForEvaluatorSince); the filter here
+  // only narrows the type and drops the rare rating row with no trace to join on.
+  const events = (await listScoreEventsForEvaluatorSince(db, evaluatorId, since)).filter(
+    (e): e is EventRow & { rating: number; traceId: string } => e.rating !== null && e.traceId !== null
   );
 
   // Corrections keyed by the event the human was re-scoring; review labels and outcomes keyed
@@ -460,10 +461,19 @@ export type JudgeTuningProposal = {
 
 function describeCase(c: CalibrationCase, i: number): string {
   const truth = c.groundTruth;
+  const verdictWord = truth.isBad ? "BAD" : "FINE";
+  const detailSuffix = truth.detail ? ` ("${truth.detail}")` : "";
+  // Each source gets an honest label: a correction without a re-score is a verdict, not a number
+  // (never "re-scored it to null/10"), and review/confirmed labels come from a human reviewer,
+  // not a real-world outcome.
   const truthLabel =
     truth.source === "correction"
-      ? `a human re-scored it to ${truth.correctedScore}/10 with rationale: "${truth.detail ?? ""}"`
-      : `${truth.source === "feedback" ? "the end user" : "a real-world outcome"} said it was ${truth.isBad ? "BAD" : "FINE"}${truth.detail ? ` ("${truth.detail}")` : ""}`;
+      ? truth.correctedScore !== null
+        ? `a human re-scored it to ${truth.correctedScore}/10 with rationale: "${truth.detail ?? ""}"`
+        : `a human marked the judgement wrong (the response was actually ${verdictWord})${detailSuffix}`
+      : truth.source === "review" || truth.source === "confirmed"
+        ? `a human reviewer labeled it ${verdictWord}${detailSuffix}`
+        : `${truth.source === "feedback" ? "the end user" : "a real-world outcome"} said it was ${verdictWord}${detailSuffix}`;
   return `Case ${i + 1}: the judge rated ${c.rating}/10 (${c.judgedBad ? "flagged as bad" : "passed as fine"}) saying "${(c.justification ?? "").slice(0, 300)}", but ${truthLabel}.
   User input: ${c.input.slice(0, 600)}
   Agent output: ${c.output.slice(0, 600)}`;
@@ -630,7 +640,13 @@ export async function validateJudgeTuning(
   for (const [kind, list] of [["disagreement", disagreements], ["control", controls]] as const) {
     for (const c of list) {
       try {
-        const scored = await scoreAgainstCriteria(criteria, { input: c.input, output: c.output });
+        // Calibration cases store input/output truncated to 1500 chars for display; exact
+        // re-judging needs what the production judge actually saw, so re-fetch the full trace
+        // text and fall back to the stored slices only when the trace is gone (pruned).
+        const trace = await getTraceRow(db, c.traceId);
+        const input = trace ? extractText(trace.input) : c.input;
+        const output = trace ? extractText(trace.output) : c.output;
+        const scored = await scoreAgainstCriteria(criteria, { input, output });
         const candidateBad = scored.rating < threshold;
         cases.push({
           eventId: c.eventId,

--- a/engine/src/core/monitor/metrics.ts
+++ b/engine/src/core/monitor/metrics.ts
@@ -277,11 +277,20 @@ export async function getMonitorMetrics(
     if (kind === "llm") {
       bucket.spansLlm++;
       if (row.model) facetModels.add(row.model);
-    } else if (kind === "tool" || (row.parentSpanId && toolNames.has(row.name))) {
+    } else if (kind === "tool") {
       bucket.spansTool++;
     } else if (kind === "retrieval") {
       bucket.spansRetrieval++;
+    } else if (kind === "chain" && row.parentSpanId && toolNames.has(row.name)) {
+      // The name set really is a LAST resort now (see its comment): only a span the classifier
+      // could say nothing about ("chain") falls back to name matching. It previously overrode
+      // stated retrieval/memory kinds AND disagreed with rollups.ts, so the same span counted
+      // as retrieval on the unfiltered dashboard and as tool the moment a filter was applied.
+      bucket.spansTool++;
     } else {
+      // "memory" (and every other minor kind) deliberately counts as other for now - the
+      // bucket columns are wire shape, and a dedicated memory metric belongs to the memory
+      // probe work (docs/memory-probe-benchmark-plan.md), not an ad hoc field.
       bucket.spansOther++;
     }
     if (!row.parentSpanId) {

--- a/engine/src/core/monitor/outcomeCalibration.ts
+++ b/engine/src/core/monitor/outcomeCalibration.ts
@@ -1,8 +1,7 @@
-import { eq, gte, and } from "drizzle-orm";
+import { eq, gte, and, inArray } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import type { MonitoringWindow } from "./events.js";
-import { listEventsForTrace } from "./events.js";
-import { listOutcomeReportRows, type OutcomeReportRow } from "../outcomes/outcomeReports.js";
+import type { OutcomeReportRow } from "../outcomes/outcomeReports.js";
 import { krippendorffAlpha, alphaBand, MIN_ALPHA_ITEMS } from "./agreement.js";
 
 // Turns "trust the LLM judge" into a measured, falsifiable number: for every reported real-world
@@ -17,13 +16,49 @@ import { krippendorffAlpha, alphaBand, MIN_ALPHA_ITEMS } from "./agreement.js";
 // than inventing a second, different default.
 const LOW_RATING_THRESHOLD = 5;
 
+type VerdictEventRow = {
+  traceId: string | null;
+  signalId: string | null;
+  patternKey: string;
+  polarity: string;
+  onlineEvaluatorId: string | null;
+  customEvaluatorId: string | null;
+};
+
+// The same join surface as listEventsForTrace (events.ts), generalized to a batch: ONE inArray
+// query for every trace the calibration pass compares, grouped in JS, instead of a sequential
+// round trip per report.
+async function listEventsByTrace(db: Db, traceIds: string[]): Promise<Map<string, VerdictEventRow[]>> {
+  const byTrace = new Map<string, VerdictEventRow[]>();
+  if (traceIds.length === 0) {
+    return byTrace;
+  }
+  const cond = and(inArray(db.schema.monitorEvents.traceId, traceIds), eq(db.schema.monitorEvents.projectId, db.projectId));
+  const rows = (
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.monitorEvents).where(cond).all()
+      : await db.db.select().from(db.schema.monitorEvents).where(cond)
+  ) as VerdictEventRow[];
+  for (const row of rows) {
+    if (!row.traceId) continue;
+    const list = byTrace.get(row.traceId) ?? [];
+    list.push(row);
+    byTrace.set(row.traceId, list);
+  }
+  return byTrace;
+}
+
 // null = AgentX has no verdict to compare against at all (no monitor_events row for that trace,
 // or an unscored eval result) - excluded from agreement math entirely rather than silently
 // counted as "not flagged", which would inflate agreement with a report that isn't actually
 // falsifiable against anything AgentX did.
-async function resolveAgentxVerdict(db: Db, report: OutcomeReportRow): Promise<boolean | null> {
+async function resolveAgentxVerdict(
+  db: Db,
+  report: OutcomeReportRow,
+  eventsByTrace: Map<string, VerdictEventRow[]>
+): Promise<boolean | null> {
   if (report.traceId) {
-    const events = await listEventsForTrace(db, report.traceId);
+    const events = eventsByTrace.get(report.traceId) ?? [];
     if (events.length === 0) {
       return null;
     }
@@ -62,9 +97,10 @@ async function resolveAgentxVerdict(db: Db, report: OutcomeReportRow): Promise<b
 export type CalibrationResult = {
   window: MonitoringWindow;
   reportedCount: number;
-  // Labeled review-queue items inside the window (core/monitor/reviewQueue.ts). Structurally the
-  // same evidence as an outcome report - a human calling one trace good or bad - so they feed the
-  // same confusion matrix. Reported separately so the UI can say how much of the agreement number
+  // Labeled review-queue items (core/monitor/reviewQueue.ts) actually tallied in the window -
+  // good/bad labels on traces no outcome report already covered. Structurally the same evidence
+  // as an outcome report - a human calling one trace good or bad - so they feed the same
+  // confusion matrix. Reported separately so the UI can say how much of the agreement number
   // came from sampled human labels rather than production outcomes.
   reviewLabelCount: number;
   // Reports whose traceId/evaluationRunResultId has no corresponding AgentX verdict yet - not an
@@ -134,16 +170,6 @@ export async function getJudgeCalibration(db: Db, window: MonitoringWindow): Pro
     }
   };
 
-  // One ground truth per trace: a trace with BOTH an outcome report and a review label used
-  // to contribute two rows to the same confusion matrix - inflating agreement on exactly the
-  // traces that got the most attention. Outcome reports outrank sampled labels (the ordering
-  // judgeTuning's evidence chain already uses).
-  const talliedTraces = new Set<string>();
-  for (const report of reports) {
-    if (report.traceId) talliedTraces.add(report.traceId);
-    tally(await resolveAgentxVerdict(db, report), report.isNegative);
-  }
-
   // Sampled human labels: the same math, windowed on when the verdict was given. This is what
   // makes a review queue over ordinary traffic worth staffing - a judge quietly scoring bad
   // answers as good never produces an outcome report, but a sampled label catches it.
@@ -157,10 +183,34 @@ export async function getJudgeCalibration(db: Db, window: MonitoringWindow): Pro
       ? db.db.select().from(db.schema.reviewQueueItems).where(reviewCond).all()
       : await db.db.select().from(db.schema.reviewQueueItems).where(reviewCond)
   ) as { traceId: string; label: string | null }[];
+
+  const eventsByTrace = await listEventsByTrace(db, [
+    ...new Set([
+      ...reports.map(r => r.traceId).filter((id): id is string => id !== null),
+      ...reviewLabels.map(r => r.traceId),
+    ]),
+  ]);
+
+  // One ground truth per trace: a trace with several outcome reports (or a report AND a review
+  // label) used to contribute multiple rows to the same confusion matrix - inflating agreement
+  // on exactly the traces that got the most attention. First report per trace wins, and outcome
+  // reports outrank sampled labels (the ordering judgeTuning's evidence chain already uses).
+  const talliedTraces = new Set<string>();
+  for (const report of reports) {
+    if (report.traceId) {
+      if (talliedTraces.has(report.traceId)) continue;
+      talliedTraces.add(report.traceId);
+    }
+    tally(await resolveAgentxVerdict(db, report, eventsByTrace), report.isNegative);
+  }
+
+  let reviewLabelCount = 0;
   for (const item of reviewLabels) {
     if (item.label !== "good" && item.label !== "bad") continue;
     if (talliedTraces.has(item.traceId)) continue;
-    tally(await resolveAgentxVerdict(db, { traceId: item.traceId } as OutcomeReportRow), item.label === "bad");
+    talliedTraces.add(item.traceId);
+    reviewLabelCount++;
+    tally(await resolveAgentxVerdict(db, { traceId: item.traceId } as OutcomeReportRow, eventsByTrace), item.label === "bad");
   }
 
   const comparedCount = truePositive + trueNegative + falsePositive + falseNegative;
@@ -176,7 +226,7 @@ export async function getJudgeCalibration(db: Db, window: MonitoringWindow): Pro
   return {
     window,
     reportedCount: reports.length,
-    reviewLabelCount: reviewLabels.length,
+    reviewLabelCount,
     noVerdictCount: noVerdict,
     comparedCount,
     agreementRate: comparedCount > 0 ? (truePositive + trueNegative) / comparedCount : null,

--- a/engine/src/core/monitor/reviewQueue.ts
+++ b/engine/src/core/monitor/reviewQueue.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, or } from "drizzle-orm";
+import { and, count, desc, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type { Db } from "../../storage/db.js";
 import { traceStoreFor } from "../trace/store/index.js";
@@ -81,32 +81,24 @@ function toWire(row: ReviewRow, trace: TraceSummary | undefined) {
   };
 }
 
-async function listRows(db: Db): Promise<ReviewRow[]> {
-  const cond = or(eq(db.schema.reviewQueueItems.projectId, db.projectId), isNull(db.schema.reviewQueueItems.projectId));
-  if (db.kind === "sqlite") {
-    return db.db
-      .select()
-      .from(db.schema.reviewQueueItems)
-      .where(cond)
-      .orderBy(desc(db.schema.reviewQueueItems.createdAt))
-      .all() as ReviewRow[];
-  }
-  return (await db.db
-    .select()
-    .from(db.schema.reviewQueueItems)
-    .where(cond)
-    .orderBy(desc(db.schema.reviewQueueItems.createdAt))) as ReviewRow[];
-}
-
+// Project scoping is a plain eq, matching how calibration/tuning already read these rows: every
+// writer stamps db.projectId (queueTraceForReviewSerialized), so the old or(eq, isNull)
+// legacy-NULL tolerance matched rows no writer ever produces.
 async function getRow(db: Db, id: string): Promise<ReviewRow | undefined> {
-  const cond = and(
-    eq(db.schema.reviewQueueItems.id, id),
-    or(eq(db.schema.reviewQueueItems.projectId, db.projectId), isNull(db.schema.reviewQueueItems.projectId))
-  );
+  const cond = and(eq(db.schema.reviewQueueItems.id, id), eq(db.schema.reviewQueueItems.projectId, db.projectId));
   if (db.kind === "sqlite") {
     return db.db.select().from(db.schema.reviewQueueItems).where(cond).all()[0] as ReviewRow | undefined;
   }
   return (await db.db.select().from(db.schema.reviewQueueItems).where(cond))[0] as ReviewRow | undefined;
+}
+
+async function countPending(db: Db): Promise<number> {
+  const cond = and(eq(db.schema.reviewQueueItems.projectId, db.projectId), eq(db.schema.reviewQueueItems.status, "pending"));
+  const rows =
+    db.kind === "sqlite"
+      ? db.db.select({ pending: count() }).from(db.schema.reviewQueueItems).where(cond).all()
+      : await db.db.select({ pending: count() }).from(db.schema.reviewQueueItems).where(cond);
+  return Number(rows[0]?.pending ?? 0);
 }
 
 async function traceSummaries(db: Db, traceIds: string[]): Promise<Map<string, TraceSummary>> {
@@ -166,13 +158,22 @@ async function queueTraceForReviewSerialized(db: Db, input: QueueForReviewInput)
     | undefined;
   if (!trace) return { ok: false, reason: "trace_not_found" };
 
-  const existing = await listRows(db);
   // Re-queueing a trace already waiting for a verdict is a no-op, so a rule that re-fires on a
-  // replayed trace (or an impatient double click) can't create duplicate work.
-  if (existing.some(r => r.traceId === input.traceId && r.status === "pending")) {
+  // replayed trace (or an impatient double click) can't create duplicate work. Both checks are
+  // scoped SQL queries, not a full-table scan.
+  const dupCond = and(
+    eq(db.schema.reviewQueueItems.projectId, db.projectId),
+    eq(db.schema.reviewQueueItems.traceId, input.traceId),
+    eq(db.schema.reviewQueueItems.status, "pending")
+  );
+  const duplicate =
+    db.kind === "sqlite"
+      ? db.db.select({ id: db.schema.reviewQueueItems.id }).from(db.schema.reviewQueueItems).where(dupCond).limit(1).all()
+      : await db.db.select({ id: db.schema.reviewQueueItems.id }).from(db.schema.reviewQueueItems).where(dupCond).limit(1);
+  if (duplicate.length > 0) {
     return { ok: false, reason: "already_queued" };
   }
-  const pending = existing.filter(r => r.status === "pending").length;
+  const pending = await countPending(db);
   if (pending >= REVIEW_QUEUE_PENDING_CAP) {
     logger.warn(
       { pending, cap: REVIEW_QUEUE_PENDING_CAP, source: input.source },
@@ -228,14 +229,33 @@ export async function listReviewQueue(
   filter: { status?: string; source?: string } = {},
   limit = 100
 ) {
-  let rows = await listRows(db);
-  if (filter.status && filter.status !== "all") rows = rows.filter(r => r.status === filter.status);
-  if (filter.source && filter.source !== "all") rows = rows.filter(r => r.source === filter.source);
-  const page = await Promise.all(rows.slice(0, limit).map(row => backfillJudgeScore(db, row)));
+  // Filters and the page limit run in SQL; `pending` stays a queue-wide count (its own query)
+  // regardless of the filter, since it feeds the cap gauge, not the current page.
+  const conditions = [eq(db.schema.reviewQueueItems.projectId, db.projectId)];
+  if (filter.status && filter.status !== "all") conditions.push(eq(db.schema.reviewQueueItems.status, filter.status));
+  if (filter.source && filter.source !== "all") conditions.push(eq(db.schema.reviewQueueItems.source, filter.source));
+  const cond = and(...conditions);
+  const rows = (
+    db.kind === "sqlite"
+      ? db.db
+          .select()
+          .from(db.schema.reviewQueueItems)
+          .where(cond)
+          .orderBy(desc(db.schema.reviewQueueItems.createdAt))
+          .limit(limit)
+          .all()
+      : await db.db
+          .select()
+          .from(db.schema.reviewQueueItems)
+          .where(cond)
+          .orderBy(desc(db.schema.reviewQueueItems.createdAt))
+          .limit(limit)
+  ) as ReviewRow[];
+  const page = await Promise.all(rows.map(row => backfillJudgeScore(db, row)));
   const traces = await traceSummaries(db, page.map(r => r.traceId));
   return {
     items: page.map(row => toWire(row, traces.get(row.traceId))),
-    pending: rows.filter(r => r.status === "pending").length,
+    pending: await countPending(db),
     cap: REVIEW_QUEUE_PENDING_CAP,
   };
 }
@@ -265,10 +285,7 @@ export async function labelReviewItem(db: Db, id: string, input: LabelReviewInpu
     status,
     reviewedAt: status === "pending" ? null : new Date(),
   };
-  const cond = and(
-    eq(db.schema.reviewQueueItems.id, id),
-    or(eq(db.schema.reviewQueueItems.projectId, db.projectId), isNull(db.schema.reviewQueueItems.projectId))
-  );
+  const cond = and(eq(db.schema.reviewQueueItems.id, id), eq(db.schema.reviewQueueItems.projectId, db.projectId));
   if (db.kind === "sqlite") {
     await db.db.update(db.schema.reviewQueueItems).set(updated).where(cond);
   } else {
@@ -281,10 +298,7 @@ export async function labelReviewItem(db: Db, id: string, input: LabelReviewInpu
 export async function deleteReviewItem(db: Db, id: string): Promise<boolean> {
   const existing = await getRow(db, id);
   if (!existing) return false;
-  const cond = and(
-    eq(db.schema.reviewQueueItems.id, id),
-    or(eq(db.schema.reviewQueueItems.projectId, db.projectId), isNull(db.schema.reviewQueueItems.projectId))
-  );
+  const cond = and(eq(db.schema.reviewQueueItems.id, id), eq(db.schema.reviewQueueItems.projectId, db.projectId));
   if (db.kind === "sqlite") {
     await db.db.delete(db.schema.reviewQueueItems).where(cond);
   } else {

--- a/engine/src/core/monitor/scorerGroups.ts
+++ b/engine/src/core/monitor/scorerGroups.ts
@@ -253,6 +253,13 @@ export function toScorerGroupWire(row: ScorerGroupRow) {
 // failure pattern, a custom score under 0.5).
 const GATE_FLOOR = 0.5;
 
+// One doctrine for the online judge budget, both scopes: reserve LAZILY (one slot per call
+// actually made - up-front reservation burned slots for members that turned out unscoreable
+// and could starve every other evaluator for the day), and a panel cut short by the budget
+// produces NO score - renormalizing the survivors would report a confident blend computed
+// from a recipe the operator never configured.
+export const BUDGET_EXHAUSTED_ERROR = "Online judge budget exhausted";
+
 export function aggregateGroupScore(members: MemberScore[]): { score: number | null; gatedBy: string | null } {
   const gated = members.find(m => m.gate && m.goodness !== null && m.goodness < GATE_FLOOR);
   if (gated) return { score: 0, gatedBy: gated.name };
@@ -260,6 +267,8 @@ export function aggregateGroupScore(members: MemberScore[]): { score: number | n
   // 500) means the configured recipe was not evaluated - producing a blend without the gate
   // would report "passed" for a safety check that never ran. No score is the honest answer.
   if (members.some(m => m.gate && m.goodness === null)) return { score: null, gatedBy: null };
+  // Same honesty for a budget-truncated panel: see BUDGET_EXHAUSTED_ERROR's comment.
+  if (members.some(m => m.error === BUDGET_EXHAUSTED_ERROR)) return { score: null, gatedBy: null };
   let total = 0;
   let weightUsed = 0;
   for (const m of members) {
@@ -276,6 +285,9 @@ export function describeGroupScore(result: { score: number | null; gatedBy: stri
   const gateErrored = members.find(m => m.gate && m.goodness === null);
   if (gateErrored) {
     return `No score: must-pass member "${gateErrored.name}" could not score (${gateErrored.error ?? "scorer failed"}).`;
+  }
+  if (members.some(m => m.error === BUDGET_EXHAUSTED_ERROR)) {
+    return "No score: the online judge budget ran out mid-panel - a partial blend would misrepresent the configured recipe.";
   }
   const parts = members
     .filter(m => m.goodness !== null && m.weight > 0)
@@ -294,12 +306,17 @@ export type GroupScoringContent = {
 // Scores every member of a group against one piece of content (an eval-run result, or a live
 // trace) and aggregates. Failures isolate per member - one deleted scorer or judge outage
 // degrades that member to goodness null (renormalized away) rather than failing the group.
-export async function computeGroupScore(db: Db, group: ScorerGroupRow, content: GroupScoringContent): Promise<GroupScore> {
+export async function computeGroupScore(
+  db: Db,
+  group: ScorerGroupRow,
+  content: GroupScoringContent,
+  options: { reserveOnlineBudget?: boolean } = {}
+): Promise<GroupScore> {
   const members: MemberScore[] = [];
 
   for (const member of group.members) {
     if (member.kind === "judge") {
-      members.push(await scoreJudgeMember(db, member, content));
+      members.push(await scoreJudgeMember(db, member, content, options));
     } else if (member.kind === "pattern") {
       members.push(await scorePatternMember(db, member, content));
     } else {
@@ -311,13 +328,22 @@ export async function computeGroupScore(db: Db, group: ScorerGroupRow, content: 
   return { score, gatedBy, members };
 }
 
-async function scoreJudgeMember(db: Db, member: ScorerGroupMember, content: GroupScoringContent): Promise<MemberScore> {
+async function scoreJudgeMember(
+  db: Db,
+  member: ScorerGroupMember,
+  content: GroupScoringContent,
+  options: { reserveOnlineBudget?: boolean } = {}
+): Promise<MemberScore> {
   const base = { kind: member.kind, refId: member.refId, weight: member.weight, gate: member.gate };
   const settings = await getEvaluationSettingsRow(db, member.refId);
   if (!settings) {
     return { ...base, name: member.refId, goodness: null, detail: "-", error: "Scorer no longer exists" };
   }
   const name = settings.name ?? member.refId;
+  // Lazily, per call actually made - see BUDGET_EXHAUSTED_ERROR's comment.
+  if (options.reserveOnlineBudget && !(await reserveOnlineJudgeCall(db))) {
+    return { ...base, name, goodness: null, detail: "-", error: BUDGET_EXHAUSTED_ERROR };
+  }
   try {
     const { rating, justification } = await scoreAgainstCriteria(
       {
@@ -465,26 +491,20 @@ export async function runScorerGroupsOnline(
   for (const group of groups) {
     const online = group.online!;
     if (!passesSampleRate(online.sampleRate)) continue;
-    // Judge members are real LLM spend at the sample rate, so they draw from the SAME online
-    // judge budget evaluators reserve from (reserveOnlineJudgeCall) - one slot per judge member,
-    // taken up front. A refused reservation skips the whole group for this trace: a partial
-    // panel would score the group on a different recipe than the one configured.
-    const judgeMemberCount = group.members.filter(m => m.kind === "judge").length;
-    let budgetOk = true;
-    for (let i = 0; i < judgeMemberCount; i++) {
-      if (!(await reserveOnlineJudgeCall(db))) {
-        budgetOk = false;
-        break;
-      }
-    }
-    if (!budgetOk) continue;
     try {
-      const result = await computeGroupScore(db, group, {
-        input: inputText,
-        output: outputText,
-        traceId: ctx.traceId,
-        toolCalls: trace.toolCalls,
-      });
+      // Judge members draw from the shared online judge budget, reserved lazily per call
+      // inside scoreJudgeMember; a truncated panel aggregates to no score at all.
+      const result = await computeGroupScore(
+        db,
+        group,
+        {
+          input: inputText,
+          output: outputText,
+          traceId: ctx.traceId,
+          toolCalls: trace.toolCalls,
+        },
+        { reserveOnlineBudget: true }
+      );
       if (result.score === null) continue;
       const justification = describeGroupScore(result, result.members);
 

--- a/engine/src/core/monitor/scriptScorer.ts
+++ b/engine/src/core/monitor/scriptScorer.ts
@@ -66,7 +66,8 @@ export type ScorerSpan = {
 // One classifier for the whole engine (core/trace/spanKind.ts). This used to be its own rule and
 // disagreed with the timeline's: a plain child span arrived here as "span" while the UI drew it
 // as a tool. Note the vocabulary shift that came with unifying - an unclassifiable child span is
-// now "chain" rather than "span", and a root span is "agent" rather than falling through.
+// now "chain" rather than "span", and a root span classifies by the same ladder as any other -
+// only a producer-stated kind makes it "agent".
 function classifySpan(row: TraceRow): string {
   return resolveSpanKind({
     spanKind: (row as { spanKind?: unknown }).spanKind,

--- a/engine/src/core/monitor/sessionScores.ts
+++ b/engine/src/core/monitor/sessionScores.ts
@@ -36,10 +36,15 @@ export type SpanWire = {
   model?: string;
   toolCalls?: unknown;
   parentSpanId?: string;
+  // Engine-resolved kind (core/trace/spanKind.ts) - present on every wire span.
+  spanKind?: string;
 };
 
 function buildSpanLine(span: SpanWire, index: number, includeToolLines = true): string {
-  const parts = [`[${index}] ${span.name}${span.model ? ` (${span.model})` : ""}`];
+  // Memory and retrieval steps are labeled so a session judge reads them as what they are -
+  // "penalize unnecessary tool calls" criteria must not count a memory recall as a tool call.
+  const kindTag = span.spanKind === "memory" || span.spanKind === "retrieval" ? ` [${span.spanKind}]` : "";
+  const parts = [`[${index}] ${span.name}${kindTag}${span.model ? ` (${span.model})` : ""}`];
   const input = span.input !== undefined ? truncate(extractText(span.input), MAX_TEXT_PER_SPAN) : "";
   const output = span.output !== undefined ? truncate(extractText(span.output), MAX_TEXT_PER_SPAN) : "";
   if (input) parts.push(`  input: ${input}`);

--- a/engine/src/core/monitor/sessionSweep.ts
+++ b/engine/src/core/monitor/sessionSweep.ts
@@ -24,6 +24,7 @@ import {
   scorePatternMember,
   scoreCustomMember,
   aggregateGroupScore,
+  BUDGET_EXHAUSTED_ERROR,
   describeGroupScore,
   type MemberScore,
   type ScorerGroupRow,
@@ -182,8 +183,8 @@ export async function judgeSessionWithDraftCriteria(
 async function judgeSessionAgainstEvaluator(
   db: Db,
   sessionId: string,
-  spanCount: number,
-  evaluator: OnlineEvaluatorRow
+  evaluator: OnlineEvaluatorRow,
+  prefetchedSpans?: SpanWire[]
 ): Promise<{
   rating: number | null;
   justification: string | null;
@@ -201,7 +202,7 @@ async function judgeSessionAgainstEvaluator(
     logger.error(`Session sweep: evaluator "${evaluator.name}" has no valid evaluator config, skipping`);
     return null;
   }
-  const spans = (await listSessionSpans(db, sessionId)) as SpanWire[];
+  const spans = prefetchedSpans ?? ((await listSessionSpans(db, sessionId)) as SpanWire[]);
   if (spans.length === 0) {
     return null;
   }
@@ -283,8 +284,6 @@ async function judgeSessionAgainstEvaluator(
   // calibration and tuning. Fallback: last span of any kind (OTel sessions whose roots folded).
   const roots = spans.filter(s => !s.parentSpanId);
   const anchorTraceId = (roots.length > 0 ? roots[roots.length - 1] : spans[spans.length - 1])?._id ?? null;
-  // The caller's windowed count is NOT what the judge saw - listSessionSpans is all-time.
-  void spanCount;
   return { rating, justification, judgeModel, anchorTraceId, driftSpanId, findings, spanCount: spans.length };
 }
 
@@ -325,11 +324,11 @@ export async function runSessionEvaluatorCheck(db: Db, sessionId: string, evalua
   if (!evaluator) {
     return null;
   }
-  const spans = await listSessionSpans(db, sessionId);
+  const spans = (await listSessionSpans(db, sessionId)) as SpanWire[];
   if (spans.length === 0) {
     return null;
   }
-  const verdict = await judgeSessionAgainstEvaluator(db, sessionId, spans.length, evaluator);
+  const verdict = await judgeSessionAgainstEvaluator(db, sessionId, evaluator, spans);
   if (!verdict) {
     return null;
   }
@@ -346,7 +345,8 @@ export async function runSessionEvaluatorCheck(db: Db, sessionId: string, evalua
     justification: verdict.justification,
     driftSpanId: verdict.driftSpanId,
     findings: verdict.findings,
-    spanCount: spans.length,
+    // What the judge actually read - the prefetched array it was handed.
+    spanCount: verdict.spanCount,
     judgeModel: verdict.judgeModel,
   });
 }
@@ -420,7 +420,7 @@ export async function scoreSessionWithGroup(
       // One budget slot per judge call actually made - a deleted ref or empty session never
       // burns a slot, and an exhausted budget degrades this member instead of the whole sweep.
       if (!(await reserveOnlineJudgeCall(db))) {
-        members.push({ ...base, name, goodness: null, detail: "-", error: "Online judge budget exhausted" });
+        members.push({ ...base, name, goodness: null, detail: "-", error: BUDGET_EXHAUSTED_ERROR });
         continue;
       }
       const toolContext = settings.toolContext ?? "simple";
@@ -504,11 +504,20 @@ const inBackoff = (key: string): boolean => {
   const last = failedAttempts.get(key);
   return last !== undefined && Date.now() - last < RETRY_BACKOFF_MS;
 };
+// Entries for permanently-failing pairs would otherwise accumulate forever; anything older
+// than a day is no longer backing anything off and can go.
+function purgeStaleBackoffs(): void {
+  const cutoff = Date.now() - 24 * 60 * 60_000;
+  for (const [key, ts] of failedAttempts) {
+    if (ts < cutoff) failedAttempts.delete(key);
+  }
+}
 
 // One pass over every project: find idle, unscored (or grown-since-scored) multi-turn sessions
 // and judge them against each enabled session-scoped evaluator. Exported for the manual-trigger
 // route (used by tests/demos); startSessionSweep below is the production path.
 export async function sweepSessionsOnce(options: { projectId?: string | null } = {}): Promise<{ judged: number }> {
+  purgeStaleBackoffs();
   const baseDb = getDb();
   const listed = await listProjectRows(baseDb);
   // The manual trigger passes the caller's project: a project API key must spend only its own
@@ -570,7 +579,7 @@ export async function sweepSessionsOnce(options: { projectId?: string | null } =
         // outage (blowing straight through the sweep lease TTL).
         judged++;
         try {
-          const verdict = await judgeSessionAgainstEvaluator(db, session.sessionId, session.spanCount, evaluator);
+          const verdict = await judgeSessionAgainstEvaluator(db, session.sessionId, evaluator);
           if (!verdict) {
             // No spans (pruned mid-tick) - back off like any failed attempt so the race
             // cannot consume a tick slot every 60s.
@@ -716,7 +725,10 @@ export async function sweepSessionsOnce(options: { projectId?: string | null } =
               traceId: result.anchorTraceId,
               onlineEvaluatorId: null,
               rating: null,
-              justification: "No group member produced a usable score for this session",
+              // The group's own explanation distinguishes "no member scored" from a
+              // fail-closed gate or a budget-truncated panel - a flat string sent operators
+              // debugging the judge key when only one custom scorer was broken.
+              justification: result.justification,
               sessionId: session.sessionId,
             });
             failedAttempts.set(retryKey, Date.now());

--- a/engine/src/core/monitor/signals.ts
+++ b/engine/src/core/monitor/signals.ts
@@ -43,10 +43,16 @@ export type SignalRow = {
 // occurrenceEvidence (keyed by event id) is a separate, optional pass: upsertSignal overwrites the
 // signal's own summary/evidence on every repeat match (last-write-wins, see upsertSignal below), so
 // occurrence #1 and #2's captured text is otherwise gone the moment #3 arrives - only getSignal
-// (one signal, bounded cost) resolves it via resolveOccurrenceEvidence; listSignals (whole table,
-// unbounded) intentionally doesn't, to avoid an N-signals x M-occurrences trace-join on every table
-// load. rating/justification are cheap either way (already columns on the event row).
+// (one signal, at most OCCURRENCE_PAGE occurrences) resolves it via resolveOccurrenceEvidence;
+// listSignals (a page of signals, each capped at OCCURRENCE_PAGE occurrences in SQL) intentionally
+// doesn't, to avoid an N-signals x M-occurrences trace-join on every table load. rating/
+// justification are cheap either way (already columns on the event row).
 type OccurrenceEvidence = { query?: string; responsePreview?: string };
+
+// The per-signal occurrence bound both readers pass to listOccurrencesForSignal: the newest 50,
+// applied in SQL - more than any list/detail view renders, small enough that a long-lived signal
+// with thousands of events stays cheap to serve.
+const OCCURRENCE_PAGE = 50;
 
 function toWire(
   row: SignalRow,
@@ -110,6 +116,22 @@ export type DetectedSignal = {
 // Upsert deduped by (patternKey, agentId): a re-detected issue for the same pattern/agent
 // increments occurrenceCount and bumps lastSeenAt instead of creating a new row, mirroring the
 // hosted SaaS's upsertMonitoringSignal (agentMonitoringService.ts).
+
+// Evidence is a convenience excerpt for the Review queue, not an archive - the full payloads
+// live on the trace. Uncapped, one verbose agent put multi-hundred-KB blobs on signal rows the
+// signals table then fetched on every refresh.
+const EVIDENCE_FIELD_CHARS = 4000;
+function capEvidence(evidence: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!evidence) return evidence;
+  const capped: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(evidence)) {
+    const text = typeof value === "string" ? value : JSON.stringify(value) ?? "";
+    capped[key] =
+      text.length <= EVIDENCE_FIELD_CHARS ? value : `${text.slice(0, EVIDENCE_FIELD_CHARS)}\n[agentx.truncated]`;
+  }
+  return capped;
+}
+
 export async function upsertSignal(
   db: Db,
   detected: DetectedSignal,
@@ -148,7 +170,7 @@ export async function upsertSignal(
       rootCause: detected.rootCause ?? null,
       agentId,
       traceId: ctx.traceId ?? null,
-      evidence: ctx.evidence ?? null,
+      evidence: capEvidence(ctx.evidence) ?? null,
       occurrenceCount: 1,
       firstSeenAt: now,
       lastSeenAt: now,
@@ -157,8 +179,10 @@ export async function upsertSignal(
     // signal all arrive having seen no row; on Postgres one then violated
     // monitor_signals_pattern_key_agent_id and that detection was lost to a log line. Losing the
     // insert just means someone else created the row - fall through and count against theirs.
-    // Signals with no agentId still dedup through the SELECT alone (NULL never conflicts with
-    // NULL), unchanged; every signal raised for a real trace has an agent.
+    // Signals with no agentId have no such backstop: NULL never conflicts in the unique index,
+    // so two concurrent detections can each pass the SELECT and both insert - a rare duplicate
+    // signal row for agent-less patterns. Accepted; every signal raised for a real trace has an
+    // agent, so only trace-less detections can race here.
     const inserted = (
       db.kind === "sqlite"
         ? db.db.insert(db.schema.monitorSignals).values(row).onConflictDoNothing().returning({ id: db.schema.monitorSignals.id }).all()
@@ -176,7 +200,7 @@ export async function upsertSignal(
     summary: detected.summary,
     severity: detected.severity,
     ...(ctx.traceId ? { traceId: ctx.traceId } : {}),
-    ...(ctx.evidence ? { evidence: ctx.evidence } : {}),
+    ...(ctx.evidence ? { evidence: capEvidence(ctx.evidence) } : {}),
     // Incremented by the database, not read-modify-written here: two checks detecting the same
     // signal at once would otherwise both write the same count and lose one sighting.
     occurrenceCount: sql`${db.schema.monitorSignals.occurrenceCount} + 1`,
@@ -231,7 +255,7 @@ export async function upsertSignal(
     rootCause: detected.rootCause ?? existing?.rootCause ?? null,
     agentId,
     traceId: ctx.traceId ?? existing?.traceId ?? null,
-    evidence: ctx.evidence ?? existing?.evidence ?? null,
+    evidence: capEvidence(ctx.evidence) ?? existing?.evidence ?? null,
     occurrenceCount: (existing?.occurrenceCount ?? 0) + 1,
     firstSeenAt: existing?.firstSeenAt ?? now,
     lastSeenAt: now,
@@ -285,7 +309,7 @@ export async function listSignals(
   if (effectivePolarity !== "all") filtered = filtered.filter(r => r.polarity === effectivePolarity);
   filtered.sort((a, b) => b.lastSeenAt.getTime() - a.lastSeenAt.getTime());
   const page = filtered.slice(0, limit);
-  const occurrencesByRow = await Promise.all(page.map(row => listOccurrencesForSignal(db, row.id)));
+  const occurrencesByRow = await Promise.all(page.map(row => listOccurrencesForSignal(db, row.id, OCCURRENCE_PAGE)));
   const agentNamesById = await getAgentNamesById(db, [
     ...page.map(row => row.agentId),
     ...occurrencesByRow.flatMap(occurrences => occurrences.map(e => e.agentId)),
@@ -325,7 +349,7 @@ export async function getSignal(db: Db, id: string) {
   if (!row) {
     return null;
   }
-  const occurrences = await listOccurrencesForSignal(db, row.id);
+  const occurrences = await listOccurrencesForSignal(db, row.id, OCCURRENCE_PAGE);
   const occurrenceEvidence = await resolveOccurrenceEvidence(db, occurrences);
   const agentNamesById = await getAgentNamesById(db, [row.agentId, ...occurrences.map(e => e.agentId)]);
   return toWire(row, occurrences, occurrenceEvidence, agentNamesById);
@@ -384,6 +408,9 @@ export async function updateSignal(db: Db, id: string, patch: UpdateSignalInput)
   } else {
     await db.db.update(db.schema.monitorSignals).set(setValues).where(updateCond);
   }
+  // Both return paths below serve the wire row back to the triage UI - resolve the agent name
+  // the same way listSignals/upsertSignal do, or the row loses its agent name after triage.
+  const agentNamesById = await getAgentNamesById(db, [updated.agentId]);
 
   // Human verdicts on judge-raised signals are calibration ground truth, and BOTH directions
   // are recorded here so no client can forget half the loop:
@@ -437,7 +464,7 @@ export async function updateSignal(db: Db, id: string, patch: UpdateSignalInput)
       // A wrong-judgement resolve that followed the correction dialog already has a richer
       // disagreement row on this event - the canned baseline must not overwrite it.
       if (!becameTriaged && (await hasCorrectionForEvent(db, id, newest.id).catch(() => false))) {
-        return toWire(updated);
+        return toWire(updated, [], undefined, agentNamesById);
       }
       await createFeedback(db, id, {
         metric: becameTriaged ? "confirmed" : "false-positive",
@@ -449,5 +476,5 @@ export async function updateSignal(db: Db, id: string, patch: UpdateSignalInput)
       }).catch(() => undefined);
     }
   }
-  return toWire(updated);
+  return toWire(updated, [], undefined, agentNamesById);
 }

--- a/engine/src/core/monitor/webhooks.ts
+++ b/engine/src/core/monitor/webhooks.ts
@@ -1,30 +1,21 @@
 import { logger } from "../../log.js";
+import { outboundUrlProblem } from "../shared/urlGuard.js";
 // LangSmith-style "webhook automation" equivalent: monitor_profiles.channels was persisted from
 // the start (dashboard's per-agent settings dialog) but self-host never had any notification
 // delivery - nothing interpreted it. No new schema: a channel entry of the form `webhook:<url>`
 // is treated as a delivery target, everything else in `channels` (there's no other kind on
 // self-host yet) is left alone.
+//
+// Runtime egress guard (channels are stored free-form, so write-time validation alone can't
+// cover them): the shared outboundUrlProblem check - http(s) only, never a cloud metadata
+// endpoint, private targets gated only on multi-tenant. See core/shared/urlGuard.ts for the
+// full posture.
 
 export function extractWebhookUrls(channels: string[] | null | undefined): string[] {
   return (channels ?? [])
     .filter((c): c is string => typeof c === "string" && c.startsWith("webhook:"))
     .map(c => c.slice("webhook:".length).trim())
-    .filter(url => url.length > 0 && isSafeWebhookUrl(url));
-}
-
-// Runtime egress guard (channels are stored free-form, so write-time validation alone can't
-// cover them): http(s) only, and never a cloud metadata endpoint - a webhook pointed at
-// 169.254.169.254 is a server-side credential grab, not an alert channel. Loopback/private
-// targets stay allowed on purpose: self-host operators page their own local services.
-function isSafeWebhookUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
-    const host = url.hostname.toLowerCase();
-    return !(host === "metadata.google.internal" || host === "metadata.goog" || /^169\.254\./.test(host) || host === "fd00:ec2::254");
-  } catch {
-    return false;
-  }
+    .filter(url => url.length > 0 && outboundUrlProblem(url) === null);
 }
 
 export type WebhookSignal = {
@@ -70,6 +61,9 @@ export function postWebhooks(urls: string[], payload: Record<string, unknown>): 
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
       signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
+      // The URL was vetted, a redirect target was not - never follow one (it could bounce the
+      // POST to a metadata endpoint the guard just refused).
+      redirect: "manual",
     })
       .then(res => {
         // fetch only rejects on transport failure, so a 404 from a mistyped Slack URL was

--- a/engine/src/core/outcomes/outcomeReports.ts
+++ b/engine/src/core/outcomes/outcomeReports.ts
@@ -72,15 +72,6 @@ export async function createOutcomeReport(db: Db, input: CreateOutcomeReportInpu
   return toWire(row);
 }
 
-export async function listOutcomeReportRows(db: Db): Promise<OutcomeReportRow[]> {
-  const cond = eq(db.schema.outcomeReports.projectId, db.projectId);
-  const rows =
-    db.kind === "sqlite"
-      ? db.db.select().from(db.schema.outcomeReports).where(cond).all()
-      : await db.db.select().from(db.schema.outcomeReports).where(cond);
-  return rows as OutcomeReportRow[];
-}
-
 export async function listOutcomeReportsForTrace(db: Db, traceId: string): Promise<OutcomeReportRow[]> {
   const cond = and(eq(db.schema.outcomeReports.projectId, db.projectId), eq(db.schema.outcomeReports.traceId, traceId));
   const rows =

--- a/engine/src/core/shared/urlGuard.ts
+++ b/engine/src/core/shared/urlGuard.ts
@@ -1,5 +1,7 @@
-// Shared outbound-URL guard for every surface that fetches a caller-supplied URL server-side
-// (playground tool endpoints, MCP servers, connectors, webhooks, external scorers).
+// Shared outbound-URL guard for every surface that fetches a caller-supplied URL server-side.
+// Importers: playground tool endpoints (core/evaluate/playground.ts), MCP servers
+// (core/evaluate/mcp.ts), monitor webhooks (core/monitor/webhooks.ts), and custom/external
+// scorer URLs (routes/agentMonitoringDashboard.ts).
 //
 // The self-host posture is deliberate: loopback and RFC1918 targets are ALLOWED - operators
 // legitimately point tools at their own local vLLM/Ollama/webhook receivers, and blocking

--- a/engine/src/core/trace/spanKind.ts
+++ b/engine/src/core/trace/spanKind.ts
@@ -45,8 +45,9 @@ export type SpanKind = (typeof SPAN_KINDS)[number];
 // (mlflow.spanType), LangSmith (run_type) and Langfuse (observation type) - so a span that was
 // instrumented for any of them classifies correctly here without the producer changing anything.
 const ALIASES: Record<string, SpanKind> = {
-  // ours / OpenInference
+  // ours / OpenInference; OTel gen_ai.operation.name's newer "retrieve" spelling folds in too.
   retriever: "retrieval",
+  retrieve: "retrieval",
   // Langfuse calls an LLM call with prompt+usage a "generation"; OTel calls the operation "chat"
   // or "text_completion"; LangSmith calls the run type "llm".
   generation: "llm",
@@ -71,6 +72,11 @@ const ALIASES: Record<string, SpanKind> = {
   memory_store: "memory",
   memory_update: "memory",
   memory_retrieval: "memory",
+  memory_recall: "memory",
+  memory_add: "memory",
+  memory_delete: "memory",
+  add_memory: "memory",
+  get_memory: "memory",
   recall: "memory",
   // MLflow's own vocabulary for the rest.
   llm: "llm",

--- a/engine/src/core/trace/store/clickhouseTraceStore.ts
+++ b/engine/src/core/trace/store/clickhouseTraceStore.ts
@@ -245,6 +245,35 @@ export class ClickHouseTraceStore implements TraceStore {
     return rows.map(fromStored);
   }
 
+  async listForExport(args: { since?: Date | null; cursor?: string | null; limit: number }): Promise<TraceRow[]> {
+    const conds = [this.scope()];
+    const params: Record<string, unknown> = {};
+    if (args.since) {
+      conds.push("created_at >= {since:DateTime64(3)}");
+      params.since = args.since.toISOString().replace("T", " ").replace("Z", "");
+    }
+    if (args.cursor) {
+      conds.push("id > {cursor:String}");
+      params.cursor = args.cursor;
+    }
+    const rows = await this.rows(
+      `SELECT * FROM ${TABLE} WHERE ${conds.join(" AND ")} ORDER BY id ASC LIMIT ${Math.floor(args.limit)}`,
+      params
+    );
+    return rows.map(fromStored);
+  }
+
+  async countAll(since?: Date | null): Promise<number> {
+    const conds = [this.scope()];
+    const params: Record<string, unknown> = {};
+    if (since) {
+      conds.push("created_at >= {since:DateTime64(3)}");
+      params.since = since.toISOString().replace("T", " ").replace("Z", "");
+    }
+    const rows = await this.rows(`SELECT count(*) AS n FROM ${TABLE} WHERE ${conds.join(" AND ")}`, params);
+    return Number((rows[0] as { n?: unknown })?.n ?? 0);
+  }
+
   async listRecent(limit: number): Promise<TraceRow[]> {
     const rows = await this.rows(`SELECT * FROM ${TABLE} WHERE ${this.scope()} LIMIT ${Math.floor(limit)}`);
     return rows.map(fromStored);

--- a/engine/src/core/trace/store/sqlTraceStore.ts
+++ b/engine/src/core/trace/store/sqlTraceStore.ts
@@ -146,6 +146,48 @@ export class SqlTraceStore implements TraceStore {
     return rows as TraceRow[];
   }
 
+  async listForExport(args: { since?: Date | null; cursor?: string | null; limit: number }): Promise<TraceRow[]> {
+    const db = this.db;
+    const conds: SQL[] = [eq(db.schema.traces.projectId, db.projectId)];
+    if (args.since) conds.push(gte(db.schema.traces.createdAt, args.since));
+    if (args.cursor) conds.push(gt(db.schema.traces.id, args.cursor));
+    const rows =
+      db.kind === "sqlite"
+        ? db.db
+            .select()
+            .from(db.schema.traces)
+            .where(and(...conds))
+            .orderBy(asc(db.schema.traces.id))
+            .limit(args.limit)
+            .all()
+        : await db.db
+            .select()
+            .from(db.schema.traces)
+            .where(and(...conds))
+            .orderBy(asc(db.schema.traces.id))
+            .limit(args.limit);
+    return rows as TraceRow[];
+  }
+
+  async countAll(since?: Date | null): Promise<number> {
+    const db = this.db;
+    const conds: SQL[] = [eq(db.schema.traces.projectId, db.projectId)];
+    if (since) conds.push(gte(db.schema.traces.createdAt, since));
+    const rows = (
+      db.kind === "sqlite"
+        ? db.db
+            .select({ n: count() })
+            .from(db.schema.traces)
+            .where(and(...conds))
+            .all()
+        : await db.db
+            .select({ n: count() })
+            .from(db.schema.traces)
+            .where(and(...conds))
+    ) as { n: number | string }[];
+    return Number(rows[0]?.n ?? 0);
+  }
+
   async listRecent(limit: number): Promise<TraceRow[]> {
     const db = this.db;
     const cond = eq(db.schema.traces.projectId, db.projectId);

--- a/engine/src/core/trace/store/traceStore.ts
+++ b/engine/src/core/trace/store/traceStore.ts
@@ -85,6 +85,14 @@ export interface TraceStore {
    *  list's "X of N" pagination total. */
   countRootsPage(query: Omit<RootsPageQuery, "cursor" | "pageSize">): Promise<number>;
   queryWindow(filter: SpanWindowFilter): Promise<TraceRow[]>;
+  /** Export paging: every span (roots and children), id-keyset ordered, optional since on
+   *  createdAt. The backup surface reads spans through THIS, never the relational table -
+   *  on the ClickHouse tier the relational traces table is empty and a schema-driven export
+   *  streamed zero-byte files while reporting success. */
+  listForExport(args: { since?: Date | null; cursor?: string | null; limit: number }): Promise<TraceRow[]>;
+  /** Every span in the project (roots and children), optionally since createdAt - the export
+   *  manifest's honest count for the traces entity. */
+  countAll(since?: Date | null): Promise<number>;
   /** Root-span count in the project, optionally windowed (rate limits, volume estimates). */
   countRoots(since?: Date): Promise<number>;
   /**

--- a/engine/src/otel/mapping.ts
+++ b/engine/src/otel/mapping.ts
@@ -21,7 +21,14 @@ function strAttr(v: unknown): string | undefined {
 }
 
 function numAttr(v: unknown): number | undefined {
-  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+  if (typeof v === "number" && Number.isFinite(v)) {
+    return v;
+  }
+  // Some exporters send counts as stringValue attributes - a string of digits is still a number.
+  if (typeof v === "string" && /^\d+$/.test(v)) {
+    return Number(v);
+  }
+  return undefined;
 }
 
 function coerceToArray(value: unknown): unknown[] | undefined {
@@ -204,15 +211,24 @@ function extractToolCalls(span: NormalizedSpan) {
 export function otelSpanToIngestInput(span: NormalizedSpan): IngestTraceInput {
   const attrs = span.attributes;
 
-  const model = strAttr(attrs["gen_ai.response.model"]) ?? strAttr(attrs["gen_ai.request.model"]);
+  // OpenInference (llm.model_name / llm.token_count.*) rides at the end of each chain - Arize
+  // instrumentations send those instead of the gen_ai.* semconv names.
+  const model =
+    strAttr(attrs["gen_ai.response.model"]) ?? strAttr(attrs["gen_ai.request.model"]) ?? strAttr(attrs["llm.model_name"]);
   const framework =
     strAttr(attrs["gen_ai.provider.name"]) ??
     strAttr(attrs["gen_ai.system"]) ??
     span.scopeName ??
     strAttr(span.resourceAttributes["service.name"]) ??
     "otel";
-  const inputTokens = numAttr(attrs["gen_ai.usage.input_tokens"]) ?? numAttr(attrs["gen_ai.usage.prompt_tokens"]);
-  const outputTokens = numAttr(attrs["gen_ai.usage.output_tokens"]) ?? numAttr(attrs["gen_ai.usage.completion_tokens"]);
+  const inputTokens =
+    numAttr(attrs["gen_ai.usage.input_tokens"]) ??
+    numAttr(attrs["gen_ai.usage.prompt_tokens"]) ??
+    numAttr(attrs["llm.token_count.prompt"]);
+  const outputTokens =
+    numAttr(attrs["gen_ai.usage.output_tokens"]) ??
+    numAttr(attrs["gen_ai.usage.completion_tokens"]) ??
+    numAttr(attrs["llm.token_count.completion"]);
   // Semconv names for prompt-caching usage - subsets of inputTokens above, same posture as the
   // Python SDK's own per-integration extraction (see core/trace/ingest.ts's ingestTraceSchema).
   const cacheReadTokens = numAttr(attrs["gen_ai.usage.cache_read_input_tokens"]);
@@ -287,6 +303,8 @@ export function otelSpanToIngestInput(span: NormalizedSpan): IngestTraceInput {
     },
     input_tokens: inputTokens,
     output_tokens: outputTokens,
+    cache_read_tokens: cacheReadTokens,
+    cache_write_tokens: cacheWriteTokens,
   };
 }
 

--- a/engine/src/otel/normalize.ts
+++ b/engine/src/otel/normalize.ts
@@ -34,6 +34,11 @@ function idToHex(value: unknown): string | null {
   if ((value.length === 32 || value.length === 16) && /^[0-9a-fA-F]+$/.test(value)) {
     return value.toLowerCase();
   }
+  // Strict base64 charset check before decoding: Buffer.from silently skips invalid characters,
+  // so a garbage id would decode to garbage hex instead of being rejected as no id at all.
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
+    return null;
+  }
   return Buffer.from(value, "base64").toString("hex");
 }
 

--- a/engine/src/routes/admin.ts
+++ b/engine/src/routes/admin.ts
@@ -1,6 +1,5 @@
 import { secretEquals } from "../auth/secretEquals.js";
 import type { NextFunction, Request, Response } from "express";
-import { and, eq, gte, isNull, sql } from "drizzle-orm";
 import { asyncRouter } from "./asyncRouter.js";
 import { traceStoreFor } from "../core/trace/store/index.js";
 import { getDb } from "../storage/db.js";

--- a/engine/src/routes/agentMonitoringDashboard.ts
+++ b/engine/src/routes/agentMonitoringDashboard.ts
@@ -51,6 +51,7 @@ import { signTuningValidation, verifyTuningValidation,
   type TuningWindow,
 } from "../core/monitor/judgeTuning.js";
 import { getModelComparison } from "../core/monitor/modelComparison.js";
+import { outboundUrlProblem } from "../core/shared/urlGuard.js";
 import { listSessionScores } from "../core/monitor/sessionScores.js";
 import { listSessions } from "../core/monitor/sessions.js";
 import {
@@ -626,12 +627,25 @@ agentMonitoringDashboardRouter.get("/model-comparison", async (req: Request, res
   res.status(200).json(await getModelComparison(scopedDb(req), parseWindow(req)));
 });
 
+// Per-route ceiling for the judge-tuning trio and the on-demand session judge routes (each is
+// one unbudgeted judge call per request), ON TOP of the data-plane limiter the whole router
+// sits behind (apiV1.ts mounts it; CodeQL cannot see cross-file parent limiters, and these
+// routes deserve a tighter bound anyway: tune/validate are real LLM spend per call, publish
+// verifies provenance and writes rubric versions). 20/min is far above any human or SDK flow
+// and far below a brute-force loop.
+const tuningRouteLimit = rateLimitMiddleware({
+  windowMs: 60_000,
+  limit: 20,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+});
+
 // On-demand Session Baseline Judge run (core/monitor/sessionSweep.ts's runSessionBaselineCheck):
 // one real judge call over the whole assembled session against the built-in evaluator's config
 // (rubric lives there, not in code). Route path kept from the old hardcoded coherence check for
 // wire compat. 502 for a judge failure (missing key, provider outage) with the underlying
 // message, same convention as the suggest-human-feedback route above.
-agentMonitoringDashboardRouter.post("/sessions/:sessionId/coherence-check", async (req: Request, res: Response) => {
+agentMonitoringDashboardRouter.post("/sessions/:sessionId/coherence-check", tuningRouteLimit, async (req: Request, res: Response) => {
   try {
     const score = await runSessionBaselineCheck(scopedDb(req), req.params.sessionId!);
     if (!score) {
@@ -651,6 +665,7 @@ agentMonitoringDashboardRouter.post("/sessions/:sessionId/coherence-check", asyn
 // also covers is never judged twice.
 agentMonitoringDashboardRouter.post(
   "/sessions/:sessionId/judge/:evaluatorId",
+  tuningRouteLimit,
   async (req: Request, res: Response) => {
     try {
       if (req.query.ifStale === "true" && (await isSessionScoreFresh(scopedDb(req), req.params.sessionId!, req.params.evaluatorId!))) {
@@ -683,7 +698,7 @@ agentMonitoringDashboardRouter.get("/sessions", async (req: Request, res: Respon
 
 // Manual trigger for the idle-session sweep (core/monitor/sessionSweep.ts) - the production path
 // is the 60s interval started at boot; this exists for tests and demos that shouldn't have to
-// wait a tick. Sweeps ALL projects (the sweep is instance-wide by design), auth still required.
+// wait a tick.
 agentMonitoringDashboardRouter.post("/session-sweep/run", async (req: Request, res: Response) => {
   // Scoped to the caller's project (a key must not spend other tenants' budgets) and
   // serialized - a concurrent sweep returns { judged: 0, skipped: true } instead of
@@ -1180,18 +1195,6 @@ agentMonitoringDashboardRouter.get(
   }
 );
 
-// Per-route ceiling for the judge-tuning trio, ON TOP of the data-plane limiter the whole
-// router sits behind (apiV1.ts mounts it; CodeQL cannot see cross-file parent limiters, and
-// these routes deserve a tighter bound anyway: tune/validate are real LLM spend per call,
-// publish verifies provenance and writes rubric versions). 20/min is far above any human or
-// SDK flow and far below a brute-force loop.
-const tuningRouteLimit = rateLimitMiddleware({
-  windowMs: 60_000,
-  limit: 20,
-  standardHeaders: "draft-7",
-  legacyHeaders: false,
-});
-
 agentMonitoringDashboardRouter.post("/online-evaluators/:evaluatorId/tune", tuningRouteLimit, async (req: Request, res: Response) => {
   const body = req.body ?? {};
   try {
@@ -1324,7 +1327,9 @@ agentMonitoringDashboardRouter.post(
         acceptanceCriteria: body.acceptanceCriteria,
         rejectionCriteria: body.rejectionCriteria,
         evaluationCriteria: body.evaluationCriteria,
-        judgePrompt: typeof body.judgePrompt === "string" && body.judgePrompt.trim() ? body.judgePrompt : undefined,
+        // Must match validate's sign-side predicate exactly (any string counts, blank included)
+        // or a validated blank judgePrompt fails token verification on publish.
+        judgePrompt: typeof body.judgePrompt === "string" ? body.judgePrompt : undefined,
       });
       if (!verified) {
         res.status(409).json({
@@ -1372,18 +1377,10 @@ function isValidHttpUrl(value: unknown): value is string {
   if (typeof value !== "string" || !value.trim()) {
     return false;
   }
-  try {
-    const url = new URL(value.trim());
-    if (url.protocol !== "http:" && url.protocol !== "https:") {
-      return false;
-    }
-    // Same egress posture as connectors/webhooks: loopback/private allowed (self-host reality),
-    // cloud metadata endpoints never - an external scorer pointed there is a credential grab.
-    const host = url.hostname.toLowerCase();
-    return !(host === "metadata.google.internal" || host === "metadata.goog" || /^169\.254\./.test(host) || host === "fd00:ec2::254");
-  } catch {
-    return false;
-  }
+  // The shared egress guard (core/shared/urlGuard.ts): http(s) only, cloud metadata endpoints
+  // never (an external scorer pointed there is a credential grab), private targets gated only
+  // on multi-tenant.
+  return outboundUrlProblem(value) === null;
 }
 
 agentMonitoringDashboardRouter.get("/custom-evaluators", async (req: Request, res: Response) => {

--- a/engine/src/routes/evaluations.ts
+++ b/engine/src/routes/evaluations.ts
@@ -149,6 +149,11 @@ evaluationsRouter.post("/runs", async (req: Request, res: Response) => {
   }
   // A typo'd (or cross-project) group id must not silently downgrade the whole run to the
   // dataset's own grading - the 201 would look identical and nothing downstream could tell.
+  // Non-string values are a 400, not a silent drop, for exactly the same reason.
+  if (scorerGroupId !== undefined && scorerGroupId !== null && typeof scorerGroupId !== "string") {
+    res.status(400).json({ error: "scorerGroupId must be a string" });
+    return;
+  }
   if (typeof scorerGroupId === "string" && scorerGroupId && !(await getScorerGroup(scopedDb(req), scorerGroupId))) {
     res.status(404).json({ error: "Scorer group not found" });
     return;
@@ -174,8 +179,8 @@ evaluationsRouter.post("/runs", async (req: Request, res: Response) => {
 
 evaluationsRouter.post("/runs/:runId/results", async (req: Request, res: Response) => {
   const { batchId, results } = req.body ?? {};
-  if (!batchId) {
-    res.status(400).json({ error: "batchId is required" });
+  if (typeof batchId !== "string" || !batchId) {
+    res.status(400).json({ error: "batchId must be a non-empty string" });
     return;
   }
   if (!Array.isArray(results) || results.length === 0) {
@@ -206,7 +211,8 @@ evaluationsRouter.post("/runs/:runId/results", async (req: Request, res: Respons
     // The only expected throw is the terminal-state guard - a real conflict. Anything else is
     // an engine fault and must not masquerade as one.
     const message = err instanceof Error ? err.message : "Unable to append results";
-    if (message.includes("terminal state") || message.includes("scorer group grading this run")) {
+    // Tagged at the throw sites (runs.ts) - matching prose here broke silently on any reword.
+    if ((err as { code?: string }).code === "conflict") {
       res.status(409).json({ error: message });
       return;
     }

--- a/engine/src/routes/exportData.ts
+++ b/engine/src/routes/exportData.ts
@@ -16,10 +16,12 @@ import {
 // /export/:entity streams the rows as NDJSON (one JSON object per line, exactly the stored
 // shape - timestamps serialize as ISO-8601). `?since=` takes any ISO date for incremental
 // pulls. Project-scoped like every data-plane route: the API key IS the project selection, so
-// an export can never cross a tenant boundary. Restore is documented in the self-host backup
-// runbook: replay (traces re-POST through /ingest) or database-level (pg_dump / SQLite file
-// copy) - there is deliberately no blind row-level import endpoint that could corrupt
-// engine-owned invariants (dedupe, id uniqueness, derived agent rows).
+// an export can never cross a tenant boundary. On restore: re-POSTing exported traces to
+// /ingest is LOSSY - rows get new ids and restore-time timestamps, and everything keyed on the
+// old trace ids (outcome reports, review labels, monitor events) ends up orphaned. Database-
+// level restore (pg_dump / SQLite file copy) is the fidelity path; this export exists for
+// portability and offline analysis. There is deliberately no blind row-level import endpoint
+// that could corrupt engine-owned invariants (dedupe, id uniqueness, derived agent rows).
 export const exportRouter = asyncRouter();
 
 exportRouter.get("/", async (req: Request, res: Response) => {
@@ -62,11 +64,21 @@ exportRouter.get("/:entity", async (req: Request, res: Response) => {
         // Respect socket backpressure so a huge table never balloons the response buffer.
         // Wait on drain OR close: a destroyed socket never drains, and waiting only on
         // drain leaked this handler (and its DB cursor loop) for the process lifetime on
-        // every aborted export.
+        // every aborted export. Whichever fires removes the other - once() only cleans up
+        // the listener that ran, and a long export pauses here thousands of times, so the
+        // losers otherwise pile up until the emitter warns (and leak per pause).
         if (!res.write(`${JSON.stringify(row)}\n`)) {
           await new Promise<void>(resolve => {
-            res.once("drain", resolve);
-            res.once("close", resolve);
+            const onDrain = () => {
+              res.off("close", onClose);
+              resolve();
+            };
+            const onClose = () => {
+              res.off("drain", onDrain);
+              resolve();
+            };
+            res.once("drain", onDrain);
+            res.once("close", onClose);
           });
           if (res.destroyed) {
             return;

--- a/engine/src/routes/insights.ts
+++ b/engine/src/routes/insights.ts
@@ -115,7 +115,8 @@ const curateSchema = z.object({
   // Bounded: "fill the whole target" is at most a dozen cases; anything larger is a bulk import,
   // which has its own surface.
   limit: z.number().int().min(1).max(12).optional(),
-});
+})
+  .strip();
 
 insightsRouter.post("/topics/curate", validateBody(curateSchema), async (req: Request, res: Response) => {
   const body = req.body as z.infer<typeof curateSchema>;

--- a/engine/src/test/pairwise.integration.test.ts
+++ b/engine/src/test/pairwise.integration.test.ts
@@ -110,6 +110,7 @@ describe("pairwise comparison", () => {
             ties: number;
             winner: string;
             flipRate: number | null;
+            errors: number;
           };
           cases: {
             presentedFirst: string;
@@ -124,13 +125,16 @@ describe("pairwise comparison", () => {
     ).comparison;
     batchId = comparison.batchId;
 
-    expect(comparison.summary.total).toBe(2);
+    expect(comparison.cases).toHaveLength(2);
     expect(comparison.cases.map(c => c.presentedFirst)).toEqual(["a", "b"]);
-    // With no key every judge call throws, and an unresolved pair is a tie rather than a win for
-    // whichever run happened to be presented first.
-    expect(comparison.summary.ties).toBe(2);
+    // With no key every judge call throws. An errored pair is stored as a tie (never a win for
+    // whichever run happened to be presented first) but reported as an error, excluded from the
+    // win/tie counts rather than dressed up as a real verdict.
+    expect(comparison.summary.total).toBe(0);
+    expect(comparison.summary.errors).toBe(2);
+    expect(comparison.summary.ties).toBe(0);
     expect(comparison.summary.winner).toBe("tie");
-    expect(comparison.cases[0]!.justification).toContain("Judging failed");
+    expect(comparison.cases[0]!.justification).toContain("JUDGE_ERROR");
     // flipRate is null unless both orders were actually judged - not a fabricated 0.
     expect(comparison.summary.flipRate).toBeNull();
     expect(comparison.bothOrders).toBe(false);
@@ -169,12 +173,15 @@ describe("pairwise comparison", () => {
     const comparison = (
       created.body as {
         comparison: {
-          summary: { total: number };
+          summary: { total: number; errors: number };
+          cases: unknown[];
           skipped: { questionIndex: number; reason: string }[];
         };
       }
     ).comparison;
-    expect(comparison.summary.total).toBe(1);
+    // The one judgeable case errors (no key), so it lands in `errors`, not `total`.
+    expect(comparison.cases).toHaveLength(1);
+    expect(comparison.summary.total + comparison.summary.errors).toBe(1);
     expect(comparison.skipped).toHaveLength(1);
     expect(comparison.skipped[0]!.reason).toContain("no output");
 


### PR DESCRIPTION
<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
