### PR TITLE
fix Gemini / OpenRouter / vLLM / Ollama judge call with 404

### DIFF
--- a/engine/src/auth/betterAuth.ts
+++ b/engine/src/auth/betterAuth.ts
@@ -312,13 +312,18 @@ export async function needsSetup(db: Db): Promise<boolean> {
 
 // Session-signing secret: explicit env wins; otherwise generated once and persisted in
 // app_settings (instance-wide) so sessions survive restarts without any required setup step.
+// The instance singleton row is ALWAYS id "default" - the same key appSettings.ts uses.
+// These readers used to take LIMIT 1 with no predicate and insert random ids, so the table
+// grew multiple pretender rows and heap order decided which one each boot read: the session
+// secret rotated (logging everyone out), and the whole-table casefold + metric-pack backfills
+// re-ran, per boot, forever. Multi-tenant "org:<id>" rows must never carry instance flags.
 export async function resolveAuthSecret(db: Db): Promise<string> {
   const fromEnv = process.env.AGENTX_AUTH_SECRET?.trim();
   if (fromEnv) return fromEnv;
   const existing =
     db.kind === "sqlite"
-      ? db.db.select().from(db.schema.appSettings).limit(1).all()[0]
-      : (await db.db.select().from(db.schema.appSettings).limit(1))[0];
+      ? db.db.select().from(db.schema.appSettings).where(eq(db.schema.appSettings.id, "default")).limit(1).all()[0]
+      : (await db.db.select().from(db.schema.appSettings).where(eq(db.schema.appSettings.id, "default")).limit(1))[0];
   if (existing?.authSecret) return existing.authSecret as string;
   const secret = randomBytes(32).toString("hex");
   if (existing) {
@@ -326,7 +331,7 @@ export async function resolveAuthSecret(db: Db): Promise<string> {
     if (db.kind === "sqlite") await db.db.update(db.schema.appSettings).set({ authSecret: secret }).where(cond);
     else await db.db.update(db.schema.appSettings).set({ authSecret: secret }).where(cond);
   } else {
-    const row = { id: nanoid(), openaiApiKey: null, anthropicApiKey: null, geminiApiKey: null, authSecret: secret, updatedAt: new Date() };
+    const row = { id: "default", openaiApiKey: null, anthropicApiKey: null, geminiApiKey: null, authSecret: secret, updatedAt: new Date() };
     if (db.kind === "sqlite") await db.db.insert(db.schema.appSettings).values(row);
     else await db.db.insert(db.schema.appSettings).values(row);
   }

--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -408,10 +408,12 @@ export const insightsCoverageResponseSchema = z
 export const insightsProbeResponseSchema = z
   .object({
     query: z.string(),
-    verdict: z.enum(["covered", "adjacent", "gap", "untested-and-unasked"]),
+    verdict: z.enum(["covered", "adjacent", "gap", "untested-and-unasked", "warming"]),
     similarity: z.number(),
     bands: z.object({ covered: z.number(), related: z.number() }).strict(),
     degraded: z.boolean(),
+    // Cases still embedding - a negative verdict downgrades to "warming" while non-zero.
+    pendingCases: z.number(),
     nearestCases: z.array(
       z
         .object({

--- a/engine/src/core/evaluate/agentConnectors.ts
+++ b/engine/src/core/evaluate/agentConnectors.ts
@@ -1,6 +1,8 @@
 import { nanoid } from "nanoid";
 import { and, eq } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
+import { maskSecret, isMaskedSecret } from "../shared/maskSecret.js";
+import { outboundUrlProblem } from "../shared/urlGuard.js";
 
 // "How to invoke my deployed agent" - modeled directly on core/monitor/customEvaluators.ts's CRUD
 // shape (same webhook-config idea, different contract: a connector returns an agent's answer to
@@ -27,14 +29,29 @@ export type AgentConnectorRow = {
 };
 
 function toWire(row: AgentConnectorRow) {
+  // Header VALUES are where bearer tokens live - the one purpose of the field. Every other
+  // stored secret masks on read (provider keys, per-model keys); echoing these verbatim put a
+  // production credential in every GET, and in the NDJSON export. Keys stay readable so the
+  // editor can list what's set; a masked value sent back on PUT means "unchanged".
+  const headers = (row.headers as Record<string, string> | null) ?? {};
   return {
     _id: row.id,
     name: row.name,
     url: row.url,
-    headers: (row.headers as Record<string, string> | null) ?? {},
+    headers: Object.fromEntries(Object.entries(headers).map(([k, v]) => [k, maskSecret(String(v))])),
     timeoutMs: row.timeoutMs,
     createdAt: row.createdAt.toISOString(),
   };
+}
+
+
+// PUT round-trips: a value that still carries the read-side mask means "keep what's stored".
+function unmaskHeaders(incoming: Record<string, string> | null, stored: unknown): Record<string, string> | null {
+  if (!incoming) return incoming;
+  const previous = (stored as Record<string, string> | null) ?? {};
+  return Object.fromEntries(
+    Object.entries(incoming).map(([k, v]) => [k, isMaskedSecret(v) && previous[k] !== undefined ? previous[k]! : v])
+  );
 }
 
 export async function createAgentConnector(db: Db, input: CreateAgentConnectorInput) {
@@ -93,7 +110,7 @@ export async function updateAgentConnector(db: Db, id: string, input: UpdateAgen
     ...existing,
     name: input.name ?? existing.name,
     url: input.url ?? existing.url,
-    headers: input.headers !== undefined ? input.headers : existing.headers,
+    headers: input.headers !== undefined ? unmaskHeaders(input.headers, existing.headers) : existing.headers,
     timeoutMs: input.timeoutMs ?? existing.timeoutMs,
   };
   const setValues = { name: updated.name, url: updated.url, headers: updated.headers, timeoutMs: updated.timeoutMs };
@@ -149,23 +166,68 @@ export type AgentConnectorResponse = {
   latencyMs?: number;
 };
 
-// Throws on any failure (network error, timeout, non-2xx, missing string `output`) - same posture
-// as callCustomEvaluator; callers (runDatasetAgainstConnector, the dashboard's test-connection
-// route) decide how to present/isolate a failure.
+// One agent answer plus metadata - 2MB is far beyond any real one, and without a cap a hostile
+// or misconfigured endpoint streams unbounded bytes into this process's memory.
+const MAX_CONNECTOR_RESPONSE_BYTES = 2 * 1024 * 1024;
+
+// Reads up to the cap, then cancels the transfer - checking content-length alone would miss
+// chunked responses, and res.text() would have buffered everything before any length check ran.
+async function readConnectorBody(res: Response, url: string): Promise<string> {
+  const reader = res.body?.getReader();
+  if (!reader) {
+    return "";
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_CONNECTOR_RESPONSE_BYTES) {
+      await reader.cancel().catch(() => {});
+      throw new Error(`Agent connector ${url} response exceeded ${MAX_CONNECTOR_RESPONSE_BYTES / (1024 * 1024)}MB - aborted`);
+    }
+    chunks.push(Buffer.from(value));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+// Throws on any failure (refused URL, network error, timeout, non-2xx, oversized body, missing
+// string `output`) - same posture as callCustomEvaluator; callers (runDatasetAgainstConnector,
+// the dashboard's test-connection route) decide how to present/isolate a failure.
 export async function callAgentConnector(
   connector: Pick<AgentConnectorRow, "url" | "headers" | "timeoutMs">,
   payload: AgentConnectorRequest
 ): Promise<AgentConnectorResponse> {
+  // Checked per call, not only at write time: a stored URL outlives any posture change, and the
+  // error string lands in the run result where the operator can see WHY the case failed.
+  const urlProblem = outboundUrlProblem(connector.url);
+  if (urlProblem) {
+    throw new Error(`Agent connector URL refused (${connector.url}): ${urlProblem}`);
+  }
   const res = await fetch(connector.url, {
     method: "POST",
     headers: { "Content-Type": "application/json", ...((connector.headers as Record<string, string> | null) ?? {}) },
     body: JSON.stringify(payload),
     signal: AbortSignal.timeout(connector.timeoutMs),
+    // The URL was vetted, a redirect target was not - never follow one (same posture as
+    // core/monitor/webhooks.ts). A 3xx surfaces below as a non-2xx failure.
+    redirect: "manual",
   });
   if (!res.ok) {
     throw new Error(`Agent connector ${connector.url} responded ${res.status}`);
   }
-  const body = (await res.json()) as {
+  const raw = await readConnectorBody(res, connector.url);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    parsed = null;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error(`Agent connector ${connector.url} did not return a JSON object`);
+  }
+  const body = parsed as {
     output?: unknown;
     toolCalls?: unknown;
     error?: unknown;

--- a/engine/src/core/evaluate/analysis.ts
+++ b/engine/src/core/evaluate/analysis.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import { getRunRowFull, getRunResults, type RunResultRow } from "./runs.js";
 import { resolvePlatformModel, callJudgeJson } from "./judge.js";
+import { mapWithConcurrency } from "../shared/concurrency.js";
 import { analysisNarrativeSchemaProperties, type AnalysisNarrative } from "@agentx/judge-core";
 
 // Self-host's own "Analyze" (AI Analysis) feature - see the plan's Context section for why this
@@ -177,12 +178,14 @@ async function scoreItemWithJudges(row: RunResultRow, judgeModels: string[]): Pr
   };
 }
 
-// All sample items scored in parallel too, not just the judges within each item - worst case
-// (SAMPLE_WORST_COUNT + SAMPLE_BEST_COUNT) x MAX_JUDGES concurrent judge calls for one "Start
-// Analysis" click. Acceptable for a manual, infrequent, user-initiated action; revisit with
-// chunking/concurrency limits if that turns out to be too aggressive against provider rate limits.
+// Bounded fan-out: the unbounded version fired (SAMPLE_WORST + SAMPLE_BEST) x MAX_JUDGES
+// concurrent judge calls (up to 51) for one click - past provider rate limits, and wide open
+// as a check-then-act window on the daily judge quota (all 51 read "under cap" before any
+// recorded). Eight in flight keeps the click fast while shrinking both.
+const ANALYSIS_ITEM_CONCURRENCY = 8;
+
 async function scoreSampleWithJudges(sample: RunResultRow[], judgeModels: string[]): Promise<JudgeEvidenceSampleItem[]> {
-  return Promise.all(sample.map(row => scoreItemWithJudges(row, judgeModels)));
+  return mapWithConcurrency(sample, ANALYSIS_ITEM_CONCURRENCY, row => scoreItemWithJudges(row, judgeModels));
 }
 
 const ANALYSIS_JSON_SCHEMA = {
@@ -247,24 +250,21 @@ export async function getEvaluationAnalysisRow(db: Db, evaluationId: string): Pr
 }
 
 async function upsertEvaluationAnalysisRow(db: Db, row: EvaluationAnalysisRow): Promise<void> {
-  const existing = await getEvaluationAnalysisRow(db, row.evaluationId);
-  if (existing) {
-    const updateCond = and(
-      eq(db.schema.evaluationAnalyses.evaluationId, row.evaluationId),
-      eq(db.schema.evaluationAnalyses.projectId, db.projectId)
-    );
-    if (db.kind === "sqlite") {
-      await db.db.update(db.schema.evaluationAnalyses).set(row).where(updateCond);
-    } else {
-      await db.db.update(db.schema.evaluationAnalyses).set(row).where(updateCond);
-    }
-    return;
-  }
+  // Atomic on the table's real primary key (evaluationId). The old read-then-branch raced a
+  // double-click into a raw PK violation after both requests paid the full judge fan-out, and
+  // could never update a legacy row whose projectId is null (the read filtered on projectId,
+  // narrower than the constraint).
   const insertRow = { ...row, projectId: db.projectId };
   if (db.kind === "sqlite") {
-    await db.db.insert(db.schema.evaluationAnalyses).values(insertRow);
+    await db.db
+      .insert(db.schema.evaluationAnalyses)
+      .values(insertRow)
+      .onConflictDoUpdate({ target: db.schema.evaluationAnalyses.evaluationId, set: insertRow });
   } else {
-    await db.db.insert(db.schema.evaluationAnalyses).values(insertRow);
+    await db.db
+      .insert(db.schema.evaluationAnalyses)
+      .values(insertRow)
+      .onConflictDoUpdate({ target: db.schema.evaluationAnalyses.evaluationId, set: insertRow });
   }
 }
 
@@ -275,7 +275,28 @@ export type AnalyzeEvaluationOptions = {
 
 export type AnalyzeEvaluationResult = { evaluationId: string; status: "completed" | "failed"; judgeModel: string };
 
+// One in-flight analysis per run: a second Start-Analysis click (or a poll-triggered retry)
+// joins the first instead of re-paying the full items x judges judge fan-out.
+const analysisInFlight = new Map<string, Promise<AnalyzeEvaluationResult | null>>();
+
 export async function runEvaluationAnalysis(
+  db: Db,
+  evaluationId: string,
+  opts: AnalyzeEvaluationOptions = {}
+): Promise<AnalyzeEvaluationResult | null> {
+  const inFlightKey = `${db.projectId ?? ""}|${evaluationId}`;
+  const inFlight = analysisInFlight.get(inFlightKey);
+  if (inFlight) {
+    return inFlight;
+  }
+  const task = runEvaluationAnalysisInner(db, evaluationId, opts).finally(() => {
+    analysisInFlight.delete(inFlightKey);
+  });
+  analysisInFlight.set(inFlightKey, task);
+  return task;
+}
+
+async function runEvaluationAnalysisInner(
   db: Db,
   evaluationId: string,
   opts: AnalyzeEvaluationOptions = {}
@@ -285,7 +306,9 @@ export async function runEvaluationAnalysis(
     return null;
   }
   const requested = (opts.judges ?? []).map(j => j.model).filter((m): m is string => !!m);
-  const judgeModels = (requested.length ? requested : [await resolvePlatformModel(db)]).slice(0, MAX_JUDGES);
+  // Deduped: the same model sent three times would triple the spend and report manufactured
+  // "unanimous" inter-judge agreement.
+  const judgeModels = [...new Set(requested.length ? requested : [await resolvePlatformModel(db)])].slice(0, MAX_JUDGES);
   const judgeModel = judgeModels[0]!;
   const results = await getRunResults(db, evaluationId);
   const statistics = computeStatistics(results);

--- a/engine/src/core/evaluate/codeScorer.ts
+++ b/engine/src/core/evaluate/codeScorer.ts
@@ -59,7 +59,10 @@ type ScorerArgs = { input: string; output: string; expected?: string; toolCalls?
 // realm, so `this.constructor.constructor("return process")()` hands a scorer the real `process`
 // (checked, not assumed). Treat scorer code as code the operator chose to run on their own machine
 // and do not expose dataset creation to anyone who should not have that. Real sandboxing needs an
-// isolate or a subprocess, neither of which survives `bun build --compile`.
+// isolate or a subprocess, neither of which survives `bun build --compile`. The same constraint
+// means there is NO heap cap: a scorer that allocates unboundedly (`while(1) a.push(...)`) can
+// OOM the engine process before the sync timeout fires - accepted under the same trust posture,
+// stated here so nobody mistakes the timeout for a resource boundary.
 //
 // Every failure (syntax error, thrown error, timeout, bad return shape) is caught here and folded
 // into { score: null, error } rather than propagated - one broken/timed-out scorer must not take
@@ -79,13 +82,17 @@ function executeInSandbox(code: string, args: ScorerArgs): unknown {
   // The function call happens inside the same runInContext call as the compile, not as a
   // separately-invoked reference afterward - the latter would run outside the timeout window
   // entirely, since vm only bounds synchronous execution during the call it wraps.
+  // Cloned per scorer: runs.ts hands EVERY scorer in a result the same scores/toolCalls
+  // objects, so without the clone one scorer's `scores.rating = 10` mutated what its siblings
+  // (and the stored trace row's live array) read. structuredClone also severs the prototype
+  // chain hop into the outer realm for these payloads specifically.
   const context = vm.createContext({
     __args: {
       input: args.input,
       output: args.output,
       expected: args.expected,
-      toolCalls: args.toolCalls,
-      scores: args.scores,
+      toolCalls: args.toolCalls === undefined ? undefined : structuredClone(args.toolCalls),
+      scores: args.scores === undefined ? undefined : structuredClone(args.scores),
     },
   });
   const wrapped = `(function({ input, output, expected, toolCalls, scores }) {\n${code}\n})(__args);`;

--- a/engine/src/core/evaluate/connectorRun.ts
+++ b/engine/src/core/evaluate/connectorRun.ts
@@ -117,7 +117,7 @@ async function driveConnectorRun(
               outputTokens: response.outputTokens,
             };
             return {
-              idempotencyKey: nanoid(),
+              idempotencyKey: `${runId}:${questionIndex}:${runNumber}`,
               questionIndex,
               runNumber,
               input: { query },
@@ -127,7 +127,7 @@ async function driveConnectorRun(
             };
           } catch (err) {
             return {
-              idempotencyKey: nanoid(),
+              idempotencyKey: `${runId}:${questionIndex}:${runNumber}`,
               questionIndex,
               runNumber,
               input: { query },
@@ -143,7 +143,14 @@ async function driveConnectorRun(
     }
     await finalizeRun(db, runId);
   } catch (err) {
-    logger.error({ err: err instanceof Error ? err.message : err }, `Connector-driven run ${runId} failed:`);
+    // A terminal-state conflict means someone legitimately finalized the run under us - the
+    // results already stored are the run; failing it would erase a completed status.
+    const message = err instanceof Error ? err.message : String(err);
+    if ((err as { code?: string }).code === "conflict" || message.includes("terminal state")) {
+      logger.warn({ runId }, "Connector run finalized elsewhere mid-drive; leaving its status untouched");
+      return;
+    }
+    logger.error({ err: message }, `Connector-driven run ${runId} failed:`);
     await failRun(db, runId);
   }
 }

--- a/engine/src/core/evaluate/curation.ts
+++ b/engine/src/core/evaluate/curation.ts
@@ -247,21 +247,25 @@ async function addCaseToDatasetSerialized(
 
   // Fresh re-read directly before the write: the dedupe pass above awaited embeddings, and a
   // write that raced in through another path (bulk coverage add, a dashboard edit) must be
-  // appended TO, not clobbered with our stale copy.
-  const fresh = (await getDataset(db, datasetId)) as (Record<string, unknown> & { questions: unknown }) | null;
-  const freshQuestions = (Array.isArray(fresh?.questions) ? fresh!.questions : questions) as ExistingQuestion[];
+  // appended TO, not clobbered with our stale copy. The WHOLE update body comes from the fresh
+  // row, not just questions - a name/criteria edit that raced in must survive this write too.
+  const fresh = (await getDataset(db, datasetId)) as
+    | (Record<string, unknown> & { name: string; questions: unknown })
+    | null;
+  const snapshot = fresh ?? dataset;
+  const freshQuestions = (Array.isArray(snapshot.questions) ? snapshot.questions : questions) as ExistingQuestion[];
 
   // updateDataset (not a raw column write) so the append lands in version history like any other
   // dataset edit. The wire shape spreads similarityConfig flat, so extract helpers map it back.
   await updateDataset(db, datasetId, {
-    name: dataset.name,
-    description: (dataset.description as string | undefined) ?? undefined,
-    numberOfRequests: (dataset.numberOfRequests as number | undefined) ?? undefined,
-    similarityConfig: extractSimilarityConfig(dataset),
-    codeScorers: extractCodeScorers(dataset),
-    acceptanceCriteria: (dataset.acceptanceCriteria as string | undefined) ?? undefined,
-    rejectionCriteria: (dataset.rejectionCriteria as string | undefined) ?? undefined,
-    evaluationCriteria: (dataset.evaluationCriteria as string | undefined) ?? undefined,
+    name: snapshot.name,
+    description: (snapshot.description as string | undefined) ?? undefined,
+    numberOfRequests: (snapshot.numberOfRequests as number | undefined) ?? undefined,
+    similarityConfig: extractSimilarityConfig(snapshot),
+    codeScorers: extractCodeScorers(snapshot),
+    acceptanceCriteria: (snapshot.acceptanceCriteria as string | undefined) ?? undefined,
+    rejectionCriteria: (snapshot.rejectionCriteria as string | undefined) ?? undefined,
+    evaluationCriteria: (snapshot.evaluationCriteria as string | undefined) ?? undefined,
     questions: [...freshQuestions, curatedCase],
   });
   return { ok: true, caseCount: freshQuestions.length + 1 };

--- a/engine/src/core/evaluate/judge.ts
+++ b/engine/src/core/evaluate/judge.ts
@@ -279,7 +279,7 @@ ${criteria.evaluationCriteria ? `**Evaluation Criteria:** ${criteria.evaluationC
     strictSchema: true,
     userMessage: `${substitutedPrompt}\n${additionalContext}`,
   });
-  const payload = judgeResult.payload as { rating: number; justification: string } | null;
+  const payload = judgeResult.payload as { rating: unknown; justification?: unknown } | null;
   if (!payload) {
     // A judge that returned nothing usable is a FAILURE, not a verdict. This used to return
     // rating 0, which offline was averaged into the run/gate as if the agent had answered
@@ -288,7 +288,17 @@ ${criteria.evaluationCriteria ? `**Evaluation Criteria:** ${criteria.evaluationC
     // (offline: status "skipped", rating null; online: judge_failure event, no Signal).
     throw new JudgeFailedError(judgeResult.failureReason ?? "emptyResponse");
   }
-  return { rating: payload.rating, justification: payload.justification };
+  // Only real-OpenAI strict mode guarantees the schema's types - Anthropic, Gemini and custom
+  // endpoints can answer {"rating": "8"} or a percent-scale 85. A string rating used to reach
+  // the run column, where averaging CONCATENATED it; clamp to the rubric's 0-10 instead.
+  const rating = Number(payload.rating);
+  if (!Number.isFinite(rating)) {
+    throw new JudgeFailedError("parseError");
+  }
+  return {
+    rating: Math.max(0, Math.min(10, rating)),
+    justification: typeof payload.justification === "string" ? payload.justification : "",
+  };
 }
 
 // The judge model was reachable but produced no usable verdict (empty response or unparseable
@@ -330,7 +340,7 @@ export async function callJudgeJson({
     throw new Error(`Judge model "${model}" needs a ${keyLabel} API key. Set ${envVar} and restart agentx-server.`);
   }
 
-  return callJudgeJsonShared({
+  const result = await callJudgeJsonShared({
     userMessage,
     model,
     jsonSchema,
@@ -339,6 +349,9 @@ export async function callJudgeJson({
     // (Gemini, vLLM/Ollama/... custom baseURLs) don't reliably implement json_schema strict
     // mode, and a rejected request would turn a fine judge model into a scoring failure.
     strictSchema: strictSchema && !isGemini && !isCustom,
+    // Compat endpoints implement /chat/completions, not the Responses API - routing them
+    // there 404ed every judge call, skipping every result they were asked to score.
+    useChatCompletions: isGemini || isCustom,
     openaiClient,
     anthropicClient: await getAnthropic(),
     // Authoritative: judge-core must not re-derive routing from the model NAME - a custom
@@ -346,6 +359,12 @@ export async function callJudgeJson({
     // upstream id) would otherwise be sent to the Anthropic client, ignoring its baseUrl.
     provider,
   });
+  if (result.retried) {
+    // judge-core's automatic empty/parse-failure retry is a second real provider call - the
+    // billing ledger under-counted by up to 2x on flaky generations without this.
+    await checkAndRecordJudgeCall(model);
+  }
+  return result;
 }
 
 // Vector similarity needs an OpenAI client for embeddings regardless of which provider judges the
@@ -404,7 +423,7 @@ async function embedOnce(
   client: EmbeddingClient,
   model: string,
   inputs: string[]
-): Promise<(number[] | null)[] | null> {
+): Promise<(number[] | null)[] | null | "transient"> {
   try {
     const response = (await client.embeddings.create({ model, input: inputs })) as {
       data?: { index: number; embedding: unknown }[];
@@ -423,7 +442,12 @@ async function embedOnce(
     // Logged by the caller, which is the only place that knows whether this is a batch about to be
     // split and retried or a single input that is genuinely unembeddable.
     logger.debug({ err: err instanceof Error ? err.message : err, inputs: inputs.length }, "Embedding batch failed");
-    return null;
+    // 400/413 = payload problem, worth halving to isolate the oversized input. Anything else
+    // (429, 5xx, timeout) is the PROVIDER failing - splitting would fire 2^k requests at an
+    // endpoint that just said stop; report it as transient so the caller leaves the whole
+    // batch pending for the next request instead.
+    const status = (err as { status?: number }).status;
+    return status === 400 || status === 413 ? null : "transient";
   }
 }
 
@@ -439,6 +463,11 @@ async function embedSplit(
   inputs: string[]
 ): Promise<(number[] | null)[]> {
   const direct = await embedOnce(client, model, inputs);
+  if (direct === "transient") {
+    // Provider outage/rate limit - the whole batch stays unembedded (callers already treat
+    // null vectors as pending) rather than recursing into a request storm.
+    return new Array<number[] | null>(inputs.length).fill(null);
+  }
   if (direct) {
     return direct;
   }
@@ -583,6 +612,10 @@ export type ModelWithToolsResult = {
   text: string;
   usage: { inputTokens: number; outputTokens: number } | null;
   toolCalls: ToolCallTrace[];
+  // True when MAX_TOOL_ROUNDS cut the loop off mid-trajectory. The empty text is then OUR
+  // truncation, not the model's answer - callers must not judge it as one (an empty string
+  // scored ~0 is a fabricated verdict about the agent).
+  truncated?: boolean;
 };
 
 // In-process CPU/network-bound loop, not a hard cost cap - just enough to stop a prompt that keeps
@@ -670,7 +703,7 @@ export async function callModelWithTools(
       messages.push({ role: "user", content: toolResults });
     }
 
-    return { text: "", usage: { inputTokens, outputTokens }, toolCalls };
+    return { text: "", usage: { inputTokens, outputTokens }, toolCalls, truncated: true };
   }
 
   const client = openaiClient;
@@ -753,7 +786,7 @@ export async function callModelWithTools(
     }
   }
 
-  return { text: "", usage: { inputTokens, outputTokens }, toolCalls };
+  return { text: "", usage: { inputTokens, outputTokens }, toolCalls, truncated: true };
 }
 
 const SMOKE_TEST_VARIANTS_SCHEMA = {

--- a/engine/src/core/evaluate/mcp.ts
+++ b/engine/src/core/evaluate/mcp.ts
@@ -1,5 +1,6 @@
 import { outboundUrlProblem } from "../shared/urlGuard.js";
 import { randomUUID } from "node:crypto";
+import { currentTenancy } from "../../auth/requestContext.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
@@ -53,6 +54,10 @@ type TransportKind = "streamable" | "sse";
 
 type McpSession = {
   id: string;
+  // Tenancy the session was minted under. Sessions hold live OAuth tokens and the tool-call
+  // surface they unlock; a session id leaking across orgs (logs, screenshots, proxies) must
+  // not let another tenant execute tools with this tenant's credentials.
+  ownerKey: string;
   serverUrl: string;
   headers: Record<string, string>;
   callbackUrl: string;
@@ -65,6 +70,19 @@ type McpSession = {
 };
 
 const sessions = new Map<string, McpSession>();
+
+// The tenancy stamp sessions are keyed to - and the guard every session lookup applies.
+const tenancyKey = (): string => {
+  const t = currentTenancy();
+  return `${t.organizationId ?? ""}|${t.projectId ?? ""}`;
+};
+const ownedSession = (sessionId: string | undefined | null): McpSession | undefined => {
+  if (!sessionId) return undefined;
+  const session = sessions.get(sessionId);
+  if (!session) return undefined;
+  // A foreign-tenant lookup behaves exactly like an expired session - no oracle.
+  return session.ownerKey === tenancyKey() ? session : undefined;
+};
 
 function sweepSessions(): void {
   const cutoff = Date.now() - SESSION_TTL_MS;
@@ -187,10 +205,11 @@ export async function loadMcpTools(input: {
     return { error: "serverUrl must be an http(s) URL" };
   }
 
-  let session = input.sessionId ? sessions.get(input.sessionId) : undefined;
+  let session = ownedSession(input.sessionId);
   if (!session) {
     session = {
       id: randomUUID(),
+      ownerKey: tenancyKey(),
       serverUrl: url.toString(),
       headers: input.headers,
       callbackUrl: input.callbackUrl,
@@ -265,7 +284,7 @@ export async function callMcpToolOnce(input: {
   } catch {
     throw new Error(`MCP server URL "${input.serverUrl}" is not a valid URL`);
   }
-  const stored = input.sessionId ? sessions.get(input.sessionId) : undefined;
+  const stored = ownedSession(input.sessionId);
   if (input.sessionId && !stored) {
     throw new Error(
       `MCP authorization for ${url.toString()} has expired - reconnect the tool (Connect on the tool row) and run again`
@@ -273,6 +292,7 @@ export async function callMcpToolOnce(input: {
   }
   const session: McpSession = stored ?? {
     id: randomUUID(),
+    ownerKey: tenancyKey(),
     serverUrl: url.toString(),
     headers: {},
     callbackUrl: "http://unused.invalid/callback",
@@ -330,7 +350,7 @@ export async function callMcpToolOnce(input: {
 // dashboard's ongoing poll then reconnects with them.
 export async function finishMcpAuth(sessionId: string, code: string): Promise<{ ok: true } | { error: string }> {
   sweepSessions();
-  const session = sessions.get(sessionId);
+  const session = ownedSession(sessionId);
   if (!session) {
     return { error: "Authorization session not found or expired - reload the MCP server and try again" };
   }

--- a/engine/src/core/evaluate/metricPack.ts
+++ b/engine/src/core/evaluate/metricPack.ts
@@ -359,8 +359,8 @@ export const METRIC_PACK_VERSION = 3;
 export async function metricPackBackfillDone(db: Db): Promise<boolean> {
   const row =
     db.kind === "sqlite"
-      ? db.db.select().from(db.schema.appSettings).limit(1).all()[0]
-      : (await db.db.select().from(db.schema.appSettings).limit(1))[0];
+      ? db.db.select().from(db.schema.appSettings).where(eq(db.schema.appSettings.id, "default")).limit(1).all()[0]
+      : (await db.db.select().from(db.schema.appSettings).where(eq(db.schema.appSettings.id, "default")).limit(1))[0];
   if (!row?.metricPackSeededAt) return false;
   const version = (row as { metricPackVersion?: number | null }).metricPackVersion ?? 1;
   return version >= METRIC_PACK_VERSION;
@@ -369,8 +369,8 @@ export async function metricPackBackfillDone(db: Db): Promise<boolean> {
 export async function markMetricPackBackfillDone(db: Db): Promise<void> {
   const existing =
     db.kind === "sqlite"
-      ? db.db.select().from(db.schema.appSettings).limit(1).all()[0]
-      : (await db.db.select().from(db.schema.appSettings).limit(1))[0];
+      ? db.db.select().from(db.schema.appSettings).where(eq(db.schema.appSettings.id, "default")).limit(1).all()[0]
+      : (await db.db.select().from(db.schema.appSettings).where(eq(db.schema.appSettings.id, "default")).limit(1))[0];
   const now = new Date();
   if (existing) {
     const cond = eq(db.schema.appSettings.id, existing.id as string);
@@ -379,7 +379,7 @@ export async function markMetricPackBackfillDone(db: Db): Promise<void> {
     else await db.db.update(db.schema.appSettings).set(patch).where(cond);
   } else {
     const row = {
-      id: nanoid(),
+      id: "default",
       openaiApiKey: null,
       anthropicApiKey: null,
       geminiApiKey: null,

--- a/engine/src/core/evaluate/pairwise.ts
+++ b/engine/src/core/evaluate/pairwise.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, or, isNull } from "drizzle-orm";
+import { and, asc, desc, eq, type SQL } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type { Db } from "../../storage/db.js";
 import { logger } from "../../log.js";
@@ -195,10 +195,13 @@ async function judgeOnce(
     justification?: string;
   } | null;
   if (!payload || !["answer_1", "answer_2", "tie"].includes(payload.winner ?? "")) {
-    // An unusable verdict is a tie, never a coin flip toward one side.
+    // An unusable verdict must not masquerade as a REAL tie: without the error prefix these
+    // counted in total/ties/flipRate, so a provider outage over 60 of 100 cases read as a
+    // confident "judge saw no difference" with errors: 0. The prefix routes it into the same
+    // excluded-and-counted error bucket a thrown judge call already uses.
     return {
       winner: "tie",
-      justification: "The judge returned no usable verdict for this pair.",
+      justification: `${JUDGE_ERROR_PREFIX} the judge returned no usable verdict for this pair`,
     };
   }
   return {
@@ -364,10 +367,11 @@ export async function runPairwise(db: Db, input: RunPairwiseInput): Promise<Pair
   };
 }
 
-const scope = (db: Db) =>
-  or(eq(db.schema.pairwiseComparisons.projectId, db.projectId), isNull(db.schema.pairwiseComparisons.projectId));
+// Strict project scope: every write stamps projectId, so the old isNull(projectId) escape hatch
+// only ever matched legacy rows - and leaked them into every OTHER project's batch listings.
+const scope = (db: Db) => eq(db.schema.pairwiseComparisons.projectId, db.projectId);
 
-async function rowsFor(db: Db, where: ReturnType<typeof scope>, limit?: number): Promise<Row[]> {
+async function rowsFor(db: Db, where: SQL | undefined, limit?: number): Promise<Row[]> {
   if (db.kind === "sqlite") {
     const query = db.db
       .select()

--- a/engine/src/core/evaluate/playground.ts
+++ b/engine/src/core/evaluate/playground.ts
@@ -22,6 +22,9 @@ export type PlaygroundTool = {
   description?: string;
   parameters: Record<string, unknown>;
   endpointUrl: string;
+  // Set when the caller supplied an endpoint the outbound guard refused - the tool call then
+  // errors instead of pretending to be a schema-only simulation.
+  endpointBlocked?: string;
   mcpServer?: string;
   // Handle of an authorized MCP OAuth session (the Playground's Connect flow) - lets the engine
   // execute an OAuth-protected server's tools with the session's stored tokens.
@@ -45,12 +48,17 @@ export function extractPlaygroundTools(body: Record<string, unknown>): Playgroun
       description: typeof t.description === "string" ? t.description : undefined,
       parameters: t.parameters && typeof t.parameters === "object" ? (t.parameters as Record<string, unknown>) : {},
       // Guarded here at extraction so BOTH downstream branches (plain POST and MCP) inherit
-      // it - an endpoint that fails the outbound guard is dropped to "" and the tool call
-      // reports a config error instead of the engine fetching it.
+      // it. A rejected endpoint must stay DISTINGUISHABLE from a deliberately schema-only
+      // tool: collapsing it to "" made the guard report a *successful simulated call* to the
+      // model, which then answered confidently off a fabricated result.
       endpointUrl:
         typeof t.endpointUrl === "string" && !outboundUrlProblem(t.endpointUrl)
           ? t.endpointUrl.trim()
           : "",
+      endpointBlocked:
+        typeof t.endpointUrl === "string" && t.endpointUrl.trim()
+          ? outboundUrlProblem(t.endpointUrl) ?? undefined
+          : undefined,
       mcpServer: typeof t.mcpServer === "string" && t.mcpServer.trim() ? t.mcpServer.trim() : undefined,
       mcpSessionId: typeof t.mcpSessionId === "string" && t.mcpSessionId.trim() ? t.mcpSessionId.trim() : undefined,
     }))
@@ -71,6 +79,11 @@ export async function callPlaygroundTool(tools: PlaygroundTool[], name: string, 
   // validation's runToolCaseVariant - what a Playground run of a schema-only tool tests is
   // whether the prompt/model CHOOSE the tool and form valid arguments, and the simulated result
   // is visible in the cell's tool-call trace so nobody mistakes it for a real lookup.
+  if (tool.endpointBlocked) {
+    // A guard-rejected endpoint is a CONFIG ERROR, never a simulation - the model must not be
+    // handed a fabricated success to build an answer on.
+    throw new Error(`Tool "${name}" endpoint rejected: ${tool.endpointBlocked}`);
+  }
   if (!tool.endpointUrl) {
     // Deliberately terse: this object is fed back to the MODEL as the tool result, and a verbose
     // explanation leaks into the final answer ("due to a simulated environment..."). The cell's
@@ -365,6 +378,21 @@ export async function runPlayground(db: Db, input: PlaygroundRunInput): Promise<
       { maxTokens: input.maxTokens, temperature: input.temperature }
     );
     const latencyMs = Date.now() - start;
+    if (completion.truncated) {
+      // The empty text is OUR round cap cutting the trajectory off, not the model's answer -
+      // judging it would score the agent ~0 for a limit the harness imposed.
+      return {
+        output: null,
+        latencyMs,
+        inputTokens: completion.usage?.inputTokens ?? null,
+        outputTokens: completion.usage?.outputTokens ?? null,
+        estimatedCostUSD: estimateCostUSD(model, completion.usage?.inputTokens ?? null, completion.usage?.outputTokens ?? null),
+        rating: null,
+        justification: null,
+        toolCalls: completion.toolCalls,
+        error: "Tool loop exceeded the round cap without a final answer - simplify the tools or the prompt",
+      };
+    }
     const estimatedCostUSD = estimateCostUSD(model, completion.usage?.inputTokens ?? null, completion.usage?.outputTokens ?? null);
 
     let rating: number | null = null;

--- a/engine/src/core/evaluate/runs.ts
+++ b/engine/src/core/evaluate/runs.ts
@@ -118,10 +118,16 @@ export async function resolveAdditionalScorerConfigs(
 export async function resolveRunConfig(
   db: Db,
   datasetId: string,
-  evaluationSettingsId: string | null
+  evaluationSettingsId: string | null,
+  // The run's frozen questions (see evaluation_runs.questions_snapshot). Scoring keys into
+  // this array by POSITION, so it must be the array the run was created against - the live
+  // dataset drifts under a long run (a deleted case re-points every later index). Null =
+  // legacy run, live questions as before.
+  questionsSnapshot?: ResolvedRunConfig["questions"] | null
 ): Promise<ResolvedRunConfig> {
   const datasetRow = await getDatasetRow(db, datasetId);
-  const questions = (datasetRow?.questions as ResolvedRunConfig["questions"] | undefined) ?? [];
+  const questions =
+    questionsSnapshot ?? (datasetRow?.questions as ResolvedRunConfig["questions"] | undefined) ?? [];
 
   let settings: EvaluationSettingsRow | null = null;
   if (evaluationSettingsId) {
@@ -231,6 +237,7 @@ export async function initRun(
     runSource: input.runSource ?? "sdk",
     sdkInfo: input.sdk ?? null,
     smokeTestVariants,
+    questionsSnapshot: dataset.questions ?? null,
     status: "in_progress",
     createdAt: new Date(),
   };
@@ -584,7 +591,12 @@ export async function appendResults(
     throw terminalErr;
   }
 
-  const config = await resolveRunConfig(db, run.datasetId, run.evaluationSettingsId);
+  const config = await resolveRunConfig(
+    db,
+    run.datasetId,
+    run.evaluationSettingsId,
+    (run as { questionsSnapshot?: ResolvedRunConfig["questions"] | null }).questionsSnapshot ?? null
+  );
   const additionalConfigs = await resolveAdditionalScorerConfigs(
     db,
     run.datasetId,
@@ -988,6 +1000,12 @@ export async function failRun(db: Db, runId: string) {
   const run = await getRunRow(db, runId);
   if (!run) {
     return null;
+  }
+  // Terminal states are terminal, mirroring finalizeRun: a run that COMPLETED with scored
+  // results must not be flipped to "failed" by a late error in the driver (the connector
+  // runner's catch used to do exactly that on a post-finalize conflict).
+  if (run.status === "completed") {
+    return { runId, status: "completed" };
   }
   const updateCond = and(eq(db.schema.evaluationRuns.id, runId), eq(db.schema.evaluationRuns.projectId, db.projectId));
   if (db.kind === "sqlite") {

--- a/engine/src/core/evaluate/simulation.ts
+++ b/engine/src/core/evaluate/simulation.ts
@@ -136,7 +136,10 @@ export async function runConversationSimulation(
   // to the dashboard as an SSE event, so the transcript renders turn by turn).
   onTurn?: (turn: SimulationTurn, index: number) => void
 ): Promise<SimulationResult> {
-  const maxTurns = Math.max(1, Math.min(MAX_TURNS_CAP, input.maxTurns ?? DEFAULT_MAX_TURNS));
+  // NaN slides through Math.min/max unchanged, and `i < NaN` is false - a non-finite maxTurns
+  // produced a zero-turn "finished" simulation instead of a conversation.
+  const requestedTurns = Number.isFinite(input.maxTurns) ? (input.maxTurns as number) : DEFAULT_MAX_TURNS;
+  const maxTurns = Math.max(1, Math.min(MAX_TURNS_CAP, requestedTurns));
   const userModel = input.userModel?.trim() || DEFAULT_JUDGE_MODEL;
   const record = input.record !== false;
   const sessionId = record ? `sim-${nanoid(12)}` : null;
@@ -202,6 +205,11 @@ export async function runConversationSimulation(
         { maxTokens: input.maxTokens, temperature: input.temperature }
       );
       turn.latencyMs = Date.now() - start;
+      if (completion.truncated) {
+        // The round cap cut the trajectory - an empty agentMessage pushed into history would
+        // poison every later turn and read as "the agent said nothing".
+        turn.error = "Tool loop exceeded the round cap without a final answer";
+      }
       turn.agentMessage = completion.text;
       if (completion.toolCalls.length > 0) turn.toolCalls = completion.toolCalls;
 

--- a/engine/src/core/evaluate/synthesize.ts
+++ b/engine/src/core/evaluate/synthesize.ts
@@ -10,6 +10,10 @@ import { getDataset } from "./datasets.js";
 
 const MAX_CASES = 20;
 
+// The whole source lands verbatim in one judge prompt: past this it exceeds context windows and
+// burns tokens on a call that was going to fail anyway, so oversized input is refused up front.
+const MAX_SOURCE_CHARS = 100_000;
+
 const SYNTHESIS_SCHEMA = {
   type: "object",
   properties: {
@@ -40,6 +44,11 @@ export async function generateSyntheticCases(
   const sourceText = input.sourceText.trim();
   if (!sourceText) {
     return { error: "sourceText is required - paste the document the cases should be grounded in" };
+  }
+  if (sourceText.length > MAX_SOURCE_CHARS) {
+    return {
+      error: `sourceText is too long (${sourceText.length} characters, cap ${MAX_SOURCE_CHARS}) - trim the document to the sections the cases should cover`,
+    };
   }
   const count = Math.max(1, Math.min(MAX_CASES, Math.floor(input.count) || 5));
 

--- a/engine/src/core/evaluate/versions.ts
+++ b/engine/src/core/evaluate/versions.ts
@@ -13,7 +13,21 @@ export type VersionEntryWire = {
   changeSummary?: string;
 };
 
-const DATASET_SNAPSHOT_FIELDS = ["name", "description", "questions", "status"] as const;
+// The full editable recipe, not just the four display fields: a snapshot that omits the
+// criteria/scorers/metrics means any restore built from it NULLS them through the full-replace
+// update route - "go back to how it was" destroying the rubric it claimed to restore.
+const DATASET_SNAPSHOT_FIELDS = [
+  "name",
+  "description",
+  "questions",
+  "status",
+  "acceptanceCriteria",
+  "rejectionCriteria",
+  "evaluationCriteria",
+  "numberOfRequests",
+  "similarityConfig",
+  "codeScorers",
+] as const;
 const DATASET_FIELD_LABELS: Record<string, string> = {
   name: "name",
   description: "description",

--- a/engine/src/core/insights/probe.ts
+++ b/engine/src/core/insights/probe.ts
@@ -15,7 +15,7 @@ import { groupByIntent, MIN_TRACES_PER_TOPIC } from "./coverage.js";
 // send a team writing tests for things nobody asks. That case gets its own verdict, which is why
 // this is a file rather than a single cosine.
 
-export type ProbeVerdict = "covered" | "adjacent" | "gap" | "untested-and-unasked";
+export type ProbeVerdict = "covered" | "adjacent" | "gap" | "untested-and-unasked" | "warming";
 
 export type ProbeNearestCase = {
   datasetId: string;
@@ -35,6 +35,9 @@ export type ProbeResult = {
   similarity: number;
   bands: { covered: number; related: number };
   degraded: boolean;
+  /** Cases not yet embedded (cache warming) - a negative verdict is downgraded to "warming"
+   * while this is non-zero, because an invisible case could be the exact cover. */
+  pendingCases: number;
   nearestCases: ProbeNearestCase[];
   /** The production topic this query lands in, when one is close enough. */
   topic: { topic: string; trafficShare: number; traceCount: number } | null;
@@ -71,6 +74,11 @@ function explain(
           `rather than meaning. Check its expected result asserts what you meant.`
         : `Effectively the same question as an existing case${nearest ? ` ("${nearest.query}")` : ""} - close enough ` +
           `that adding it would be rejected as a duplicate. Check its expected result asserts what you meant.`;
+    case "warming":
+      return (
+        `Nothing close was found - but some dataset cases are still being indexed, and one of ` +
+        `them could be the cover. Probe again once indexing finishes before treating this as a gap.`
+      );
     case "adjacent":
       return (
         `The nearest case asks something related but not this${nearest ? ` ("${nearest.query}")` : ""}. It sits in the ` +
@@ -95,13 +103,16 @@ type ProbeContext = {
   groups: ReturnType<typeof groupByIntent>;
   totalTraces: number;
   embeddedCases: boolean;
+  // Cases whose embeddings are still warming - invisible to similarity scoring, so any
+  // negative verdict while this is non-zero is a floor, not a fact.
+  pendingCases: number;
 };
 
 async function loadContext(db: Db, window: MonitoringWindow, datasetIds?: string[]): Promise<ProbeContext> {
   const { days } = windowConfig(window);
   const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
   const [rows, cases] = await Promise.all([listClassificationsSince(db, since), listDatasetCases(db, datasetIds)]);
-  const { embedded } = await attachCaseEmbeddings(db, cases);
+  const { embedded, pending } = await attachCaseEmbeddings(db, cases);
   // Same floor the coverage sweep applies. Without it a single stray classification is enough to
   // turn "nobody asks this" into a fabricated real gap - the one verdict the probe exists to avoid
   // handing out.
@@ -109,7 +120,7 @@ async function loadContext(db: Db, window: MonitoringWindow, datasetIds?: string
   // Denominator over the SAME filtered groups the sweep uses, not every classified row - otherwise
   // one topic reports two different traffic shares depending on which screen you read it from.
   const totalTraces = groups.reduce((sum, g) => sum + g.rows.length, 0);
-  return { cases, groups, totalTraces, embeddedCases: embedded };
+  return { cases, groups, totalTraces, embeddedCases: embedded, pendingCases: pending };
 }
 
 async function scorerFor(query: string, ctx: ProbeContext): Promise<Scorer> {
@@ -176,14 +187,20 @@ function probeWith(query: string, ctx: ProbeContext, scorer: Scorer): ProbeResul
     topic = null;
   }
 
+  // A cold embedding cache hides real cases from the scorer - asserting "gap" then sends a
+  // team to write a duplicate test for a query case #200 already covers. Positive verdicts
+  // stand (a found cover is a found cover); negative ones downgrade to "warming".
+  const blind = !scorer.degraded && ctx.pendingCases > 0;
   const verdict: ProbeVerdict =
     best >= scorer.bands.covered
       ? "covered"
       : best >= scorer.bands.related
         ? "adjacent"
-        : topic
-          ? "gap"
-          : "untested-and-unasked";
+        : blind
+          ? "warming"
+          : topic
+            ? "gap"
+            : "untested-and-unasked";
 
   return {
     query,
@@ -191,6 +208,7 @@ function probeWith(query: string, ctx: ProbeContext, scorer: Scorer): ProbeResul
     similarity: Math.round(best * 1000) / 1000,
     bands: scorer.bands,
     degraded: scorer.degraded,
+    pendingCases: ctx.pendingCases,
     nearestCases,
     topic,
     explanation: explain(verdict, nearestCases[0] ?? null, topic, scorer.degraded),

--- a/engine/src/core/monitor/attention.ts
+++ b/engine/src/core/monitor/attention.ts
@@ -94,7 +94,10 @@ export async function getAttentionDigest(db: Db): Promise<AttentionDigest> {
 
     const spark = new Array<number>(SPARK_DAYS).fill(0);
     for (const event of own) {
-      const dayIndex = SPARK_DAYS - 1 - Math.floor((todayStart - new Date(event.createdAt).setHours(0, 0, 0, 0)) / dayMs);
+      // Math.round, not floor: two LOCAL midnights are 23h or 25h apart across a DST
+      // transition, and a fixed 24h divisor shifted the whole pre-transition sparkline one
+      // day - a phantom week-over-week spike on the triage digest.
+      const dayIndex = SPARK_DAYS - 1 - Math.round((todayStart - new Date(event.createdAt).setHours(0, 0, 0, 0)) / dayMs);
       if (dayIndex >= 0 && dayIndex < SPARK_DAYS) spark[dayIndex] = (spark[dayIndex] ?? 0) + 1;
     }
     const lastWeek = spark.slice(0, 7).reduce((a, b) => a + b, 0);

--- a/engine/src/core/monitor/events.ts
+++ b/engine/src/core/monitor/events.ts
@@ -278,10 +278,13 @@ export async function listScoreEventsForEvaluatorSince(db: Db, evaluatorId: stri
     eq(db.schema.monitorEvents.onlineEvaluatorId, evaluatorId),
     isNotNull(db.schema.monitorEvents.rating)
   );
+  // Bounded: a busy evaluator's 30d window can be millions of rows - materializing them in
+  // JS to keep 40 tuning cases stalled the event loop for every project on the box. 50k is
+  // far beyond what any consumer aggregates meaningfully.
   const rows =
     db.kind === "sqlite"
-      ? db.db.select().from(db.schema.monitorEvents).where(cond).all()
-      : await db.db.select().from(db.schema.monitorEvents).where(cond);
+      ? db.db.select().from(db.schema.monitorEvents).where(cond).orderBy(desc(db.schema.monitorEvents.createdAt)).limit(50000).all()
+      : await db.db.select().from(db.schema.monitorEvents).where(cond).orderBy(desc(db.schema.monitorEvents.createdAt)).limit(50000);
   return rows as EventRow[];
 }
 

--- a/engine/src/core/monitor/judgeTuning.ts
+++ b/engine/src/core/monitor/judgeTuning.ts
@@ -567,11 +567,21 @@ Rewrite so the judge would agree with the recorded ground truth on these cases. 
     });
   }
 
+  // A prompt the model did NOT rewrite must go back as the caller's sentinel, not the resolved
+  // default text. The evaluator's settings row is SHARED with offline dataset runs: an empty
+  // judgePrompt there means "engine default", which for a dataset run is the REFERENCE-BASED
+  // prompt ({expected} comparison). Materializing the reference-free live-scoring default into
+  // the column on a no-op tuning silently and permanently dropped the expected-answer
+  // comparison from every later dataset run graded by this scorer.
+  const settingsPromptWasEmpty = !(settings.judgePrompt ?? "").trim();
+  const judgePromptOut =
+    settingsPromptWasEmpty && proposedJudgePrompt === currentJudgePrompt ? "" : proposedJudgePrompt;
+
   return {
     acceptanceCriteria: payload.acceptanceCriteria,
     rejectionCriteria: typeof payload.rejectionCriteria === "string" ? payload.rejectionCriteria : current.rejectionCriteria,
     evaluationCriteria: typeof payload.evaluationCriteria === "string" ? payload.evaluationCriteria : current.evaluationCriteria,
-    judgePrompt: proposedJudgePrompt,
+    judgePrompt: judgePromptOut,
     reasoning: typeof payload.reasoning === "string" ? payload.reasoning : "",
     changes,
     judgeModel,

--- a/engine/src/core/monitor/onlineEvaluators.ts
+++ b/engine/src/core/monitor/onlineEvaluators.ts
@@ -325,12 +325,14 @@ export async function reserveOnlineJudgeCall(db: Db): Promise<boolean> {
   if (!Number.isFinite(cap) || cap <= 0) return true;
   let granted = false;
   const reserve = async () => {
-    const day = new Date().toDateString();
+    // UTC day key and UTC midnight: stored createdAt is UTC, so a local-time window under- or
+    // over-seeded the count by the server's TZ offset and rolled the cap at local midnight.
+    const now = new Date();
+    const day = now.toISOString().slice(0, 10);
     const key = db.projectId ?? "";
     let entry = onlineJudgeSpend.get(key);
     if (!entry || entry.day !== day) {
-      const midnight = new Date();
-      midnight.setHours(0, 0, 0, 0);
+      const midnight = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
       const rows = await listEventsSince(db, midnight);
       // Approximate judge calls made today: per-trace and per-session evaluator verdicts and
       // failures, plus scorer-group JUDGE member verdicts (their patternKey embeds the member

--- a/engine/src/core/monitor/outcomeCalibration.ts
+++ b/engine/src/core/monitor/outcomeCalibration.ts
@@ -195,6 +195,9 @@ export async function getJudgeCalibration(db: Db, window: MonitoringWindow): Pro
   // label) used to contribute multiple rows to the same confusion matrix - inflating agreement
   // on exactly the traces that got the most attention. First report per trace wins, and outcome
   // reports outrank sampled labels (the ordering judgeTuning's evidence chain already uses).
+  // Deterministic: a bare SELECT's row order is unspecified (Postgres after vacuum
+  // especially) - sort by reportedAt so "first" means first in time, every request.
+  reports.sort((a, b) => a.reportedAt.getTime() - b.reportedAt.getTime());
   const talliedTraces = new Set<string>();
   for (const report of reports) {
     if (report.traceId) {

--- a/engine/src/core/monitor/signals.ts
+++ b/engine/src/core/monitor/signals.ts
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { desc, and, eq, isNull, sql } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import { listOccurrencesForSignal, extractText, type EventRow } from "./events.js";
 import { logger } from "../../log.js";
@@ -283,10 +283,13 @@ export async function signalCountsByPatternKey(db: Db): Promise<Map<string, { to
 
 export async function listSignalRows(db: Db): Promise<SignalRow[]> {
   const cond = eq(db.schema.monitorSignals.projectId, db.projectId);
+  // Bounded: interactive readers (the Overview digest polls this) keep at most a dozen rows,
+  // and a years-old install has no business materializing its whole signal history per poll.
+  // Newest-first so the cap keeps what those readers actually rank.
   const rows =
     db.kind === "sqlite"
-      ? db.db.select().from(db.schema.monitorSignals).where(cond).all()
-      : await db.db.select().from(db.schema.monitorSignals).where(cond);
+      ? db.db.select().from(db.schema.monitorSignals).where(cond).orderBy(desc(db.schema.monitorSignals.lastSeenAt)).limit(10000).all()
+      : await db.db.select().from(db.schema.monitorSignals).where(cond).orderBy(desc(db.schema.monitorSignals.lastSeenAt)).limit(10000);
   return rows as SignalRow[];
 }
 

--- a/engine/src/core/monitor/webhooks.test.ts
+++ b/engine/src/core/monitor/webhooks.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import { extractWebhookUrls, notifyWebhooks } from "./webhooks.js";
+import { extractWebhookUrls, notifyWebhooks, postWebhooks } from "./webhooks.js";
 
 // POSTs to an operator-supplied URL on every raised signal. Two properties matter more than the
 // payload: it must not block the caller, and a target that never answers must not hold a socket
@@ -117,6 +117,15 @@ describe("notifyWebhooks", () => {
     const before = received.length;
     notifyWebhooks([], signal);
     expect(received.length).toBe(before);
+  });
+
+  it("skips guarded URLs at send time and still delivers to legitimate targets", async () => {
+    // rules.ts hands its webhook-action URL to postWebhooks without going through
+    // extractWebhookUrls, so the send loop itself must refuse a metadata target.
+    received.length = 0;
+    postWebhooks(["http://169.254.169.254/latest/meta-data/", `${base}/guarded-ok`], { text: "x" });
+    await waitFor(() => received.some(r => r.path === "/guarded-ok"));
+    expect(received.map(r => r.path)).toEqual(["/guarded-ok"]);
   });
 
   it("gives up on a target that never responds instead of holding the socket open", async () => {

--- a/engine/src/core/monitor/webhooks.ts
+++ b/engine/src/core/monitor/webhooks.ts
@@ -1,4 +1,5 @@
 import { logger } from "../../log.js";
+import { maskSecret } from "../shared/maskSecret.js";
 import { outboundUrlProblem } from "../shared/urlGuard.js";
 // LangSmith-style "webhook automation" equivalent: monitor_profiles.channels was persisted from
 // the start (dashboard's per-agent settings dialog) but self-host never had any notification
@@ -10,6 +11,15 @@ import { outboundUrlProblem } from "../shared/urlGuard.js";
 // cover them): the shared outboundUrlProblem check - http(s) only, never a cloud metadata
 // endpoint, private targets gated only on multi-tenant. See core/shared/urlGuard.ts for the
 // full posture.
+
+
+const safeHost = (url: string): string => {
+  try {
+    return new URL(url).host;
+  } catch {
+    return "(invalid url)";
+  }
+};
 
 export function extractWebhookUrls(channels: string[] | null | undefined): string[] {
   return (channels ?? [])
@@ -49,6 +59,10 @@ export function notifyWebhooks(urls: string[], signal: WebhookSignal): void {
   });
 }
 
+// A stored bad target skips on every signal it would have received - warned once per URL per
+// process, not once per skip.
+const warnedBlockedUrls = new Set<string>();
+
 // The delivery primitive both callers share: signal notifications above, and automation rules'
 // webhook action (core/monitor/rules.ts), which sends its own rule-shaped payload.
 export function postWebhooks(urls: string[], payload: Record<string, unknown>): void {
@@ -56,6 +70,17 @@ export function postWebhooks(urls: string[], payload: Record<string, unknown>): 
     return;
   }
   for (const url of urls) {
+    // Re-vetted at send time: extractWebhookUrls guards profile channels, but rules.ts hands its
+    // webhook-action URL straight in, and a URL stored before a posture change (e.g. flipping a
+    // deployment to multi-tenant) outlives its write-time check.
+    const problem = outboundUrlProblem(url);
+    if (problem) {
+      if (!warnedBlockedUrls.has(url)) {
+        warnedBlockedUrls.add(url);
+        logger.warn(`Monitor webhook target skipped (${url}): ${problem}`);
+      }
+      continue;
+    }
     void fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -69,11 +94,20 @@ export function postWebhooks(urls: string[], payload: Record<string, unknown>): 
         // fetch only rejects on transport failure, so a 404 from a mistyped Slack URL was
         // indistinguishable from a delivered notification.
         if (!res.ok) {
-          logger.error(`Monitor webhook delivery failed (${url}): responded ${res.status}`);
+          // The URL IS the credential for Slack/Teams-style incoming hooks - log the host
+          // and a masked tail, never the whole thing, or every failing delivery exfiltrates
+          // it into the log stream.
+          logger.error(
+            { host: safeHost(url), url: maskSecret(url), status: res.status },
+            "Monitor webhook delivery failed"
+          );
         }
       })
       .catch(err => {
-        logger.error({ err: err instanceof Error ? err.message : err }, `Monitor webhook delivery failed (${url}):`);
+        logger.error(
+          { err: err instanceof Error ? err.message : err, host: safeHost(url), url: maskSecret(url) },
+          "Monitor webhook delivery failed"
+        );
       });
   }
 }

--- a/engine/src/core/settings/appSettings.ts
+++ b/engine/src/core/settings/appSettings.ts
@@ -24,6 +24,58 @@ function settingsRowId(): string {
   return SETTINGS_ROW_ID;
 }
 
+
+// One-time adoption for installs whose app_settings grew "pretender" rows: before the readers
+// were keyed on the "default" id, boot-time writers (auth secret, casefold + metric-pack
+// markers) inserted rows under random ids, and LIMIT-1 heap order decided which one each boot
+// read. Merge every non-org pretender's instance flags onto "default" (creating it from the
+// first pretender when absent) and delete the pretenders, so keyed readers see the history
+// instead of rotating the session secret and re-running whole-table backfills one last time.
+export async function consolidateAppSettingsSingleton(db: Db): Promise<void> {
+  const rows = (
+    db.kind === "sqlite"
+      ? db.db.select().from(db.schema.appSettings).all()
+      : await db.db.select().from(db.schema.appSettings)
+  ) as Array<Record<string, unknown> & { id: string }>;
+  const pretenders = rows.filter(r => r.id !== "default" && !r.id.startsWith("org:"));
+  if (pretenders.length === 0) return;
+  const existingDefault = rows.find(r => r.id === "default");
+  const FLAGS = [
+    "authSecret",
+    "frameworkCasefoldedAt",
+    "metricPackSeededAt",
+    "metricPackVersion",
+    "openaiApiKey",
+    "anthropicApiKey",
+    "geminiApiKey",
+  ] as const;
+  const merged: Record<string, unknown> = { ...(existingDefault ?? { id: "default", updatedAt: new Date() }) };
+  for (const pretender of pretenders) {
+    for (const flag of FLAGS) {
+      if (merged[flag] == null && pretender[flag] != null) merged[flag] = pretender[flag];
+    }
+  }
+  if (db.kind === "sqlite") {
+    if (existingDefault) {
+      await db.db.update(db.schema.appSettings).set(merged as never).where(eq(db.schema.appSettings.id, "default"));
+    } else {
+      await db.db.insert(db.schema.appSettings).values({ ...merged, id: "default" } as never);
+    }
+    for (const pretender of pretenders) {
+      await db.db.delete(db.schema.appSettings).where(eq(db.schema.appSettings.id, pretender.id));
+    }
+  } else {
+    if (existingDefault) {
+      await db.db.update(db.schema.appSettings).set(merged as never).where(eq(db.schema.appSettings.id, "default"));
+    } else {
+      await db.db.insert(db.schema.appSettings).values({ ...merged, id: "default" } as never);
+    }
+    for (const pretender of pretenders) {
+      await db.db.delete(db.schema.appSettings).where(eq(db.schema.appSettings.id, pretender.id));
+    }
+  }
+}
+
 export type AppSettings = {
   openaiApiKey: string | null;
   anthropicApiKey: string | null;

--- a/engine/src/core/shared/maskSecret.ts
+++ b/engine/src/core/shared/maskSecret.ts
@@ -4,3 +4,9 @@
 export function maskSecret(key: string): string {
   return key.length <= 8 ? "••••" : `${key.slice(0, 3)}...${key.slice(-4)}`;
 }
+
+// Whether a value IS the masked form above - PUT round-trips send it back verbatim to mean
+// "keep the stored secret", and writers must never store the mask itself.
+export function isMaskedSecret(value: string): boolean {
+  return value === "••••" || /^.{3}\.\.\..{4}$/.test(value);
+}

--- a/engine/src/core/shared/urlGuard.test.ts
+++ b/engine/src/core/shared/urlGuard.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { outboundUrlProblem } from "./urlGuard.js";
+
+// The guard's contract has two tiers: metadata endpoints are refused on every deployment shape,
+// while private/loopback targets are refused only under multi-tenant (self-host operators point
+// tools at their own local receivers on purpose). The bypass spellings below are the ones a
+// hostname-literal check historically missed: numeric IPv4 literals, v4-mapped IPv6, link-local
+// IPv6, and the 0.0.0.0/8 "this host" range.
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function multiTenant() {
+  vi.stubEnv("AGENTX_AUTH", "enabled");
+  vi.stubEnv("AGENTX_MULTI_TENANT", "true");
+}
+
+describe("outboundUrlProblem - every deployment shape", () => {
+  it("rejects garbage and non-http(s) schemes", () => {
+    expect(outboundUrlProblem("not a url")).toBe("not a valid URL");
+    expect(outboundUrlProblem("ftp://example.com/x")).toBe("only http(s) URLs are allowed");
+    expect(outboundUrlProblem("file:///etc/passwd")).toBe("only http(s) URLs are allowed");
+  });
+
+  it("rejects cloud metadata endpoints in any spelling", () => {
+    expect(outboundUrlProblem("http://metadata.google.internal/computeMetadata/v1/")).not.toBeNull();
+    expect(outboundUrlProblem("http://169.254.169.254/latest/meta-data/")).not.toBeNull();
+    // 169.254.169.254 as a decimal literal - URL canonicalizes it, the guard must still refuse it.
+    expect(outboundUrlProblem("http://2852039166/latest/meta-data/")).not.toBeNull();
+    expect(outboundUrlProblem("http://[::ffff:169.254.169.254]/latest/meta-data/")).not.toBeNull();
+    expect(outboundUrlProblem("http://[fd00:ec2::254]/latest/meta-data/")).not.toBeNull();
+  });
+
+  it("allows loopback and RFC1918 targets on single-tenant self-host", () => {
+    expect(outboundUrlProblem("http://localhost:11434/v1/chat")).toBeNull();
+    expect(outboundUrlProblem("http://127.0.0.1:8000/hook")).toBeNull();
+    expect(outboundUrlProblem("http://192.168.1.20/webhook")).toBeNull();
+    expect(outboundUrlProblem("https://hooks.slack.com/services/T0/B0/x")).toBeNull();
+  });
+});
+
+describe("outboundUrlProblem - multi-tenant", () => {
+  it("rejects loopback and RFC1918 targets", () => {
+    multiTenant();
+    for (const url of [
+      "http://localhost:8000/hook",
+      "http://127.0.0.1/hook",
+      "http://10.1.2.3/hook",
+      "http://192.168.1.20/hook",
+      "http://172.16.0.1/hook",
+      "http://172.31.255.255/hook",
+    ]) {
+      expect(outboundUrlProblem(url), url).not.toBeNull();
+    }
+  });
+
+  it("rejects numeric IPv4 literal spellings of private targets", () => {
+    multiTenant();
+    for (const url of [
+      "http://2130706433/hook", // decimal 127.0.0.1
+      "http://0x7f000001/hook", // hex 127.0.0.1
+      "http://0177.0.0.1/hook", // octal first octet
+      "http://0/hook", // 0.0.0.0 shorthand
+      "http://0.0.0.0/hook",
+    ]) {
+      expect(outboundUrlProblem(url), url).not.toBeNull();
+    }
+  });
+
+  it("rejects IPv6 loopback, unspecified, link-local, ULA, and v4-mapped forms", () => {
+    multiTenant();
+    for (const url of [
+      "http://[::1]/hook",
+      "http://[::]/hook",
+      "http://[fe80::1]/hook",
+      "http://[fd12:3456::1]/hook",
+      "http://[::ffff:127.0.0.1]/hook",
+      "http://[::ffff:7f00:1]/hook",
+      "http://[::ffff:10.0.0.1]/hook",
+    ]) {
+      expect(outboundUrlProblem(url), url).not.toBeNull();
+    }
+  });
+
+  it("still allows public targets, and private ones with the explicit opt-in", () => {
+    multiTenant();
+    expect(outboundUrlProblem("https://hooks.slack.com/services/T0/B0/x")).toBeNull();
+    vi.stubEnv("AGENTX_EGRESS_ALLOW_PRIVATE", "1");
+    expect(outboundUrlProblem("http://127.0.0.1:8000/hook")).toBeNull();
+    // The opt-in never reaches metadata endpoints.
+    expect(outboundUrlProblem("http://169.254.169.254/latest/meta-data/")).not.toBeNull();
+  });
+});

--- a/engine/src/core/shared/urlGuard.ts
+++ b/engine/src/core/shared/urlGuard.ts
@@ -1,7 +1,8 @@
 // Shared outbound-URL guard for every surface that fetches a caller-supplied URL server-side.
 // Importers: playground tool endpoints (core/evaluate/playground.ts), MCP servers
-// (core/evaluate/mcp.ts), monitor webhooks (core/monitor/webhooks.ts), and custom/external
-// scorer URLs (routes/agentMonitoringDashboard.ts).
+// (core/evaluate/mcp.ts), monitor webhooks (core/monitor/webhooks.ts), custom/external
+// scorer URLs (routes/agentMonitoringDashboard.ts), and agent connectors
+// (core/evaluate/agentConnectors.ts).
 //
 // The self-host posture is deliberate: loopback and RFC1918 targets are ALLOWED - operators
 // legitimately point tools at their own local vLLM/Ollama/webhook receivers, and blocking
@@ -12,17 +13,63 @@
 //
 // Hostname-literal checks only: DNS-rebinding-grade defenses are out of scope for a
 // trusted-operator tier and documented as such.
+import { isIP } from "node:net";
 import { isMultiTenant } from "../../auth/mode.js";
 
 const METADATA_HOSTS = new Set(["metadata.google.internal", "metadata.goog", "fd00:ec2::254", "[fd00:ec2::254]"]);
 
+// A pure-numeric host is an IPv4 literal in disguise: decimal (2130706433), hex (0x7f000001),
+// or octal (017700000001) all dial 127.0.0.1. Node's WHATWG URL parser already folds these into
+// dotted-quad hostnames, so this decode is defense in depth for any caller that hands the guard
+// a host that never went through URL parsing.
+function ipv4FromNumericLiteral(host: string): string | null {
+  if (!/^(0x[0-9a-f]+|\d+)$/i.test(host)) return null;
+  const value = /^0x/i.test(host)
+    ? Number.parseInt(host.slice(2), 16)
+    : /^0\d+$/.test(host)
+      ? Number.parseInt(host, 8)
+      : Number.parseInt(host, 10);
+  if (!Number.isInteger(value) || value < 0 || value > 0xffffffff) return null;
+  return [(value >>> 24) & 0xff, (value >>> 16) & 0xff, (value >>> 8) & 0xff, value & 0xff].join(".");
+}
+
+// v4-mapped IPv6 wraps an IPv4 target in a bracket host ([::ffff:127.0.0.1]). URL serializes
+// the mapped form as pure hex groups ("::ffff:7f00:1"), so both spellings are accepted.
+function ipv4FromMapped(bare: string): string | null {
+  const dotted = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(bare);
+  if (dotted) return dotted[1]!;
+  const hex = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(bare);
+  if (hex) {
+    const hi = Number.parseInt(hex[1]!, 16);
+    const lo = Number.parseInt(hex[2]!, 16);
+    return [hi >> 8, hi & 0xff, lo >> 8, lo & 0xff].join(".");
+  }
+  return null;
+}
+
+/** Every spelling of an IPv4 target (dotted, numeric literal, v4-mapped IPv6) as dotted-quad. */
+function effectiveIpv4(host: string): string | null {
+  const bare = host.replace(/^\[|\]$/g, "");
+  if (isIP(bare) === 4) return bare;
+  return ipv4FromNumericLiteral(bare) ?? ipv4FromMapped(bare);
+}
+
 function isPrivateHost(host: string): boolean {
-  if (host === "localhost" || host === "::1" || host === "[::1]") return true;
-  if (/^127\./.test(host)) return true;
-  if (/^10\./.test(host)) return true;
-  if (/^192\.168\./.test(host)) return true;
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
-  if (/^f[cd][0-9a-f]{2}:/i.test(host.replace(/^\[|\]$/g, ""))) return true;
+  const bare = host.replace(/^\[|\]$/g, "").toLowerCase();
+  if (bare === "localhost") return true;
+  // IPv6: loopback, unspecified (routes to loopback), ULA fc00::/7, link-local fe80::/10.
+  if (bare === "::1" || bare === "::") return true;
+  if (/^f[cd][0-9a-f]{2}:/.test(bare)) return true;
+  if (/^fe[89ab][0-9a-f]:/.test(bare)) return true;
+  const ip4 = effectiveIpv4(host);
+  if (ip4) {
+    if (/^127\./.test(ip4)) return true;
+    // 0.0.0.0/8: "0", "0.0.0.0" and friends reach the local host on Linux and macOS.
+    if (/^0\./.test(ip4)) return true;
+    if (/^10\./.test(ip4)) return true;
+    if (/^192\.168\./.test(ip4)) return true;
+    if (/^172\.(1[6-9]|2\d|3[01])\./.test(ip4)) return true;
+  }
   return false;
 }
 
@@ -38,7 +85,10 @@ export function outboundUrlProblem(raw: string): string | null {
     return "only http(s) URLs are allowed";
   }
   const host = url.hostname.toLowerCase();
-  if (METADATA_HOSTS.has(host) || /^169\.254\./.test(host)) {
+  // The link-local check runs on the canonical IPv4 so 169.254.169.254 spelled as a decimal
+  // literal or a v4-mapped IPv6 host is refused the same as the dotted form.
+  const ip4 = effectiveIpv4(host);
+  if (METADATA_HOSTS.has(host) || /^169\.254\./.test(ip4 ?? host)) {
     return "cloud metadata endpoints are never a valid target";
   }
   if (isMultiTenant() && process.env.AGENTX_EGRESS_ALLOW_PRIVATE !== "1" && isPrivateHost(host)) {

--- a/engine/src/core/trace/store/index.ts
+++ b/engine/src/core/trace/store/index.ts
@@ -62,8 +62,8 @@ export async function backfillFrameworkCasefold(db: Db): Promise<void> {
   try {
     const settings =
       db.kind === "sqlite"
-        ? db.db.select().from(db.schema.appSettings).limit(1).all()[0]
-        : (await db.db.select().from(db.schema.appSettings).limit(1))[0];
+        ? db.db.select().from(db.schema.appSettings).where(eq(db.schema.appSettings.id, "default")).limit(1).all()[0]
+        : (await db.db.select().from(db.schema.appSettings).where(eq(db.schema.appSettings.id, "default")).limit(1))[0];
     if ((settings as { frameworkCasefoldedAt?: Date | null } | undefined)?.frameworkCasefoldedAt) {
       return;
     }
@@ -102,7 +102,7 @@ export async function backfillFrameworkCasefold(db: Db): Promise<void> {
     } else {
       // No settings row yet (fresh install pre-first-save): the marker still has to persist or
       // every boot rescans. Insert the singleton the same way markMetricPackBackfillDone does.
-      const row = { id: `app-${now.getTime()}`, frameworkCasefoldedAt: now, updatedAt: now };
+      const row = { id: "default", frameworkCasefoldedAt: now, updatedAt: now };
       if (db.kind === "sqlite") {
         await db.db.insert(db.schema.appSettings).values(row);
       } else {

--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -14,6 +14,7 @@ import { getDefaultProject, listProjectRows } from "./core/project/projects.js";
 import { ensureSessionBaselineJudge } from "./core/monitor/builtinEvaluators.js";
 import { ensureMetricPackConfigs, metricPackBackfillDone, markMetricPackBackfillDone } from "./core/evaluate/metricPack.js";
 import { authMode, initAuth, resolveAuthSecret } from "./auth/betterAuth.js";
+import { consolidateAppSettingsSingleton } from "./core/settings/appSettings.js";
 import { mailerConfigured } from "./auth/mailer.js";
 import { registerAuthRoutes, registerApiV1 } from "./routes/apiV1.js";
 import { findWebIndexHtml, downloadWebBundle, webBundleCandidates, describeWebBundle } from "./web.js";
@@ -89,6 +90,9 @@ async function main() {
   await initDb();
   // One-time: fold pre-existing trace framework labels to lowercase so old traffic groups and
   // filters with new traffic (ingest folds on write since the Platforms chart landed).
+  // Before any singleton reader runs: adopt legacy pretender app_settings rows onto the
+  // "default" id (see appSettings.ts) so the keyed readers below see the stored history.
+  await consolidateAppSettingsSingleton(getDb());
   await backfillFrameworkCasefold(getDb());
   // Partitioned-Postgres maintenance (ADR-0007): pre-create upcoming partitions, drop expired
   // ones. Daily cadence; the DEFAULT partition keeps correctness independent of this timer.

--- a/engine/src/otel/normalize.ts
+++ b/engine/src/otel/normalize.ts
@@ -36,10 +36,14 @@ function idToHex(value: unknown): string | null {
   }
   // Strict base64 charset check before decoding: Buffer.from silently skips invalid characters,
   // so a garbage id would decode to garbage hex instead of being rejected as no id at all.
-  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
+  // base64url (-/_, what several Go and hand-rolled exporters emit) folds onto standard
+  // base64 first - rejecting it stripped the span id, which broke retry idempotency: the 429
+  // "retry with backoff" answer redelivered batches whose spans then re-ingested as new rows.
+  const standard = value.replace(/-/g, "+").replace(/_/g, "/");
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(standard)) {
     return null;
   }
-  return Buffer.from(value, "base64").toString("hex");
+  return Buffer.from(standard, "base64").toString("hex");
 }
 
 // A handful of real-world JSON producers emit snake_case (the literal .proto field names) instead

--- a/engine/src/routes/agentMonitoringDashboard.ts
+++ b/engine/src/routes/agentMonitoringDashboard.ts
@@ -1299,27 +1299,10 @@ agentMonitoringDashboardRouter.post(
       | { verdict?: string; netAgreementGain?: number; fixed?: number; brokenControls?: number }
       | undefined;
     const force = body.force === true;
-    if (!force) {
-      if (!validation || typeof validation.verdict !== "string") {
-        res.status(409).json({
-          error:
-            "Publishing tuned criteria requires the validation result (run POST .../tune/validate and pass its verdict as `validation`), or force: true to publish unvalidated.",
-        });
-        return;
-      }
-      if (validation.verdict === "regressed") {
-        res.status(409).json({
-          error:
-            "Validation measured a net regression on this judge's own cases - not published. Re-generate the proposal, or pass force: true to publish anyway.",
-        });
-        return;
-      }
-    }
     // Provenance honesty: a token minted by /tune/validate proves the verdict was measured
-    // for EXACTLY this candidate package on this evaluator. Without one (older clients), the
-    // stamp says client-asserted - the version history must never present an unverified
-    // claim as a measurement. A token that fails verification (criteria edited after
-    // validating, or another evaluator's token) is a hard 409, not a downgrade.
+    // for EXACTLY this candidate package on this evaluator. A token that fails verification
+    // (criteria edited after validating, or another evaluator's token) is a hard 409, not a
+    // downgrade.
     const token = (validation as { token?: string } | undefined)?.token;
     let verified: { verdict: string; netAgreementGain: number | null } | null = null;
     if (typeof token === "string" && token) {
@@ -1335,6 +1318,25 @@ agentMonitoringDashboardRouter.post(
         res.status(409).json({
           error:
             "The validation token does not match what is being published - the criteria changed after validation (or the token belongs to another scorer). Re-run POST .../tune/validate on this exact package.",
+        });
+        return;
+      }
+    }
+    if (!force) {
+      // The gate runs on the VERIFIED verdict, never the client's assertion - otherwise
+      // omitting the token skipped the regression check entirely (a caller could publish a
+      // measured regression by simply claiming "improved" with no proof, no force needed).
+      if (!verified) {
+        res.status(409).json({
+          error:
+            "Publishing tuned criteria requires the verified validation from POST .../tune/validate (pass its result - including validationToken - as `validation`), or force: true to publish unvalidated.",
+        });
+        return;
+      }
+      if (verified.verdict === "regressed") {
+        res.status(409).json({
+          error:
+            "Validation measured a net regression on this judge's own cases - not published. Re-generate the proposal, or pass force: true to publish anyway.",
         });
         return;
       }

--- a/engine/src/routes/apiV1.ts
+++ b/engine/src/routes/apiV1.ts
@@ -220,6 +220,15 @@ export function registerApiV1(app: Express, deps: ApiV1Deps): void {
         res.status(401).json({ error: "Provide a valid project API key (printed at engine startup)" });
         return;
       }
+      // A key deletes only ITS OWN project. Any-valid-key-deletes-anything meant one leaked
+      // staging key could irreversibly cascade-delete production; the dashboard already sends
+      // the target's own key (it adopts a project's key on switch), so nothing legitimate is
+      // lost. Callers holding another project's key genuinely have it - use it. 404, not 403:
+      // no cross-project existence oracle.
+      if (caller.id !== target.id) {
+        res.status(404).json({ error: "Project not found" });
+        return;
+      }
     }
     if (target.isDefault) {
       res.status(400).json({ error: "The default project cannot be deleted" });

--- a/engine/src/routes/auditTap.ts
+++ b/engine/src/routes/auditTap.ts
@@ -110,6 +110,11 @@ export function classifyControlPlane(method: string, path: string): Classified |
   return { action: `${noun}.${verb}`, entityType: noun, entityId };
 }
 
+// Field NAMES are caller-controlled strings too: thirty megabyte-long keys would land megabytes
+// per request in an append-only table. 10KB keeps every row bounded without losing which fields
+// a legitimate request touched.
+const MAX_SUMMARY_JSON_CHARS = 10 * 1024;
+
 function safeSummary(body: unknown): Record<string, unknown> | null {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     return null;
@@ -119,10 +124,15 @@ function safeSummary(body: unknown): Record<string, unknown> | null {
   if (fields.length === 0) {
     return null;
   }
-  return {
+  const summary = {
     fields,
     ...(typeof record.name === "string" ? { name: record.name.slice(0, 200) } : {}),
   };
+  const json = JSON.stringify(summary);
+  if (json.length > MAX_SUMMARY_JSON_CHARS) {
+    return { truncated: `${json.slice(0, MAX_SUMMARY_JSON_CHARS)}…[truncated]` };
+  }
+  return summary;
 }
 
 async function resolveActor(req: Request): Promise<{ actor: string; actorType: AuditActorType }> {

--- a/engine/src/routes/authOrg.ts
+++ b/engine/src/routes/authOrg.ts
@@ -143,7 +143,9 @@ authOrgRouter.post("/organizations/:orgId/invitations", async (req: Request, res
   }
   // The path the dashboard's accept page mounts at; PUBLIC_URL makes the link shareable
   // beyond localhost when configured (the cloud deployment always sets it).
-  const base = (process.env.AGENTX_PUBLIC_URL || "").replace(/\/$/, "");
+  // Fall back to the request origin: with no AGENTX_PUBLIC_URL the invite email otherwise
+  // carried a bare relative path - an unclickable link in every mail client.
+  const base = (process.env.AGENTX_PUBLIC_URL?.trim() || `${req.protocol}://${req.get("host")}`).replace(/\/$/, "");
   const url = `${base}/accept-invite?token=${row.id}`;
   // With a mailer configured the invitee gets the link directly; the response still carries it
   // either way so the inviter can always hand it over out-of-band.

--- a/engine/src/routes/evaluateDashboard.ts
+++ b/engine/src/routes/evaluateDashboard.ts
@@ -58,6 +58,7 @@ import {
   getAgentConnectorRow,
   testAgentConnectorConnection,
 } from "../core/evaluate/agentConnectors.js";
+import { outboundUrlProblem } from "../core/shared/urlGuard.js";
 import { startConnectorRun } from "../core/evaluate/connectorRun.js";
 import {
   createToolSchema,
@@ -571,6 +572,11 @@ evaluateDashboardRouter.post("/agent-connectors", async (req: Request, res: Resp
     res.status(400).json({ error: "url must be an http(s) URL" });
     return;
   }
+  const headerProblem = connectorHeaderProblem(body.headers);
+  if (headerProblem) {
+    res.status(400).json({ error: headerProblem });
+    return;
+  }
   const connector = await createAgentConnector(scopedDb(req), {
     name: body.name,
     url: String(body.url).trim(),
@@ -584,6 +590,11 @@ evaluateDashboardRouter.put("/agent-connectors/:id", async (req: Request, res: R
   const body = req.body ?? {};
   if (body.url !== undefined && !isHttpUrl(body.url)) {
     res.status(400).json({ error: "url must be an http(s) URL" });
+    return;
+  }
+  const putHeaderProblem = connectorHeaderProblem(body.headers);
+  if (putHeaderProblem) {
+    res.status(400).json({ error: putHeaderProblem });
     return;
   }
   const connector = await updateAgentConnector(scopedDb(req), req.params.id!, {
@@ -950,25 +961,28 @@ evaluateDashboardRouter.patch("/tool-schemas/:id/test-endpoint", async (req: Req
   res.status(200).json(updated);
 });
 
-function isHttpUrl(value: unknown): boolean {
-  if (typeof value !== "string" || !value.trim()) return false;
-  try {
-    const url = new URL(value.trim());
-    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
-    // Self-host deliberately allows loopback/private targets (operators point connectors and
-    // webhooks at their own services) - but cloud metadata endpoints are never a legitimate
-    // connector, and a stored URL reaching one is a server-side credential grab. Blocked at
-    // write time; DNS-rebinding-grade defenses are out of scope for a trusted-operator tier.
-    return !isMetadataTarget(url.hostname);
-  } catch {
-    return false;
+
+// A nested/array header value 201s at write time and then TypeErrors inside undici on every
+// connector call - a 200-case run completing with 200 identical "connector_error" results and
+// nothing saying the CONFIG was malformed. Strings only; explicit null clears.
+function connectorHeaderProblem(headers: unknown): string | null {
+  if (headers === undefined || headers === null) return null;
+  if (typeof headers !== "object" || Array.isArray(headers)) return "headers must be an object of string values";
+  for (const value of Object.values(headers as Record<string, unknown>)) {
+    if (typeof value !== "string") return "headers must be an object of string values";
   }
+  return null;
 }
 
-function isMetadataTarget(hostname: string): boolean {
-  const host = hostname.toLowerCase();
-  return host === "metadata.google.internal" || host === "metadata.goog" || /^169\.254\./.test(host) || host === "[fd00:ec2::254]" || host === "fd00:ec2::254";
+function isHttpUrl(value: unknown): boolean {
+  // The shared egress guard (core/shared/urlGuard.ts): http(s)-only, metadata hosts always
+  // refused, private/loopback refused under AGENTX_MULTI_TENANT. The local two-rule copy this
+  // replaced silently skipped the multi-tenant private-range rule, making connectors the one
+  // caller-supplied-URL surface a tenant could point at the operator's internal network.
+  if (typeof value !== "string" || !value.trim()) return false;
+  return outboundUrlProblem(value.trim()) === null;
 }
+
 
 // Remote MCP introspection for Register Tool (core/evaluate/mcp.ts): connect, tools/list, hand
 // the shapes back for review. headers = the dialog's key-value pairs (sent as HTTP headers -

--- a/engine/src/routes/evaluations.ts
+++ b/engine/src/routes/evaluations.ts
@@ -356,8 +356,8 @@ evaluationsRouter.get("/runs/:runId/gate", async (req: Request, res: Response) =
     res.status(400).json({ error: "failUnder must be a number" });
     return;
   }
-  if (tolerance !== undefined && !Number.isFinite(tolerance)) {
-    res.status(400).json({ error: "tolerance must be a number" });
+  if (tolerance !== undefined && (!Number.isFinite(tolerance) || tolerance < 0)) {
+    res.status(400).json({ error: "tolerance must be a non-negative number" });
     return;
   }
   if (failUnder == null && !noRegression) {

--- a/engine/src/routes/otlp.ts
+++ b/engine/src/routes/otlp.ts
@@ -51,6 +51,13 @@ const MONITOR_OTEL_TRACES = process.env.AGENTX_OTEL_MONITOR !== "false";
 // per-span behavior for an operator who deliberately wants it.
 const MONITOR_CHILD_SPANS = process.env.AGENTX_MONITOR_CHILD_SPANS === "true";
 
+// Per-request span cap: everything past normalization is per-span work (mapping, validation,
+// queued ingest, up to six background checks each) with the whole batch held in memory, so an
+// unbounded export is a one-request amplification vector. 5000 is an order of magnitude above
+// any sane exporter batch (the OTel SDK default is 512); the whole request is refused with 413
+// before any span is processed, so a conforming exporter can split and resend without dupes.
+const MAX_SPANS_PER_EXPORT = 5000;
+
 otlpRouter.post("/v1/traces", async (req: Request, res: Response) => {
   const isProtobuf = Boolean(req.is("application/x-protobuf"));
   // Any other content type leaves req.body an empty object, which reads here as a valid export of
@@ -88,6 +95,12 @@ otlpRouter.post("/v1/traces", async (req: Request, res: Response) => {
   }
 
   const spans = normalizeExportRequest(parsed);
+  if (spans.length > MAX_SPANS_PER_EXPORT) {
+    res.status(413).json({
+      error: `too many spans in one export (${spans.length} > ${MAX_SPANS_PER_EXPORT}) - nothing was ingested, split the batch and resend`,
+    });
+    return;
+  }
   const db = scopedDb(req);
   let rejected = 0;
   let lastError = "";
@@ -109,7 +122,16 @@ otlpRouter.post("/v1/traces", async (req: Request, res: Response) => {
   let mappingRejected = 0;
   for (const span of spans) {
     try {
-      candidates.push(otelSpanToIngestInput(span));
+      const mapped = otelSpanToIngestInput(span);
+      // A span whose id the normalizer rejected has NO dedupe key - storing it makes the 429
+      // "safe to retry, span ids make the stored part idempotent" answer a lie (each retry
+      // re-inserts it). Rejected into partialSuccess like any other unmappable span.
+      if (!mapped.span_id) {
+        mappingRejected++;
+        logger.warn("OTLP: span carried no decodable span id - rejected into partialSuccess (undedupable)");
+        continue;
+      }
+      candidates.push(mapped);
     } catch (err) {
       mappingRejected++;
       logger.warn({ err }, "OTLP: span failed to map - rejected into partialSuccess");

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -456,6 +456,7 @@ export function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean }
       run_source TEXT,
       sdk_info TEXT,
       smoke_test_variants TEXT,
+      questions_snapshot TEXT,
       status TEXT NOT NULL DEFAULT 'in_progress',
       created_at INTEGER NOT NULL,
       project_id TEXT
@@ -1105,6 +1106,7 @@ export function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean }
     // pairwise_comparisons shipped before the both-orders pass existed; an install upgraded past
     // that point 500s on every new comparison without this (fresh DBs get it via CREATE TABLE).
     ["pairwise_comparisons", "ALTER TABLE pairwise_comparisons ADD COLUMN both_orders INTEGER NOT NULL DEFAULT 0"],
+    ["evaluation_runs", "ALTER TABLE evaluation_runs ADD COLUMN questions_snapshot TEXT"],
     ["monitor_classifications", "ALTER TABLE monitor_classifications ADD COLUMN input_embedding TEXT"],
     ["monitor_signal_feedback", "ALTER TABLE monitor_signal_feedback ADD COLUMN event_id TEXT"],
     ["monitor_profiles", "ALTER TABLE monitor_profiles ADD COLUMN topics_enabled INTEGER NOT NULL DEFAULT 0"],
@@ -1825,6 +1827,7 @@ export async function bootstrapPostgres(pool: Pool): Promise<{ freshInstall: boo
       run_source TEXT,
       sdk_info JSONB,
       smoke_test_variants JSONB,
+      questions_snapshot JSONB,
       status TEXT NOT NULL DEFAULT 'in_progress',
       created_at TIMESTAMP NOT NULL,
       project_id TEXT
@@ -2420,6 +2423,7 @@ export async function bootstrapPostgres(pool: Pool): Promise<{ freshInstall: boo
     ALTER TABLE monitor_patterns ADD COLUMN IF NOT EXISTS scope_mode TEXT NOT NULL DEFAULT 'all';
     ALTER TABLE monitor_patterns ADD COLUMN IF NOT EXISTS agent_ids JSONB;
     ALTER TABLE pairwise_comparisons ADD COLUMN IF NOT EXISTS both_orders BOOLEAN NOT NULL DEFAULT FALSE;
+    ALTER TABLE evaluation_runs ADD COLUMN IF NOT EXISTS questions_snapshot JSONB;
     ALTER TABLE evaluation_runs ADD COLUMN IF NOT EXISTS scorer_group_id TEXT;
     ALTER TABLE monitor_classifications ADD COLUMN IF NOT EXISTS input_embedding JSONB;
     ALTER TABLE monitor_profiles ADD COLUMN IF NOT EXISTS channels JSONB;

--- a/engine/src/storage/schema.pg.ts
+++ b/engine/src/storage/schema.pg.ts
@@ -121,6 +121,8 @@ export const evaluationRuns = pgTable("evaluation_runs", {
   additionalScorerIds: jsonb("additional_scorer_ids"),
   scorerGroupId: text("scorer_group_id"),
   smokeTestVariants: jsonb("smoke_test_variants"),
+  // See schema.sqlite.ts - frozen questions so positional scoring survives dataset edits.
+  questionsSnapshot: jsonb("questions_snapshot"),
   status: text("status").notNull().default("in_progress"),
   createdAt: timestamp("created_at", { mode: "date" }).notNull(),
   projectId: text("project_id"),

--- a/engine/src/storage/schema.sqlite.ts
+++ b/engine/src/storage/schema.sqlite.ts
@@ -205,6 +205,11 @@ export const evaluationRuns = sqliteTable("evaluation_runs", {
   // judge.ts's generateSmokeTestVariants) for questions with main_question.smokeTest.enabled,
   // frozen for the lifetime of the run so a later call can't see it change mid-run.
   smokeTestVariants: text("smoke_test_variants", { mode: "json" }),
+  // The dataset's questions AS OF run creation. Scoring keys into questions by POSITION
+  // (questionIndex), so grading against the live dataset meant a case deleted mid-run silently
+  // re-pointed every later index at the wrong expected answer. Null on legacy runs = fall back
+  // to the live dataset, exactly the old behavior.
+  questionsSnapshot: text("questions_snapshot", { mode: "json" }),
   status: text("status").notNull().default("in_progress"),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
   projectId: text("project_id"),

--- a/engine/src/test/confirmAgreement.integration.test.ts
+++ b/engine/src/test/confirmAgreement.integration.test.ts
@@ -23,6 +23,18 @@ beforeAll(async () => {
     req.resume();
     req.on("end", () => {
       res.setHeader("content-type", "application/json");
+      // Custom (OpenAI-compat) models are now correctly routed to /chat/completions -
+      // serve the same verdict in that shape.
+      if ((req.url ?? "").includes("/chat/completions")) {
+        res.end(
+          JSON.stringify({
+            id: "chat_stub",
+            choices: [{ message: { role: "assistant", content: JSON.stringify({ rating: 2, justification: "stub says bad" }) } }],
+            usage: { prompt_tokens: 5, completion_tokens: 5 },
+          })
+        );
+        return;
+      }
       res.end(
         JSON.stringify({
           id: "resp_stub",

--- a/engine/src/test/embeddingBatch.test.ts
+++ b/engine/src/test/embeddingBatch.test.ts
@@ -7,7 +7,9 @@ import { embedBatched, type EmbeddingClient } from "../core/evaluate/judge.js";
 // next time - so a batch that fails as a unit does not lose one case, it blocks every case behind it
 // forever. These pin that it splits instead.
 
-/** A client that rejects any request containing `poison`, the way an over-long input does. */
+/** A client that rejects any request containing `poison`, the way an over-long input does.
+ * The thrown error carries `.status` like the real SDK's APIError - splitting keys on it:
+ * only payload-shaped failures (400/413) are worth halving; transient ones are not. */
 const clientRejecting = (poison: string) => {
   const calls: string[][] = [];
   const client: EmbeddingClient = {
@@ -15,7 +17,7 @@ const clientRejecting = (poison: string) => {
       create: async ({ input }) => {
         calls.push(input);
         if (input.includes(poison)) {
-          throw new Error("400 - requested too many tokens");
+          throw Object.assign(new Error("400 - requested too many tokens"), { status: 400 });
         }
         return { data: input.map((text, index) => ({ index, embedding: [text.length, 0] })) };
       },
@@ -78,15 +80,20 @@ describe("embedBatched", () => {
     expect(await embedBatched(client, ["x", "y", "z"])).toEqual([[0], [1], [2]]);
   });
 
-  it("nulls only the input that cannot be embedded at all", async () => {
+  it("a transient provider failure leaves the batch pending WITHOUT splitting", async () => {
+    // A 429/5xx means the PROVIDER is failing - halving would fire 2^k requests at an
+    // endpoint that just said stop. One request, whole batch null (pending for next time).
+    let calls = 0;
     const client: EmbeddingClient = {
       embeddings: {
         create: async () => {
-          throw new Error("500");
+          calls++;
+          throw Object.assign(new Error("500"), { status: 500 });
         },
       },
     };
 
     expect(await embedBatched(client, ["a", "b"])).toEqual([null, null]);
+    expect(calls).toBe(1);
   });
 });

--- a/engine/src/test/evalBreadth.integration.test.ts
+++ b/engine/src/test/evalBreadth.integration.test.ts
@@ -24,6 +24,18 @@ beforeAll(async () => {
       // Alternates 3, 9, 3, 9... so repetitions of the same case get a real spread.
       const rating = stubCalls % 2 === 1 ? 3 : 9;
       res.setHeader("content-type", "application/json");
+      // Custom (OpenAI-compat) models are now correctly routed to /chat/completions -
+      // serve the same verdict in that shape.
+      if ((req.url ?? "").includes("/chat/completions")) {
+        res.end(
+          JSON.stringify({
+            id: "chat_stub",
+            choices: [{ message: { role: "assistant", content: JSON.stringify({ rating, justification: `stub verdict ${rating}` }) } }],
+            usage: { prompt_tokens: 5, completion_tokens: 5 },
+          })
+        );
+        return;
+      }
       res.end(
         JSON.stringify({
           id: "resp_stub",

--- a/engine/src/test/improvementGroups.integration.test.ts
+++ b/engine/src/test/improvementGroups.integration.test.ts
@@ -38,6 +38,18 @@ beforeAll(async () => {
             ],
           }
         : { rating: 2, justification: "stub says bad" };
+      // Custom (OpenAI-compat) models are now correctly routed to /chat/completions -
+      // serve the same verdict in that shape.
+      if ((req.url ?? "").includes("/chat/completions")) {
+        res.end(
+          JSON.stringify({
+            id: "chat_stub",
+            choices: [{ message: { role: "assistant", content: JSON.stringify(output) } }],
+            usage: { prompt_tokens: 5, completion_tokens: 5 },
+          })
+        );
+        return;
+      }
       res.end(
         JSON.stringify({
           id: "resp_stub",

--- a/engine/src/test/judgeLoop.integration.test.ts
+++ b/engine/src/test/judgeLoop.integration.test.ts
@@ -38,6 +38,18 @@ beforeAll(async () => {
           }
         : { rating: 3, justification: "stub: weak answer" };
       res.setHeader("content-type", "application/json");
+      // Custom (OpenAI-compat) models are now correctly routed to /chat/completions -
+      // serve the same marker-keyed verdict in that shape.
+      if ((req.url ?? "").includes("/chat/completions")) {
+        res.end(
+          JSON.stringify({
+            id: "chat_stub",
+            choices: [{ message: { role: "assistant", content: JSON.stringify(payload) } }],
+            usage: { prompt_tokens: 10, completion_tokens: 10 },
+          })
+        );
+        return;
+      }
       res.end(
         JSON.stringify({
           id: "resp_stub",
@@ -179,19 +191,48 @@ describe("provenance-gated publish", () => {
     expect(summaries.some(s => s.includes("[judge tuning: published without validation]"))).toBe(true);
   });
 
-  it("accepts a validated improvement and stamps the measured gain", async () => {
+  it("refuses a client-asserted verdict without the validate token, accepts the verified one", async () => {
+    const criteria = {
+      acceptanceCriteria: "Concrete resolution with specifics, v2.",
+      rejectionCriteria: "Brush-offs.",
+      evaluationCriteria: "Did the agent actually resolve the request?",
+    };
+    // Claiming "improved" with no proof used to pass the regression gate outright - the gate
+    // now runs on the VERIFIED verdict only, so a token-less assertion is a 409, not a bypass.
+    const asserted = await api(
+      `/agent-monitoring/online-evaluators/${profileId}/tune/publish`,
+      postJson({ ...criteria, validation: { verdict: "improved", netAgreementGain: 3 } })
+    );
+    expect(asserted.status).toBe(409);
+
+    // The real flow: validate mints the HMAC token for exactly this package...
+    const validated = await api(
+      `/agent-monitoring/online-evaluators/${profileId}/tune/validate`,
+      postJson(criteria)
+    );
+    expect(validated.status).toBe(200);
+    const validationBody = validated.body as {
+      verdict: string;
+      netAgreementGain: number;
+      validationToken?: string;
+    };
+    expect(typeof validationBody.validationToken).toBe("string");
+
+    // ...and publish accepts the token-carrying result, stamping the measured verdict.
     const ok = await api(
       `/agent-monitoring/online-evaluators/${profileId}/tune/publish`,
       postJson({
-        acceptanceCriteria: "Concrete resolution with specifics, v2.",
-        rejectionCriteria: "Brush-offs.",
-        evaluationCriteria: "Did the agent actually resolve the request?",
-        validation: { verdict: "improved", netAgreementGain: 3 },
+        ...criteria,
+        validation: {
+          verdict: validationBody.verdict,
+          netAgreementGain: validationBody.netAgreementGain,
+          token: validationBody.validationToken,
+        },
       })
     );
     expect(ok.status).toBe(200);
     const versions = await api(`/evaluate/evaluationSettings/${scorerId}/versions`);
     const summaries = (versions.body as Array<{ changeSummary?: string }>).map(v => v.changeSummary ?? "");
-    expect(summaries.some(s => s.includes("validated improved") && s.includes("+3"))).toBe(true);
+    expect(summaries.some(s => s.includes(`validated ${validationBody.verdict}`))).toBe(true);
   });
 });

--- a/engine/src/test/lowScoreWebhook.integration.test.ts
+++ b/engine/src/test/lowScoreWebhook.integration.test.ts
@@ -24,6 +24,18 @@ beforeAll(async () => {
     req.resume();
     req.on("end", () => {
       res.setHeader("content-type", "application/json");
+      // Custom (OpenAI-compat) models are now correctly routed to /chat/completions -
+      // serve the same verdict in that shape.
+      if ((req.url ?? "").includes("/chat/completions")) {
+        res.end(
+          JSON.stringify({
+            id: "chat_stub",
+            choices: [{ message: { role: "assistant", content: JSON.stringify({ rating: 2, justification: "stub says bad" }) } }],
+            usage: { prompt_tokens: 5, completion_tokens: 5 },
+          })
+        );
+        return;
+      }
       res.end(
         JSON.stringify({
           id: "resp_stub",

--- a/engine/src/test/monitorOps.integration.test.ts
+++ b/engine/src/test/monitorOps.integration.test.ts
@@ -22,6 +22,18 @@ beforeAll(async () => {
     req.on("data", chunk => (raw += chunk));
     req.on("end", () => {
       res.setHeader("content-type", "application/json");
+      // Custom (OpenAI-compat) models are now correctly routed to /chat/completions -
+      // serve the same verdict in that shape.
+      if ((req.url ?? "").includes("/chat/completions")) {
+        res.end(
+          JSON.stringify({
+            id: "chat_stub",
+            choices: [{ message: { role: "assistant", content: JSON.stringify({ rating: 8, justification: "stub" }) } }],
+            usage: { prompt_tokens: 5, completion_tokens: 5 },
+          })
+        );
+        return;
+      }
       res.end(
         JSON.stringify({
           id: "resp_stub",

--- a/engine/src/test/multiJudge.integration.test.ts
+++ b/engine/src/test/multiJudge.integration.test.ts
@@ -25,13 +25,21 @@ beforeAll(async () => {
     req.on("end", () => {
       const rating = raw.includes("SAFETYMARK") ? 3 : raw.includes("TONEMARK") ? 6 : 9;
       res.setHeader("content-type", "application/json");
-      // Judges arrive via the Responses API (judge-core), the Playground's model completion via
-      // chat completions - serve whichever shape the path asks for.
+      // Custom (OpenAI-compat) models route judge calls AND playground completions to
+      // /chat/completions - json_object marks a judge call, anything else is a completion.
       if ((req.url ?? "").includes("/chat/completions")) {
+        const isJudgeCall = raw.includes("json_object");
         res.end(
           JSON.stringify({
             id: "chat_stub",
-            choices: [{ message: { role: "assistant", content: "stub answer" } }],
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: isJudgeCall ? JSON.stringify({ rating, justification: `stub rated ${rating}` }) : "stub answer",
+                },
+              },
+            ],
             usage: { prompt_tokens: 5, completion_tokens: 5 },
           })
         );

--- a/engine/src/test/otlp.integration.test.ts
+++ b/engine/src/test/otlp.integration.test.ts
@@ -164,6 +164,25 @@ describe("POST /api/v1/otel/v1/traces", () => {
     expect(res.status).toBe(200);
   });
 
+  it("refuses an oversized batch with 413 before processing any span", async () => {
+    // 5001 spans, each with a unique spanId so nothing would dedupe if they were processed.
+    const spans = Array.from({ length: 5001 }, (_, i) =>
+      goodSpan({ spanId: b64(i.toString(16).padStart(16, "0")), name: `cap-check-${i}` })
+    );
+    const res = await engine.json("/api/v1/otel/v1/traces", {
+      method: "POST",
+      body: JSON.stringify({
+        resourceSpans: [{ resource: { attributes: [] }, scopeSpans: [{ scope: { name: "cap" }, spans }] }],
+      }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(res.status).toBe(413);
+    expect(JSON.stringify(res.body)).toContain("too many spans");
+
+    const listed = await engine.json("/api/v1/ingest/traces?limit=100");
+    expect(JSON.stringify(listed.body)).not.toContain("cap-check-");
+  });
+
   it("requires an API key", async () => {
     const res = await postOtlp(exportRequest(goodSpan()));
     expect(res.status).toBe(200);

--- a/engine/src/test/projects.integration.test.ts
+++ b/engine/src/test/projects.integration.test.ts
@@ -160,7 +160,7 @@ describe("project deletion", () => {
     expect(countIn(before, "evaluation_settings")).toBeGreaterThan(0);
     before.close();
 
-    const deleted = await engine.request(`/api/v1/projects/${doomed._id}`, { method: "DELETE", apiKey: keyA });
+    const deleted = await engine.request(`/api/v1/projects/${doomed._id}`, { method: "DELETE", apiKey: doomed.apiKey });
     expect(deleted.status).toBe(204);
     await deleted.text();
 
@@ -178,7 +178,7 @@ describe("project deletion", () => {
     const doomed = await createProject("Key revoked on delete");
     expect((await engine.json("/api/v1/ingest/traces", { apiKey: doomed.apiKey })).status).toBe(200);
 
-    const deleted = await engine.request(`/api/v1/projects/${doomed._id}`, { method: "DELETE", apiKey: keyA });
+    const deleted = await engine.request(`/api/v1/projects/${doomed._id}`, { method: "DELETE", apiKey: doomed.apiKey });
     expect(deleted.status).toBe(204);
     await deleted.text();
 
@@ -199,6 +199,19 @@ describe("project deletion", () => {
 
     const still = await engine.json("/api/v1/projects", { apiKey: keyA });
     expect((still.body as { projects: { _id: string }[] }).projects.map(p => p._id)).toContain(fallback!._id);
+  });
+
+  it("a key cannot delete another project (404, no existence oracle)", async () => {
+    const doomed = await createProject("Someone else's project");
+    // keyA belongs to the default project - deleting a DIFFERENT project with it used to
+    // cascade-delete it; now the caller only ever deletes itself.
+    const res = await engine.request(`/api/v1/projects/${doomed._id}`, { method: "DELETE", apiKey: keyA });
+    expect(res.status).toBe(404);
+    await res.text();
+    const still = await engine.json("/api/v1/projects", { apiKey: keyA });
+    expect((still.body as { projects: { _id: string }[] }).projects.map(p => p._id)).toContain(doomed._id);
+    // Cleanup with its own key - the allowed path.
+    await (await engine.request(`/api/v1/projects/${doomed._id}`, { method: "DELETE", apiKey: doomed.apiKey })).text();
   });
 
   it("404s an unknown project id", async () => {

--- a/engine/src/test/scorerGroups.integration.test.ts
+++ b/engine/src/test/scorerGroups.integration.test.ts
@@ -23,13 +23,21 @@ beforeAll(async () => {
     req.on("end", () => {
       const rating = raw.includes("HARSHMARK") ? 2 : 8;
       res.setHeader("content-type", "application/json");
-      // Judges arrive via the Responses API (judge-core); the Playground's model completion
-      // uses chat completions - serve whichever shape the path asks for.
+      // Custom (OpenAI-compat) models route judge calls AND playground completions to
+      // /chat/completions - json_object marks a judge call, anything else is a completion.
       if ((req.url ?? "").includes("/chat/completions")) {
+        const isJudgeCall = raw.includes("json_object");
         res.end(
           JSON.stringify({
             id: "chat_stub",
-            choices: [{ message: { role: "assistant", content: "stub answer" } }],
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: isJudgeCall ? JSON.stringify({ rating, justification: `stub rated ${rating}` }) : "stub answer",
+                },
+              },
+            ],
             usage: { prompt_tokens: 5, completion_tokens: 5 },
           })
         );

--- a/packages/judge-core/src/index.ts
+++ b/packages/judge-core/src/index.ts
@@ -87,6 +87,7 @@ export async function callJudgeJson({
   jsonSchema,
   maxTokens = 1200,
   strictSchema = false,
+  useChatCompletions = false,
   openaiClient,
   anthropicClient,
   provider,
@@ -105,12 +106,16 @@ export async function callJudgeJson({
   strictSchema?: boolean;
   openaiClient?: OpenAI | null;
   anthropicClient?: Anthropic | null;
+  // OpenAI-COMPAT endpoints (Gemini's compat layer, OpenRouter, vLLM/Ollama/LM Studio custom
+  // baseURLs) implement /chat/completions, NOT the Responses API - routing them to
+  // responses.create 404s on every call, which silently skipped every result they judged.
+  useChatCompletions?: boolean;
   // The caller's RESOLVED provider. When set it is authoritative: a custom/OpenAI-compat
   // model whose id happens to start with "claude-" must NOT be re-derived onto the Anthropic
   // client by the name heuristic below - the caller already routed it (baseUrl and all).
   provider?: LlmProvider;
 }): Promise<JudgeCallResult> {
-  const first = await callJudgeJsonOnce({ userMessage, model, jsonSchema, maxTokens, strictSchema, openaiClient, anthropicClient, provider });
+  const first = await callJudgeJsonOnce({ userMessage, model, jsonSchema, maxTokens, strictSchema, useChatCompletions, openaiClient, anthropicClient, provider });
   // One automatic retry on a recoverable model failure (empty response or unparseable JSON),
   // with the failure spelled out - a single flaky generation should not permanently lose a
   // verdict. Client-missing returns (payload null, no failureReason) are not retried: the
@@ -128,6 +133,7 @@ export async function callJudgeJson({
     jsonSchema,
     maxTokens,
     strictSchema,
+    useChatCompletions,
     openaiClient,
     anthropicClient,
     provider,
@@ -141,6 +147,7 @@ async function callJudgeJsonOnce({
   jsonSchema,
   maxTokens,
   strictSchema,
+  useChatCompletions,
   openaiClient,
   anthropicClient,
   provider: statedProvider,
@@ -150,6 +157,7 @@ async function callJudgeJsonOnce({
   jsonSchema: object;
   maxTokens: number;
   strictSchema: boolean;
+  useChatCompletions?: boolean;
   openaiClient?: OpenAI | null;
   anthropicClient?: Anthropic | null;
   provider?: LlmProvider;
@@ -157,7 +165,15 @@ async function callJudgeJsonOnce({
   const provider = statedProvider ?? getProviderForModel(model);
 
   if (provider === "openai") {
-    return callOpenAIJson({ userMessage, model, jsonSchema, maxTokens, strictSchema, client: openaiClient ?? null });
+    return callOpenAIJson({
+      userMessage,
+      model,
+      jsonSchema,
+      maxTokens,
+      strictSchema,
+      useChatCompletions: useChatCompletions ?? false,
+      client: openaiClient ?? null,
+    });
   }
 
   if (!anthropicClient) {
@@ -215,6 +231,7 @@ async function callOpenAIJson({
   jsonSchema,
   maxTokens,
   strictSchema,
+  useChatCompletions,
   client,
 }: {
   userMessage: string;
@@ -222,6 +239,7 @@ async function callOpenAIJson({
   jsonSchema: object;
   maxTokens: number;
   strictSchema: boolean;
+  useChatCompletions?: boolean;
   client: OpenAI | null;
 }): Promise<JudgeCallResult> {
   if (!client) {
@@ -234,6 +252,37 @@ async function callOpenAIJson({
   const enhancedUserMessage = strictSchema
     ? userMessage
     : `${userMessage}\n\nIMPORTANT: Your response must strictly conform to this JSON schema:\n${JSON.stringify(jsonSchema, null, 2)}`;
+
+  // OpenAI-compat endpoints (Gemini compat, OpenRouter, vLLM/Ollama/...) implement
+  // /chat/completions only - the Responses API below is real-OpenAI-specific, and sending it
+  // to a compat baseURL 404s every judge call.
+  if (useChatCompletions) {
+    const response = await client.chat.completions.create({
+      model,
+      temperature: isReasoningModel(model) ? undefined : 0,
+      max_tokens: isReasoningModel(model) ? Math.max(maxTokens, 8192) : maxTokens,
+      messages: [{ role: "user", content: enhancedUserMessage }],
+      // json_object is the widely-implemented subset; strict json_schema is not, which is why
+      // callers already force strictSchema=false for compat routes.
+      response_format: { type: "json_object" as const },
+    });
+    const usage: TokenUsage | null =
+      typeof response.usage?.prompt_tokens === "number" && typeof response.usage?.completion_tokens === "number"
+        ? { inputTokens: response.usage.prompt_tokens, outputTokens: response.usage.completion_tokens }
+        : null;
+    const rawContent = response.choices?.[0]?.message?.content?.trim() || null;
+    if (!rawContent) {
+      console.error("judge-core: OpenAI-compat endpoint returned an empty response");
+      return { payload: null, usage, failureReason: "emptyResponse" };
+    }
+    try {
+      // Local/compat models fence JSON in markdown constantly - same tolerance as Anthropic.
+      return { payload: JSON.parse(stripJsonFences(rawContent)), usage };
+    } catch (error) {
+      console.error("judge-core: error parsing OpenAI-compat response", error);
+      return { payload: null, usage, error, failureReason: "parseError" };
+    }
+  }
 
   const response = await client.responses.create({
     model,
@@ -262,7 +311,8 @@ async function callOpenAIJson({
   }
 
   try {
-    return { payload: JSON.parse(rawContent), usage };
+    // Even real OpenAI json_object mode occasionally fences; stripping is a no-op otherwise.
+    return { payload: JSON.parse(stripJsonFences(rawContent)), usage };
   } catch (error) {
     console.error("judge-core: error parsing OpenAI response", error);
     return { payload: null, usage, error, failureReason: "parseError" };
@@ -480,7 +530,7 @@ export function analysisNarrativeSchemaProperties({ requireRatings = false }: { 
         weaknesses: { type: "array", items: { type: "string" } },
         rating: { type: "string", enum: ["high", "medium", "low"] },
       },
-      required: ["strengths", "weaknesses", "rating"],
+      required: ["strengths", "weaknesses", ...ratingIfRequired],
     },
   };
 }
@@ -569,14 +619,26 @@ export function computeBleuScore(expected: string | null | undefined, actual: st
   return Math.max(0, Math.min(1, brevityPenalty * Math.exp(logSum)));
 }
 
-function longestCommonSubsequenceLength(a: string[], b: string[]): number {
-  const dp: number[][] = Array.from({ length: a.length + 1 }, () => new Array(b.length + 1).fill(0));
+// Bounded: two pasted 15k-word documents used to allocate a ~225M-cell dense matrix here and
+// OOM the process mid-run. The cap trades exactness on pathological inputs for survival; the
+// rolling two-row DP keeps memory at O(min side) for everything under it.
+const LCS_MAX_TOKENS = 4000;
+
+function longestCommonSubsequenceLength(aFull: string[], bFull: string[]): number {
+  const a = aFull.length > LCS_MAX_TOKENS ? aFull.slice(0, LCS_MAX_TOKENS) : aFull;
+  const b = bFull.length > LCS_MAX_TOKENS ? bFull.slice(0, LCS_MAX_TOKENS) : bFull;
+  let prev = new Array<number>(b.length + 1).fill(0);
+  let curr = new Array<number>(b.length + 1).fill(0);
   for (let i = 1; i <= a.length; i++) {
     for (let j = 1; j <= b.length; j++) {
-      dp[i]![j] = a[i - 1] === b[j - 1] ? dp[i - 1]![j - 1]! + 1 : Math.max(dp[i - 1]![j]!, dp[i]![j - 1]!);
+      curr[j] = a[i - 1] === b[j - 1] ? prev[j - 1]! + 1 : Math.max(prev[j]!, curr[j - 1]!);
     }
+    const swap = prev;
+    prev = curr;
+    curr = swap;
+    curr.fill(0);
   }
-  return dp[a.length]![b.length]!;
+  return prev[b.length]!;
 }
 
 // ROUGE-L: F1 of precision/recall over the longest common (in-order) subsequence.
@@ -594,8 +656,10 @@ export function computeRougeScore(expected: string | null | undefined, actual: s
   if (lcsLength === 0) {
     return 0;
   }
-  const recall = lcsLength / reference.length;
-  const precision = lcsLength / candidate.length;
+  // Denominators use the same capped lengths the LCS saw, so a capped comparison stays a true
+  // F1 over the compared window instead of shrinking toward 0 as the full texts grow.
+  const recall = lcsLength / Math.min(reference.length, LCS_MAX_TOKENS);
+  const precision = lcsLength / Math.min(candidate.length, LCS_MAX_TOKENS);
   return Math.max(0, Math.min(1, (2 * precision * recall) / (precision + recall)));
 }
 


### PR DESCRIPTION
<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
