### PR TITLE
fix Connector auth headers leaked

### DIFF
--- a/engine/src/auth/betterAuth.ts
+++ b/engine/src/auth/betterAuth.ts
@@ -7,6 +7,8 @@ import { genericOAuth, organization } from "better-auth/plugins";
 import { mailerConfigured, sendMailInBackground } from "./mailer.js";
 
 // Verification is an explicit opt-in on top of a working mailer.
+let firstSignupChain: Promise<void> = Promise.resolve();
+
 export function verificationRequired(): boolean {
   return mailerConfigured() && process.env.AGENTX_REQUIRE_EMAIL_VERIFICATION === "true";
 }
@@ -142,6 +144,10 @@ async function onUserCreated(db: Db, userId: string, userName?: string | null): 
     await ensureMetricPackConfigs(scoped).catch(() => undefined);
     return;
   }
+  // Serialized: two simultaneous first signups both passing the anyMember check would each
+  // mint a "first" org, with one silently owning every unclaimed project and the other an
+  // empty shell. In-process is the realistic boundary - first boot is one instance.
+  const run = async () => {
   const anyMember =
     db.kind === "sqlite"
       ? db.db.select().from(db.schema.authMembers).limit(1).all()[0]
@@ -183,6 +189,18 @@ async function onUserCreated(db: Db, userId: string, userName?: string | null): 
     await db.db.insert(db.schema.authMembers).values(memberRow);
   } else {
     await db.db.insert(db.schema.authMembers).values(memberRow);
+  }
+  };
+  // Chain stays alive across failures (then(run, run) posture) - but THIS caller still sees
+  // its own error: a failed first-signup bootstrap must not silently produce an org-less user.
+  const prior = firstSignupChain;
+  let settle!: () => void;
+  firstSignupChain = new Promise<void>(resolve => (settle = resolve));
+  await prior.catch(() => undefined);
+  try {
+    await run();
+  } finally {
+    settle();
   }
 }
 

--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -690,6 +690,15 @@ export const scorerGroupRatingsResponseSchema = z
   })
   .strict();
 
+// POST /agent-monitoring/session-sweep/run - the SDK's client.monitor.sessions.run_sweep().
+export const sessionSweepRunResponseSchema = z
+  .object({
+    judged: z.number(),
+    // Present (true) when a sweep was already in flight and this call did nothing.
+    skipped: z.boolean().optional(),
+  })
+  .strict();
+
 export const sessionScoresResponseSchema = z
   .object({
     scores: z.array(
@@ -910,6 +919,13 @@ export const WIRE_CONTRACT = [
     summary: "Session-level verdicts - evaluators, scorer groups, legacy coherence",
     response: sessionScoresResponseSchema,
     name: "SessionScores",
+  },
+  {
+    method: "post" as const,
+    path: "/agent-monitoring/session-sweep/run",
+    summary: "Run the idle-session sweep once, scoped to the caller's project",
+    response: sessionSweepRunResponseSchema,
+    name: "SessionSweepRun",
   },
   {
     method: "post" as const,

--- a/engine/src/core/evaluate/agentConnectors.ts
+++ b/engine/src/core/evaluate/agentConnectors.ts
@@ -31,7 +31,7 @@ export type AgentConnectorRow = {
 function toWire(row: AgentConnectorRow) {
   // Header VALUES are where bearer tokens live - the one purpose of the field. Every other
   // stored secret masks on read (provider keys, per-model keys); echoing these verbatim put a
-  // production credential in every GET, and in the NDJSON export. Keys stay readable so the
+  // production credential in every GET, and the NDJSON export redacts the values outright (core/export/exportData.ts). Keys stay readable so the
   // editor can list what's set; a masked value sent back on PUT means "unchanged".
   const headers = (row.headers as Record<string, string> | null) ?? {};
   return {

--- a/engine/src/core/evaluate/analysis.ts
+++ b/engine/src/core/evaluate/analysis.ts
@@ -153,14 +153,28 @@ async function scoreItemWithJudges(row: RunResultRow, judgeModels: string[]): Pr
   const judges: ItemJudgeRating[] = await Promise.all(
     judgeModels.map(async (model, i) => {
       const variant = JUDGE_VARIANTS[i] ?? String(i + 1);
-      const result = await callJudgeJson({ model, jsonSchema: ITEM_SCORE_SCHEMA, userMessage: prompt });
-      const payload = result.payload as { rating?: number; justification?: string } | null;
-      return {
-        judgeVariant: variant,
-        model,
-        rating: typeof payload?.rating === "number" ? payload.rating : null,
-        justification: payload?.justification ?? null,
-      };
+      try {
+        const result = await callJudgeJson({ model, jsonSchema: ITEM_SCORE_SCHEMA, userMessage: prompt });
+        const payload = result.payload as { rating?: number; justification?: string } | null;
+        return {
+          judgeVariant: variant,
+          model,
+          // Clamped: percent-scale answers from compat endpoints (85 for 8.5) must not skew
+          // finalScore, the disagreement bands, or the narrative prompt.
+          rating: typeof payload?.rating === "number" ? Math.max(0, Math.min(10, payload.rating)) : null,
+          justification: payload?.justification ?? null,
+        };
+      } catch (err) {
+        // One judge without a key (or in outage) degrades to a null rating - it must not
+        // reject the item and thereby fail the whole analysis, discarding the other judges'
+        // completed, paid-for calls. ItemJudgeRating.rating is nullable for exactly this.
+        return {
+          judgeVariant: variant,
+          model,
+          rating: null,
+          justification: `judge failed: ${err instanceof Error ? err.message : "unknown error"}`,
+        };
+      }
     })
   );
 
@@ -284,7 +298,9 @@ export async function runEvaluationAnalysis(
   evaluationId: string,
   opts: AnalyzeEvaluationOptions = {}
 ): Promise<AnalyzeEvaluationResult | null> {
-  const inFlightKey = `${db.projectId ?? ""}|${evaluationId}`;
+  // The judge selection is part of the identity: restarting with different judges must start
+  // a new analysis, not silently join (and return) the in-flight one with the old panel.
+  const inFlightKey = `${db.projectId ?? ""}|${evaluationId}|${(opts.judges ?? []).map(j => j.model).sort().join(",")}|${opts.qualityMode ?? ""}`;
   const inFlight = analysisInFlight.get(inFlightKey);
   if (inFlight) {
     return inFlight;

--- a/engine/src/core/evaluate/curation.ts
+++ b/engine/src/core/evaluate/curation.ts
@@ -15,6 +15,8 @@ import { cosine, normalizeText } from "../shared/vector.js";
 // only reads main_question/follow_up_questions) but lets the dashboard badge production-born
 // cases and lets addCaseToDataset refuse to add the same trace twice.
 
+export const MAX_CURATED_FOLLOW_UPS = 50;
+
 export type CuratedTestCase = { query: string; expectedResults: string | null };
 
 export type CuratedCase = {
@@ -85,7 +87,10 @@ export async function previewCaseFromSession(db: Db, sessionId: string): Promise
   return {
     case: {
       main_question: { query: first.query, expectedResults: null },
-      follow_up_questions: turns.slice(1).map(t => ({ query: t.query, expectedResults: null })),
+      // Capped: one case's follow-ups become sequential agent turns on EVERY future run of the
+      // dataset, and its JSON is copied into every later version snapshot - a 4,000-turn
+      // runaway session must not become a 4,000-turn test case.
+      follow_up_questions: turns.slice(1, 1 + MAX_CURATED_FOLLOW_UPS).map(t => ({ query: t.query, expectedResults: null })),
       source: { sessionId, addedAt: new Date().toISOString() },
     },
     turns,

--- a/engine/src/core/evaluate/datasets.ts
+++ b/engine/src/core/evaluate/datasets.ts
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { and, desc, eq } from "drizzle-orm";
+import { sql, and, desc, eq } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import type { CodeScorerConfig } from "./codeScorer.js";
 import { recordDatasetVersionIfChanged } from "./versions.js";
@@ -277,25 +277,27 @@ export async function listDatasetActivity(db: Db): Promise<Map<string, DatasetAc
     createdAt: Date;
   };
 
+  // Grouped in SQL: auto-versioned datasets accumulate thousands of version rows, and the
+  // list only ever needs the newest timestamp per dataset.
   const versionRows = (
     db.kind === "sqlite"
       ? db.db
           .select({
             datasetId: db.schema.datasetVersions.datasetId,
-            createdAt: db.schema.datasetVersions.createdAt,
+            createdAt: sql<Date>`max(${db.schema.datasetVersions.createdAt})`,
           })
           .from(db.schema.datasetVersions)
           .where(versionCond)
-          .orderBy(desc(db.schema.datasetVersions.createdAt))
+          .groupBy(db.schema.datasetVersions.datasetId)
           .all()
       : await db.db
           .select({
             datasetId: db.schema.datasetVersions.datasetId,
-            createdAt: db.schema.datasetVersions.createdAt,
+            createdAt: sql<Date>`max(${db.schema.datasetVersions.createdAt})`,
           })
           .from(db.schema.datasetVersions)
           .where(versionCond)
-          .orderBy(desc(db.schema.datasetVersions.createdAt))
+          .groupBy(db.schema.datasetVersions.datasetId)
   ) as VersionRow[];
 
   const runRows = (
@@ -312,6 +314,10 @@ export async function listDatasetActivity(db: Db): Promise<Map<string, DatasetAc
           .from(db.schema.evaluationRuns)
           .where(runCond)
           .orderBy(desc(db.schema.evaluationRuns.createdAt))
+          // Bounded: only the newest run per dataset is kept, and any dataset active in the
+          // last ~10k runs has it inside this window. A dataset idle for longer shows no
+          // last-run chip - honest degradation, not a full-table transfer per page load.
+          .limit(10_000)
           .all()
       : await db.db
           .select({
@@ -325,6 +331,7 @@ export async function listDatasetActivity(db: Db): Promise<Map<string, DatasetAc
           .from(db.schema.evaluationRuns)
           .where(runCond)
           .orderBy(desc(db.schema.evaluationRuns.createdAt))
+          .limit(10_000)
   ) as RunRow[];
 
   const activity = new Map<string, DatasetActivity>();

--- a/engine/src/core/evaluate/judge.ts
+++ b/engine/src/core/evaluate/judge.ts
@@ -3,7 +3,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { getDb } from "../../storage/db.js";
 import { getAppSettings } from "../settings/appSettings.js";
 import { isMultiTenant } from "../../auth/mode.js";
-import { checkAndRecordJudgeCall } from "../shared/usage.js";
+import { checkAndRecordJudgeCall, recordJudgeCall } from "../shared/usage.js";
 
 // Multi-tenant hard rule: provider keys come only from the org's own settings row - the
 // process env belongs to the operator, and letting a tenant's judge calls fall back to it
@@ -361,8 +361,10 @@ export async function callJudgeJson({
   });
   if (result.retried) {
     // judge-core's automatic empty/parse-failure retry is a second real provider call - the
-    // billing ledger under-counted by up to 2x on flaky generations without this.
-    await checkAndRecordJudgeCall(model);
+    // billing ledger under-counted by up to 2x on flaky generations without this. Record-only:
+    // the quota gate ran before the call, and throwing HERE would discard a successful,
+    // already-billed result at the exact boundary of the daily cap.
+    await recordJudgeCall(model);
   }
   return result;
 }
@@ -853,9 +855,17 @@ export async function scorePortabilityResponse(
 ): Promise<{ rating: number; justification: string }> {
   const prompt = applyJudgePromptTemplate(PORTABILITY_JUDGE_PROMPT, { input, output, expected: "" });
   const result = await callJudgeJson({ model: judgeModel, jsonSchema: SCORE_SCHEMA, userMessage: prompt });
-  const payload = result.payload as { rating: number; justification: string } | null;
+  const payload = result.payload as { rating?: unknown; justification?: unknown } | null;
   if (!payload) {
     throw new Error("Judge model returned no result");
   }
-  return { rating: payload.rating, justification: payload.justification };
+  // Same coercion + clamp scoreAgainstCriteria applies, for the same reason: this is exactly
+  // the surface judged by non-OpenAI/custom endpoints, which answer {"rating": "8"} or a
+  // percent-scale 85 often enough that an unvalidated pass-through corrupts the comparison.
+  const numeric = typeof payload.rating === "number" ? payload.rating : Number(payload.rating);
+  if (!Number.isFinite(numeric)) {
+    throw new Error("Judge model returned a non-numeric rating");
+  }
+  const rating = Math.max(0, Math.min(10, numeric));
+  return { rating, justification: typeof payload.justification === "string" ? payload.justification : "" };
 }

--- a/engine/src/core/evaluate/pairwise.ts
+++ b/engine/src/core/evaluate/pairwise.ts
@@ -377,14 +377,25 @@ async function rowsFor(db: Db, where: SQL | undefined, limit?: number): Promise<
       .select()
       .from(db.schema.pairwiseComparisons)
       .where(where)
-      .orderBy(desc(db.schema.pairwiseComparisons.createdAt), asc(db.schema.pairwiseComparisons.questionIndex));
+      // batchId between createdAt and questionIndex: rows of two batches created in the same
+      // millisecond must stay contiguous, or the cap-pop below drops a COMPLETE batch while a
+      // truncated one survives and summarizes as a clean sweep.
+      .orderBy(
+        desc(db.schema.pairwiseComparisons.createdAt),
+        asc(db.schema.pairwiseComparisons.batchId),
+        asc(db.schema.pairwiseComparisons.questionIndex)
+      );
     return (limit ? query.limit(limit).all() : query.all()) as Row[];
   }
   const query = db.db
     .select()
     .from(db.schema.pairwiseComparisons)
     .where(where)
-    .orderBy(desc(db.schema.pairwiseComparisons.createdAt), asc(db.schema.pairwiseComparisons.questionIndex));
+    .orderBy(
+      desc(db.schema.pairwiseComparisons.createdAt),
+      asc(db.schema.pairwiseComparisons.batchId),
+      asc(db.schema.pairwiseComparisons.questionIndex)
+    );
   return (await (limit ? query.limit(limit) : query)) as Row[];
 }
 

--- a/engine/src/core/evaluate/portability.ts
+++ b/engine/src/core/evaluate/portability.ts
@@ -1,6 +1,6 @@
 import { getTraceRow, type TraceRow } from "../trace/ingest.js";
 import type { Db } from "../../storage/db.js";
-import { callModelCompletion, scorePortabilityResponse, type ReconstructedContext } from "./judge.js";
+import { callModelCompletion, scorePortabilityResponse, resolvePlatformModel, type ReconstructedContext } from "./judge.js";
 import { getPortabilityModel, estimateCostUSD, type PortabilityModel } from "./models.js";
 
 // Model portability: "would a different model handle this specific captured input about as
@@ -160,11 +160,15 @@ export async function runModelPortabilityCheck(
   // its rating is directly comparable to the candidates (it was never judged against this rubric
   // when first ingested - Monitor's checks are pattern/rating checks, not a quality score).
   const baselineOutputText = extractContent(trace.output);
+  // Same platform-model resolution every other platform operation uses - an operator with only
+  // an Anthropic key must not have portability hard-wired to the OpenAI default judge.
+  const platformJudgeModel = await resolvePlatformModel(db);
   const baselineModel = trace.model ? await getPortabilityModel(db, trace.model) : null;
   try {
     const { rating, justification } = await scorePortabilityResponse(
       reconstructed.messages[reconstructed.messages.length - 1]?.content ?? "",
-      baselineOutputText
+      baselineOutputText,
+      platformJudgeModel
     );
     results.push({
       model: trace.model ?? "(unknown)",
@@ -209,7 +213,8 @@ export async function runModelPortabilityCheck(
       const latencyMs = Date.now() - start;
       const { rating, justification } = await scorePortabilityResponse(
         reconstructed.messages[reconstructed.messages.length - 1]?.content ?? "",
-        completion.text
+        completion.text,
+        platformJudgeModel
       );
       results.push({
         model: modelId,

--- a/engine/src/core/evaluate/simulation.ts
+++ b/engine/src/core/evaluate/simulation.ts
@@ -206,11 +206,15 @@ export async function runConversationSimulation(
       );
       turn.latencyMs = Date.now() - start;
       if (completion.truncated) {
-        // The round cap cut the trajectory - an empty agentMessage pushed into history would
-        // poison every later turn and read as "the agent said nothing".
+        // The round cap cut the trajectory. An empty agentMessage pushed into history would
+        // poison every later turn (the persona reacts to silence, the rest of the conversation
+        // becomes fiction) and an empty-output span would trip the empty-response detector on
+        // synthetic traffic - so the turn carries an explicit marker instead of "".
         turn.error = "Tool loop exceeded the round cap without a final answer";
       }
-      turn.agentMessage = completion.text;
+      turn.agentMessage = completion.truncated
+        ? completion.text || "(no final answer - the tool loop exceeded the round cap)"
+        : completion.text;
       if (completion.toolCalls.length > 0) turn.toolCalls = completion.toolCalls;
 
       if (record && sessionId) {
@@ -227,7 +231,7 @@ export async function runConversationSimulation(
         await ingestTrace(db, {
           name: agentName,
           input: { query: userTurn.message },
-          output: completion.text,
+          output: turn.agentMessage,
           latency_ms: turn.latencyMs,
           model: input.model,
           session_id: sessionId,

--- a/engine/src/core/export/exportData.ts
+++ b/engine/src/core/export/exportData.ts
@@ -12,6 +12,19 @@ import type { Db } from "../../storage/db.js";
 // flat regardless of table size and an interrupted export can be diffed against a re-run (ids
 // are stable). Instance-wide tables (portability models, app settings, auth_*) are deliberately
 // absent: they belong to the operator's own infrastructure backup, not a project's data export.
+// Bearer tokens live in connector header VALUES - the dashboard masks them on every GET, and
+// the export stream must not be the one surface that hands them out in cleartext. A restored
+// backup keeps the header KEYS; the operator re-enters the secrets, same as provider keys
+// (which are excluded from export entirely).
+function redactConnectorRow(row: Record<string, unknown>): Record<string, unknown> {
+  const headers = row.headers;
+  if (!headers || typeof headers !== "object") return row;
+  return {
+    ...row,
+    headers: Object.fromEntries(Object.entries(headers as Record<string, unknown>).map(([k]) => [k, "***redacted***"])),
+  };
+}
+
 export const EXPORT_ENTITIES = {
   traces: { table: "traces", sinceColumn: "createdAt" },
   signals: { table: "monitorSignals", sinceColumn: "lastSeenAt" },
@@ -64,7 +77,7 @@ export const EXPORT_ENTITIES = {
   // Playground runs, and the audit log.
   agents: { table: "agents", sinceColumn: "createdAt" },
   "monitor-profiles": { table: "monitorProfiles", sinceColumn: "createdAt" },
-  "agent-connectors": { table: "agentConnectors", sinceColumn: "createdAt" },
+  "agent-connectors": { table: "agentConnectors", sinceColumn: "createdAt", redact: redactConnectorRow },
   "playground-runs": { table: "playgroundRuns", sinceColumn: "createdAt" },
   "audit-events": { table: "auditEvents", sinceColumn: "createdAt" },
   // Deliberately excluded (derived/ephemeral, cheap to rebuild): monitorRollups,
@@ -145,6 +158,9 @@ export async function fetchExportBatch(
     .where(buildWhere(db, entity, since, cursor))
     .orderBy(asc(entityKeyColumn(db, entity)))
     .limit(EXPORT_BATCH);
-  return db.kind === "sqlite" ? q.all() : await q;
+  const rows = (db.kind === "sqlite" ? q.all() : await q) as Record<string, unknown>[];
+  const redact = (EXPORT_ENTITIES[entity] as { redact?: (row: Record<string, unknown>) => Record<string, unknown> })
+    .redact;
+  return redact ? rows.map(redact) : rows;
 }
  

--- a/engine/src/core/monitor/conditions.ts
+++ b/engine/src/core/monitor/conditions.ts
@@ -44,7 +44,7 @@ export function buildSourceTexts({ responseText, trace }: { responseText?: strin
     trace: [
       stringify(trace?.output),
       trace?.error ?? "",
-      ...((trace?.toolCalls ?? []) as NonNullable<TraceLike["toolCalls"]>).map(call =>
+      ...((Array.isArray(trace?.toolCalls) ? trace.toolCalls : []) as NonNullable<TraceLike["toolCalls"]>).map(call =>
         [call.name, stringify(call.output), stringify(call.input)].filter(Boolean).join(" ")
       ),
     ]

--- a/engine/src/core/monitor/detect.ts
+++ b/engine/src/core/monitor/detect.ts
@@ -110,7 +110,7 @@ function classifyOperational(trace: TraceLike & { latencyMs?: number | null }): 
   // Checked BEFORE the generic trace-error case: when a tool call fails and its exception
   // escapes the agent loop, the SDK records both (success:false on the call AND the span's own
   // error), and "which tool failed" is the more specific, actionable classification.
-  const failedCall = (trace.toolCalls ?? []).find(call => call.success === false);
+  const failedCall = (Array.isArray(trace.toolCalls) ? trace.toolCalls : []).find(call => call.success === false);
   if (failedCall) {
     return {
       type: "agent_tool_failure",

--- a/engine/src/core/monitor/events.ts
+++ b/engine/src/core/monitor/events.ts
@@ -161,6 +161,9 @@ export async function pruneRetentionData(db: Db, agentId: string | null, retenti
   if (Date.now() - last < PRUNE_INTERVAL_MS) {
     return;
   }
+  // Stamped up front so concurrent callers in the same tick don't all run the delete - but
+  // RESET on failure below, so a failed prune retries on the next call instead of silently
+  // waiting out the hour with the invariant broken.
   lastPruneAt.set(key, Date.now());
   const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
 
@@ -189,14 +192,12 @@ export async function pruneRetentionData(db: Db, agentId: string | null, retenti
           eq(db.schema.monitorClassifications.projectId, db.projectId)
         );
 
-  // Spans age out through the port (ADR-0007): the store picks its engine-native mechanism.
-  await traceStoreFor(db).prune(cutoff, agentId);
-  // Rollups ride the same clock (ADR-0006). They are project-minute keyed (not agent-scoped),
-  // so they are pruned past EVERY scope's cutoff, agent passes included: an agent-scoped prune
-  // just removed raw spans whose counts still live inside this project's rollup minutes, and a
-  // rollup that outlives its raw spans would let the dashboard's fast path report pruned
-  // traffic the raw fallback can no longer see. Deleting rollups is always safe - they are
-  // derived data, and an under-covered window falls back to the raw scan (slower, never wrong).
+  // Rollups FIRST, then the spans they were derived from: the two deletes have no shared
+  // transaction (on the enterprise tier they are two different systems), and the failure modes
+  // are asymmetric - losing a rollup early just sends a window to the raw scan (slower, never
+  // wrong), while a rollup outliving its pruned spans makes the fast path report traffic the
+  // raw fallback can no longer see. Rollups are project-minute keyed (not agent-scoped), so
+  // they are pruned past EVERY scope's cutoff, agent passes included.
   const cutoffMinute = Math.floor(cutoff.getTime() / 60_000) * 60_000;
   const rollupCond = and(
     eq(db.schema.monitorRollups.projectId, db.projectId),
@@ -204,10 +205,17 @@ export async function pruneRetentionData(db: Db, agentId: string | null, retenti
   );
   // The branches read identically but narrow drizzle's dialect union - .delete() is not
   // callable on the un-narrowed Db.
-  if (db.kind === "sqlite") {
-    await db.db.delete(db.schema.monitorRollups).where(rollupCond);
-  } else {
-    await db.db.delete(db.schema.monitorRollups).where(rollupCond);
+  try {
+    if (db.kind === "sqlite") {
+      await db.db.delete(db.schema.monitorRollups).where(rollupCond);
+    } else {
+      await db.db.delete(db.schema.monitorRollups).where(rollupCond);
+    }
+    // Spans age out through the port (ADR-0007): the store picks its engine-native mechanism.
+    await traceStoreFor(db).prune(cutoff, agentId);
+  } catch (err) {
+    lastPruneAt.delete(key);
+    throw err;
   }
   if (db.kind === "sqlite") {
     await db.db.delete(db.schema.monitorEvents).where(eventsCond);

--- a/engine/src/core/monitor/judgeTuning.ts
+++ b/engine/src/core/monitor/judgeTuning.ts
@@ -233,8 +233,8 @@ export async function getEvaluatorCalibration(
   );
   const corrections = (
     (db.kind === "sqlite"
-      ? db.db.select().from(db.schema.monitorSignalFeedback).where(feedbackCond).all()
-      : await db.db.select().from(db.schema.monitorSignalFeedback).where(feedbackCond)) as FeedbackCorrectionRow[]
+      ? db.db.select().from(db.schema.monitorSignalFeedback).where(feedbackCond).limit(50_000).all()
+      : await db.db.select().from(db.schema.monitorSignalFeedback).where(feedbackCond).limit(50_000)) as FeedbackCorrectionRow[]
   ).filter(
     c =>
       c.correctedScore !== null || c.metric === "false-positive" || c.metric === "confirmed" || c.queuedForAutotune === true
@@ -258,15 +258,18 @@ export async function getEvaluatorCalibration(
 
   // Labeled human-review rows, windowed on reviewedAt: the calibration pair the review queue
   // exists to produce (this stream was previously collected and displayed but fed nothing).
+  // Windowed and bounded IN SQL: a year of labeled reviews must not be materialized per panel
+  // open just to keep the handful inside the window (the sibling event stream caps at 50k too).
   const reviewCond = and(
     eq(db.schema.reviewQueueItems.projectId, db.projectId),
-    eq(db.schema.reviewQueueItems.status, "labeled")
+    eq(db.schema.reviewQueueItems.status, "labeled"),
+    gte(db.schema.reviewQueueItems.reviewedAt, since)
   );
   const reviewRows = (
     (db.kind === "sqlite"
-      ? db.db.select().from(db.schema.reviewQueueItems).where(reviewCond).all()
-      : await db.db.select().from(db.schema.reviewQueueItems).where(reviewCond)) as ReviewLabelRow[]
-  ).filter(r => r.label && r.traceId && r.reviewedAt && r.reviewedAt.getTime() >= since.getTime());
+      ? db.db.select().from(db.schema.reviewQueueItems).where(reviewCond).limit(50_000).all()
+      : await db.db.select().from(db.schema.reviewQueueItems).where(reviewCond).limit(50_000)) as ReviewLabelRow[]
+  ).filter(r => r.label && r.traceId && r.reviewedAt);
   const reviewByTrace = new Map<string, ReviewLabelRow>();
   for (const r of reviewRows) {
     const existing = reviewByTrace.get(r.traceId);
@@ -278,8 +281,8 @@ export async function getEvaluatorCalibration(
   const outcomesCond = and(eq(db.schema.outcomeReports.projectId, db.projectId), gte(db.schema.outcomeReports.reportedAt, since));
   const outcomes = (
     db.kind === "sqlite"
-      ? db.db.select().from(db.schema.outcomeReports).where(outcomesCond).all()
-      : await db.db.select().from(db.schema.outcomeReports).where(outcomesCond)
+      ? db.db.select().from(db.schema.outcomeReports).where(outcomesCond).limit(50_000).all()
+      : await db.db.select().from(db.schema.outcomeReports).where(outcomesCond).limit(50_000)
   ) as OutcomeRow[];
   const outcomeByTrace = new Map<string, OutcomeRow>();
   for (const o of outcomes) {

--- a/engine/src/core/monitor/metrics.ts
+++ b/engine/src/core/monitor/metrics.ts
@@ -98,6 +98,8 @@ export type MonitorMetricsResponse = {
   /** Which path answered: "rollups" (ADR-0006 fast path) or "raw" (window scan). Diagnostic -
    *  and load-bearing in tests, which assert the fast path was actually taken. */
   source: "rollups" | "raw";
+  /** Raw path only: the window scan hit its row cap - counts below cover a subset. */
+  truncated?: boolean;
   buckets: MonitorMetricsBucket[];
   totals: {
     spansLlm: number;
@@ -176,8 +178,16 @@ export async function getMonitorMetrics(
     if (fast) return fast;
   }
   // One window scan through the TraceStore port (ADR-0002); production only - the buckets
-  // describe live traffic, not eval harnesses.
-  let rows = (await traceStoreFor(db).queryWindow({ since, productionOnly: true })) as unknown as Row[];
+  // describe live traffic, not eval harnesses. Bounded: an unfiltered 30d window on a busy
+  // install is millions of full rows, and the engine shares one process with ingest - past
+  // the cap the response says so (truncated) instead of presenting a subset as the whole.
+  const RAW_METRICS_ROW_CAP = 200_000;
+  let rows = (await traceStoreFor(db).queryWindow({
+    since,
+    productionOnly: true,
+    limit: RAW_METRICS_ROW_CAP,
+  })) as unknown as Row[];
+  const truncated = rows.length >= RAW_METRICS_ROW_CAP;
 
   // ---- filters, resolved per SESSION so a matching root brings its child spans along ---------
   // (a root and its children share sessionId - every SDK trace auto-creates one; rows without a
@@ -274,9 +284,11 @@ export async function getMonitorMetrics(
       toolCalls: row.toolCalls,
       parentSpanId: row.parentSpanId,
     });
+    // Model facet is kind-independent (the rollup path counts every byModel key) - a model on
+    // a chain-classified span must not appear in the dropdown unfiltered and vanish filtered.
+    if (row.model) facetModels.add(row.model);
     if (kind === "llm") {
       bucket.spansLlm++;
-      if (row.model) facetModels.add(row.model);
     } else if (kind === "tool") {
       bucket.spansTool++;
     } else if (kind === "retrieval") {
@@ -430,6 +442,7 @@ export async function getMonitorMetrics(
     start,
     end: range.to,
     source: "raw",
+    truncated,
     buckets,
     totals,
     tools,

--- a/engine/src/core/monitor/outcomeCalibration.ts
+++ b/engine/src/core/monitor/outcomeCalibration.ts
@@ -140,8 +140,8 @@ export async function getJudgeCalibration(db: Db, window: MonitoringWindow): Pro
   const cond = and(gte(db.schema.outcomeReports.reportedAt, since), eq(db.schema.outcomeReports.projectId, db.projectId));
   const reports = (
     db.kind === "sqlite"
-      ? db.db.select().from(db.schema.outcomeReports).where(cond).all()
-      : await db.db.select().from(db.schema.outcomeReports).where(cond)
+      ? db.db.select().from(db.schema.outcomeReports).where(cond).limit(50_000).all()
+      : await db.db.select().from(db.schema.outcomeReports).where(cond).limit(50_000)
   ) as OutcomeReportRow[];
 
   let noVerdict = 0;
@@ -180,8 +180,8 @@ export async function getJudgeCalibration(db: Db, window: MonitoringWindow): Pro
   );
   const reviewLabels = (
     db.kind === "sqlite"
-      ? db.db.select().from(db.schema.reviewQueueItems).where(reviewCond).all()
-      : await db.db.select().from(db.schema.reviewQueueItems).where(reviewCond)
+      ? db.db.select().from(db.schema.reviewQueueItems).where(reviewCond).limit(50_000).all()
+      : await db.db.select().from(db.schema.reviewQueueItems).where(reviewCond).limit(50_000)
   ) as { traceId: string; label: string | null }[];
 
   const eventsByTrace = await listEventsByTrace(db, [
@@ -200,9 +200,12 @@ export async function getJudgeCalibration(db: Db, window: MonitoringWindow): Pro
   reports.sort((a, b) => a.reportedAt.getTime() - b.reportedAt.getTime());
   const talliedTraces = new Set<string>();
   for (const report of reports) {
-    if (report.traceId) {
-      if (talliedTraces.has(report.traceId)) continue;
-      talliedTraces.add(report.traceId);
+    // Run-result-keyed reports dedupe too: 5 retries of one ServiceNow POST against one eval
+    // result must contribute one matrix row, exactly like trace-keyed ground truth.
+    const dedupeKey = report.traceId ?? (report.evaluationRunResultId ? `rr:${report.evaluationRunResultId}` : null);
+    if (dedupeKey) {
+      if (talliedTraces.has(dedupeKey)) continue;
+      talliedTraces.add(dedupeKey);
     }
     tally(await resolveAgentxVerdict(db, report, eventsByTrace), report.isNegative);
   }

--- a/engine/src/core/monitor/patterns.ts
+++ b/engine/src/core/monitor/patterns.ts
@@ -125,10 +125,27 @@ function toWire(row: PatternRow) {
 }
 
 export async function createPattern(db: Db, input: CreatePatternInput) {
+  // Signals dedupe on (patternKey, agentId): two patterns named the same must not share a key,
+  // or their detections merge into one signal row that survives either's deletion. Suffix on
+  // collision only, so the common single-pattern case keeps its readable slug.
+  const baseKey = `custom:${slugify(input.name) || nanoid(6)}`;
+  const existingRows = (
+    db.kind === "sqlite"
+      ? db.db
+          .select({ key: db.schema.monitorPatterns.key })
+          .from(db.schema.monitorPatterns)
+          .where(and(eq(db.schema.monitorPatterns.projectId, db.projectId), eq(db.schema.monitorPatterns.key, baseKey)))
+          .all()
+      : await db.db
+          .select({ key: db.schema.monitorPatterns.key })
+          .from(db.schema.monitorPatterns)
+          .where(and(eq(db.schema.monitorPatterns.projectId, db.projectId), eq(db.schema.monitorPatterns.key, baseKey)))
+  ) as { key: string }[];
+  const key = existingRows.length > 0 ? `${baseKey}-${nanoid(6)}` : baseKey;
   const row: PatternRow = {
     id: nanoid(),
     projectId: db.projectId,
-    key: `custom:${slugify(input.name) || nanoid(6)}`,
+    key,
     name: input.name,
     description: input.description ?? null,
     category: input.category ?? null,

--- a/engine/src/core/monitor/userFeedback.ts
+++ b/engine/src/core/monitor/userFeedback.ts
@@ -45,16 +45,51 @@ export type RecordFeedbackInput = {
   endUserId?: string;
 };
 
+const MAX_FEEDBACK_COMMENT_CHARS = 4_000;
+
 export async function recordUserFeedback(db: Db, input: RecordFeedbackInput) {
   const trace = await getTraceRow(db, input.traceId);
   if (!trace) return null;
+
+  // Idempotent per (trace, end user): a retrying HTTP client re-sending the same thumbs-down
+  // must not inflate the signal's occurrence count (which ranks the Attention digest) or pile
+  // up duplicate outcome reports. Same rating + same voter = update-in-place; a CHANGED rating
+  // replaces the old vote rather than coexisting with it.
+  const voter = input.endUserId?.trim() || null;
+  if (voter) {
+    const dupCond = and(
+      eq(db.schema.userFeedback.projectId, db.projectId),
+      eq(db.schema.userFeedback.traceId, input.traceId),
+      eq(db.schema.userFeedback.endUserId, voter)
+    );
+    const existing = (
+      db.kind === "sqlite"
+        ? db.db.select().from(db.schema.userFeedback).where(dupCond).limit(1).all()
+        : await db.db.select().from(db.schema.userFeedback).where(dupCond).limit(1)
+    ) as UserFeedbackRow[];
+    const prior = existing[0];
+    if (prior) {
+      const patch = {
+        rating: input.rating,
+        comment: input.comment?.trim().slice(0, MAX_FEEDBACK_COMMENT_CHARS) || null,
+        createdAt: new Date(),
+      };
+      const idCond = and(eq(db.schema.userFeedback.id, prior.id), eq(db.schema.userFeedback.projectId, db.projectId));
+      if (db.kind === "sqlite") {
+        db.db.update(db.schema.userFeedback).set(patch).where(idCond).run();
+      } else {
+        await db.db.update(db.schema.userFeedback).set(patch).where(idCond);
+      }
+      return toWire({ ...prior, ...patch });
+    }
+  }
 
   const row: UserFeedbackRow = {
     id: nanoid(),
     traceId: input.traceId,
     rating: input.rating,
-    comment: input.comment?.trim() || null,
-    endUserId: input.endUserId?.trim() || null,
+    comment: input.comment?.trim().slice(0, MAX_FEEDBACK_COMMENT_CHARS) || null,
+    endUserId: voter,
     createdAt: new Date(),
     projectId: db.projectId,
   };

--- a/engine/src/core/project/deleteOrganization.ts
+++ b/engine/src/core/project/deleteOrganization.ts
@@ -59,15 +59,23 @@ export async function deleteOrganization(db: Db, organizationId: string): Promis
   if (db.kind === "sqlite") {
     await db.db.delete(db.schema.appSettings).where(settingsCond);
     await db.db.delete(db.schema.portabilityModels).where(catalogCond);
-    await db.db.delete(db.schema.authMembers).where(membersCond);
+    // Org row BEFORE members: a failure between the two leaves the owner's membership alive
+    // (pointing at a gone org - GET /organizations drops it), so the DELETE can be retried.
+    // The old order stranded a half-deleted org the owner could no longer authenticate
+    // against to finish the job.
     await db.db.delete(db.schema.authInvitations).where(invitesCond);
     await db.db.delete(db.schema.authOrganizations).where(orgCond);
+    await db.db.delete(db.schema.authMembers).where(membersCond);
   } else {
     await db.db.delete(db.schema.appSettings).where(settingsCond);
     await db.db.delete(db.schema.portabilityModels).where(catalogCond);
-    await db.db.delete(db.schema.authMembers).where(membersCond);
+    // Org row BEFORE members: a failure between the two leaves the owner's membership alive
+    // (pointing at a gone org - GET /organizations drops it), so the DELETE can be retried.
+    // The old order stranded a half-deleted org the owner could no longer authenticate
+    // against to finish the job.
     await db.db.delete(db.schema.authInvitations).where(invitesCond);
     await db.db.delete(db.schema.authOrganizations).where(orgCond);
+    await db.db.delete(db.schema.authMembers).where(membersCond);
   }
 
   return { projectsDeleted: projectIds.length };

--- a/engine/src/core/shared/usage.ts
+++ b/engine/src/core/shared/usage.ts
@@ -52,6 +52,21 @@ async function countJudgeCallsToday(db: Db, organizationId: string | null): Prom
 // QuotaExceededError when the day's allowance is spent - callers already treat judge failures
 // as isolated per-item errors, so one tenant hitting its cap degrades exactly like a judge
 // outage would: clear message, nothing else affected.
+// Record-only twin of checkAndRecordJudgeCall - for accounting a call that ALREADY happened
+// (judge-core's internal retry is a second real provider call). The quota gate must not run
+// here: throwing after a successful, billed result would discard it, which is worse than
+// letting the day's count land one over the ceiling.
+export async function recordJudgeCall(model: string | null): Promise<void> {
+  const db = getDb();
+  const { organizationId = null, projectId = null } = currentTenancy();
+  const row = { id: nanoid(), kind: "judge_call", model, organizationId, projectId, createdAt: new Date() };
+  if (db.kind === "sqlite") {
+    await db.db.insert(db.schema.usageEvents).values(row);
+  } else {
+    await db.db.insert(db.schema.usageEvents).values(row);
+  }
+}
+
 export async function checkAndRecordJudgeCall(model: string | null): Promise<void> {
   const db = getDb();
   const { organizationId = null, projectId = null } = currentTenancy();
@@ -84,14 +99,28 @@ export async function checkAndRecordJudgeCall(model: string | null): Promise<voi
 // Admin overview helper: per-org judge calls in the trailing 24h.
 export async function judgeCallsSince(db: Db, since: Date): Promise<Map<string | null, number>> {
   const cond = and(eq(db.schema.usageEvents.kind, "judge_call"), gte(db.schema.usageEvents.createdAt, since));
-  const rows = (
+  // Grouped count in SQL: an instance doing millions of judge calls a day must not ship every
+  // usage row to the admin overview just to count them.
+  const grouped =
     db.kind === "sqlite"
-      ? db.db.select().from(db.schema.usageEvents).where(cond).all()
-      : await db.db.select().from(db.schema.usageEvents).where(cond)
-  ) as { organizationId: string | null }[];
+      ? db.db
+          .select({ organizationId: db.schema.usageEvents.organizationId, n: sql<number>`count(*)` })
+          .from(db.schema.usageEvents)
+          .where(cond)
+          .groupBy(db.schema.usageEvents.organizationId)
+          .all()
+      : await db.db
+          .select({ organizationId: db.schema.usageEvents.organizationId, n: sql<number>`count(*)` })
+          .from(db.schema.usageEvents)
+          .where(cond)
+          .groupBy(db.schema.usageEvents.organizationId);
+  const rows = grouped.map(g => ({ organizationId: g.organizationId, n: Number(g.n) })) as {
+    organizationId: string | null;
+    n: number;
+  }[];
   const counts = new Map<string | null, number>();
   for (const row of rows) {
-    counts.set(row.organizationId, (counts.get(row.organizationId) ?? 0) + 1);
+    counts.set(row.organizationId, row.n);
   }
   return counts;
 }

--- a/engine/src/core/trace/ingest.ts
+++ b/engine/src/core/trace/ingest.ts
@@ -57,7 +57,10 @@ export const ingestTraceSchema = z.preprocess(foldCamelAliases, z.object({
   name: z.string().min(1).max(2_000),
   input: z.unknown().optional(),
   output: z.unknown().optional(),
-  error: z.string().max(20_000).optional(),
+  // No hard cap: a 25KB chained-exception traceback is the single most diagnostically
+  // valuable span of the day and must not be the one payload the schema REJECTS while a 10MB
+  // healthy output gets truncated-and-kept. capPayloadField clips it below like its siblings.
+  error: z.string().optional(),
   latency_ms: z.number().optional(),
   framework: z.string().optional(),
   model: z.string().optional(),
@@ -130,6 +133,24 @@ export function capPayloadField(value: unknown): unknown {
     return value;
   }
   if (serialized.length <= MAX_FIELD_CHARS) return value;
+  if (Array.isArray(value)) {
+    // Arrays keep their shape: readers .map/.find over toolCalls, and an object impostor is a
+    // TypeError waiting in every one of them. Drop tail items until it fits (floor: 1 marker).
+    const kept: unknown[] = [];
+    let budget = MAX_FIELD_CHARS;
+    for (const item of value) {
+      let itemLen = 0;
+      try {
+        itemLen = (JSON.stringify(item) ?? "").length;
+      } catch {
+        break;
+      }
+      if (itemLen > budget) break;
+      kept.push(item);
+      budget -= itemLen;
+    }
+    return [...kept, { "agentx.truncated": true, dropped: value.length - kept.length }];
+  }
   return { "agentx.truncated": true, preview: serialized.slice(0, MAX_FIELD_CHARS) };
 }
 
@@ -163,7 +184,7 @@ async function prepareSpanRow(
     name: payload.name,
     input: capPayloadField(payload.input ?? null),
     output: capPayloadField(payload.output ?? null),
-    error: payload.error ?? null,
+    error: (capPayloadField(payload.error ?? null) as string | null),
     latencyMs: payload.latency_ms ?? null,
     framework: normalizeFramework(payload.framework),
     model: payload.model ?? null,
@@ -181,8 +202,13 @@ async function prepareSpanRow(
     parentSpanId: payload.parent_span_id ?? null,
     startedAt,
     // Historical imports send real past start times; createdAt drives every window-based view,
-    // so it reflects when the traffic HAPPENED, not when it was imported.
-    createdAt: startedAt ?? new Date(),
+    // so it reflects when the traffic HAPPENED, not when it was imported. Clamped against
+    // future clocks (a container without NTP, a replay with a unit bug): one span stamped a
+    // year ahead sits in pg's DEFAULT partition and blocks that day's partition creation
+    // forever, and is invisible to every window and immune to retention. startedAt itself
+    // stays verbatim - the waterfall renders the stated time; only the window key is clamped.
+    createdAt:
+      startedAt && startedAt.getTime() <= Date.now() + 60_000 ? startedAt : new Date(),
     agentId,
     projectId: db.projectId,
   };

--- a/engine/src/core/trace/store/clickhouseTraceStore.ts
+++ b/engine/src/core/trace/store/clickhouseTraceStore.ts
@@ -179,6 +179,10 @@ export class ClickHouseTraceStore implements TraceStore {
   }
 
   private scope(): string {
+    // The "" sentinel from an unscoped Db must fail CLOSED here too: CH stores unscoped writes
+    // as project_id = '' (non-nullable String), which the sentinel would happily match -
+    // turning "forgot withProjectId" from empty-results into a shared hidden bucket.
+    if (this.projectId === "") return "1 = 0";
     return `project_id = {project:String}`;
   }
 
@@ -236,10 +240,12 @@ export class ClickHouseTraceStore implements TraceStore {
   }
 
   async listBySession(sessionId: string): Promise<TraceRow[]> {
-    // Same cap and ordering as the SQL store: oldest-first so a truncated runaway session
-    // keeps the conversation's beginning (the transcript's anchor), and 5000 bounds the heap.
+    // Same cap and ordering as the SQL store (created_at ASC): oldest-first so a truncated
+    // runaway session keeps the conversation's beginning, and 5000 bounds the heap. created_at
+    // primary - the SQL adapter orders by createdAt, and the truncation boundary of a mixed
+    // session must not differ between tiers.
     const rows = await this.rows(
-      `SELECT * FROM ${TABLE} WHERE ${this.scope()} AND session_id = {sessionId:String} ORDER BY started_at ASC, created_at ASC LIMIT 5000`,
+      `SELECT * FROM ${TABLE} WHERE ${this.scope()} AND session_id = {sessionId:String} ORDER BY created_at ASC, started_at ASC LIMIT 5000`,
       { sessionId }
     );
     return rows.map(fromStored);
@@ -249,8 +255,10 @@ export class ClickHouseTraceStore implements TraceStore {
     const conds = [this.scope()];
     const params: Record<string, unknown> = {};
     if (args.since) {
-      conds.push("created_at >= {since:DateTime64(3)}");
-      params.since = args.since.toISOString().replace("T", " ").replace("Z", "");
+      // Epoch-milli bound like every other time predicate here - a DateTime64 param without a
+      // timezone is parsed in the SERVER\'s tz, silently shifting incremental backups on non-UTC
+      // ClickHouse installs.
+      conds.push(`created_at >= fromUnixTimestamp64Milli(${args.since.getTime()})`);
     }
     if (args.cursor) {
       conds.push("id > {cursor:String}");
@@ -267,15 +275,18 @@ export class ClickHouseTraceStore implements TraceStore {
     const conds = [this.scope()];
     const params: Record<string, unknown> = {};
     if (since) {
-      conds.push("created_at >= {since:DateTime64(3)}");
-      params.since = since.toISOString().replace("T", " ").replace("Z", "");
+      // Epoch-milli, tz-safe - see listForExport.
+      conds.push(`created_at >= fromUnixTimestamp64Milli(${since.getTime()})`);
     }
     const rows = await this.rows(`SELECT count(*) AS n FROM ${TABLE} WHERE ${conds.join(" AND ")}`, params);
     return Number((rows[0] as { n?: unknown })?.n ?? 0);
   }
 
   async listRecent(limit: number): Promise<TraceRow[]> {
-    const rows = await this.rows(`SELECT * FROM ${TABLE} WHERE ${this.scope()} LIMIT ${Math.floor(limit)}`);
+    // Newest-first, like the SQL store - "recent" from an unordered SELECT was storage-order.
+    const rows = await this.rows(
+      `SELECT * FROM ${TABLE} WHERE ${this.scope()} ORDER BY created_at DESC LIMIT ${Math.floor(limit)}`
+    );
     return rows.map(fromStored);
   }
 

--- a/engine/src/core/trace/store/sqlTraceStore.ts
+++ b/engine/src/core/trace/store/sqlTraceStore.ts
@@ -193,8 +193,8 @@ export class SqlTraceStore implements TraceStore {
     const cond = eq(db.schema.traces.projectId, db.projectId);
     const rows =
       db.kind === "sqlite"
-        ? db.db.select().from(db.schema.traces).where(cond).limit(limit).all()
-        : await db.db.select().from(db.schema.traces).where(cond).limit(limit);
+        ? db.db.select().from(db.schema.traces).where(cond).orderBy(desc(db.schema.traces.createdAt)).limit(limit).all()
+        : await db.db.select().from(db.schema.traces).where(cond).orderBy(desc(db.schema.traces.createdAt)).limit(limit);
     return rows as TraceRow[];
   }
 

--- a/engine/src/routes/agentMonitoringDashboard.ts
+++ b/engine/src/routes/agentMonitoringDashboard.ts
@@ -83,7 +83,7 @@ import {
   type JudgeScorerOnlineInput,
 } from "../core/monitor/judgeScorers.js";
 import { patchEvaluationSettings } from "../core/evaluate/evaluationSettings.js";
-import {
+import { getCustomEvaluatorRow,
   createCustomEvaluator,
   updateCustomEvaluator,
   deleteCustomEvaluator,
@@ -1429,9 +1429,21 @@ agentMonitoringDashboardRouter.post("/custom-evaluators", async (req: Request, r
 
 agentMonitoringDashboardRouter.put("/custom-evaluators/:evaluatorId", async (req: Request, res: Response) => {
   const body = req.body ?? {};
-  if (body.url !== undefined && !isValidHttpUrl(body.url)) {
+  // CODE scorers store url as "" and the dashboard round-trips the whole draft on save -
+  // validating that empty string made every edit of an existing code scorer a 400. The URL
+  // requirement is the EXTERNAL kind's; look the row up before enforcing it.
+  const existing = await getCustomEvaluatorRow(scopedDb(req), req.params.evaluatorId!);
+  if (!existing) {
+    res.status(404).json({ error: "Scorer not found" });
+    return;
+  }
+  const isCode = (existing as { kind?: string }).kind === "code";
+  if (!isCode && body.url !== undefined && !isValidHttpUrl(body.url)) {
     res.status(400).json({ error: "A valid http:// or https:// url is required" });
     return;
+  }
+  if (isCode && body.url !== undefined) {
+    delete body.url;
   }
   const evaluator = await updateCustomEvaluator(scopedDb(req), req.params.evaluatorId!, {
     name: body.name,

--- a/engine/src/routes/authOrg.ts
+++ b/engine/src/routes/authOrg.ts
@@ -239,6 +239,26 @@ authOrgRouter.post("/invitations/:id/accept", async (req: Request, res: Response
     res.status(403).json({ error: `This invitation was issued to ${invitation.email} - sign in with that account` });
     return;
   }
+  // The org can be deleted between invite and accept - a member row pointing at nothing reads
+  // as a successful accept with no workspace, which is worse than saying what happened.
+  const orgRows = (
+    db.kind === "sqlite"
+      ? db.db
+          .select({ id: db.schema.authOrganizations.id })
+          .from(db.schema.authOrganizations)
+          .where(eq(db.schema.authOrganizations.id, invitation.organizationId))
+          .limit(1)
+          .all()
+      : await db.db
+          .select({ id: db.schema.authOrganizations.id })
+          .from(db.schema.authOrganizations)
+          .where(eq(db.schema.authOrganizations.id, invitation.organizationId))
+          .limit(1)
+  ) as { id: string }[];
+  if (orgRows.length === 0) {
+    res.status(410).json({ error: "The organization this invitation was for no longer exists" });
+    return;
+  }
   if (!(await memberIn(db, user.id, invitation.organizationId))) {
     const memberRow = {
       id: nanoid(),

--- a/engine/src/routes/curationHandlers.ts
+++ b/engine/src/routes/curationHandlers.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 import { scopedDb } from "../auth/apiKey.js";
-import {
+import { MAX_CURATED_FOLLOW_UPS,
   previewCaseFromTrace,
   previewCaseFromSession,
   suggestExpected,
@@ -65,7 +65,10 @@ export async function handleAddCase(req: Request, res: Response) {
         expectedResults:
           typeof curated.main_question.expectedResults === "string" ? curated.main_question.expectedResults : null,
       },
+      // Same bound the preview applies - the client's array is re-accepted here and must not
+      // smuggle an unbounded case past it.
       follow_up_questions: (Array.isArray(curated.follow_up_questions) ? curated.follow_up_questions : [])
+        .slice(0, MAX_CURATED_FOLLOW_UPS)
         .filter(f => typeof f?.query === "string" && f.query.trim())
         .map(f => ({
           query: f.query,

--- a/engine/src/routes/evaluateDashboard.ts
+++ b/engine/src/routes/evaluateDashboard.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from "express";
+import { and, eq, inArray } from "drizzle-orm";
 import { asyncRouter } from "./asyncRouter.js";
 import { nanoid } from "nanoid";
 import { handleCasePreview, handleSuggestExpected, handleAddCase } from "./curationHandlers.js";
@@ -1554,7 +1555,38 @@ function toResultWire(r: RunResultRow, evaluationSettingsQuestions: unknown, dat
 // always computed from the real result rows regardless, since the table's rating column reads
 // liveStatistics.averageRating, not results.length, and a rating of exactly 0 (e.g. an errored
 // result) must not be treated as "no rating yet" (0 !== null).
-async function toEvaluateWire(db: Db, run: FullRunRow, includeResults: boolean) {
+// Latest gate verdict per run - the CI PASS/FAIL badge's data. Batched for the list route so
+// 50 rows cost one query, not 50.
+async function latestGateResults(db: Db, runIds: string[]): Promise<Map<string, boolean>> {
+  if (runIds.length === 0) return new Map();
+  const cond = and(inArray(db.schema.gateResults.runId, runIds), eq(db.schema.gateResults.projectId, db.projectId));
+  const rows = (
+    db.kind === "sqlite"
+      ? db.db
+          .select({
+            runId: db.schema.gateResults.runId,
+            passed: db.schema.gateResults.passed,
+            createdAt: db.schema.gateResults.createdAt,
+          })
+          .from(db.schema.gateResults)
+          .where(cond)
+          .all()
+      : await db.db
+          .select({
+            runId: db.schema.gateResults.runId,
+            passed: db.schema.gateResults.passed,
+            createdAt: db.schema.gateResults.createdAt,
+          })
+          .from(db.schema.gateResults)
+          .where(cond)
+  ) as { runId: string; passed: boolean; createdAt: Date }[];
+  rows.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  const latest = new Map<string, boolean>();
+  for (const row of rows) latest.set(row.runId, row.passed); // later rows overwrite: latest wins
+  return latest;
+}
+
+async function toEvaluateWire(db: Db, run: FullRunRow, includeResults: boolean, gateResult?: "pass" | "fail" | null) {
   const scorerGroupId = (run as { scorerGroupId?: string | null }).scorerGroupId ?? null;
   const [dataset, evaluationSettings, results, analysisRow, scorerGroup] = await Promise.all([
     getDataset(db, run.datasetId),
@@ -1644,6 +1676,8 @@ async function toEvaluateWire(db: Db, run: FullRunRow, includeResults: boolean) 
       : undefined,
     evaluationSubject: run.evaluationSubject ?? undefined,
     runSource: run.runSource ?? "sdk",
+    // Latest recorded CI gate verdict, when one exists - the runs table's PASS/FAIL badge.
+    gateResult: gateResult ?? null,
     createdAt: run.createdAt,
     updatedAt: run.createdAt,
   };
@@ -1653,7 +1687,12 @@ evaluateDashboardRouter.get("/list", async (req: Request, res: Response) => {
   const { page, limit } = parsePageLimit(req);
   const allRows = await listRunRows(scopedDb(req));
   const { page: rows, pagination } = paginate(allRows, page, limit);
-  const evaluations = await Promise.all(rows.map(run => toEvaluateWire(scopedDb(req), run, false)));
+  const gateByRun = await latestGateResults(scopedDb(req), rows.map(run => run.id));
+  const evaluations = await Promise.all(
+    rows.map(run =>
+      toEvaluateWire(scopedDb(req), run, false, gateByRun.has(run.id) ? (gateByRun.get(run.id) ? "pass" : "fail") : null)
+    )
+  );
   res.status(200).json({ evaluations, pagination: { ...pagination, limit } });
 });
 
@@ -1663,6 +1702,12 @@ evaluateDashboardRouter.get("/:id", async (req: Request, res: Response) => {
     res.status(404).json({ error: "Evaluation not found" });
     return;
   }
-  const evaluation = await toEvaluateWire(scopedDb(req), run, true);
+  const gateByRun = await latestGateResults(scopedDb(req), [run.id]);
+  const evaluation = await toEvaluateWire(
+    scopedDb(req),
+    run,
+    true,
+    gateByRun.has(run.id) ? (gateByRun.get(run.id) ? "pass" : "fail") : null
+  );
   res.status(200).json(evaluation);
 });

--- a/engine/src/routes/monitor.ts
+++ b/engine/src/routes/monitor.ts
@@ -73,6 +73,11 @@ monitorRouter.post("/patterns", async (req: Request, res: Response) => {
     severity: body.severity,
     polarity: body.polarity,
     enabled: body.enabled,
+    // Cost controls the SDK sends and this route silently dropped: a semantic pattern is an
+    // LLM call per trace, and "sample 5% of one agent" must not become 100% of every agent.
+    sampleRate: typeof body.sampleRate === "number" ? body.sampleRate : undefined,
+    scopeMode: body.scopeMode === "selected" ? "selected" : body.scopeMode === "all" ? "all" : undefined,
+    agentIds: Array.isArray(body.agentIds) ? await resolveAgentIds(scopedDb(req), body.agentIds) : undefined,
   });
   res.status(201).json({ pattern });
 });

--- a/engine/src/routes/openapi.ts
+++ b/engine/src/routes/openapi.ts
@@ -13,10 +13,20 @@ function buildDocument(): object {
   const schemas: Record<string, unknown> = {};
   for (const entry of WIRE_CONTRACT) {
     schemas[entry.name] = zodToJsonSchema(entry.response, { target: "openApi3" });
-    paths[`/api/v1${entry.path}`] = {
-      ...(paths[`/api/v1${entry.path}`] ?? {}),
+    // OpenAPI templating, not Express syntax: ":id" is a literal path segment to every
+    // generator, which turns the stated consumers' clients into guaranteed 404s.
+    const oasPath = entry.path.replace(/:([A-Za-z0-9_]+)/g, "{$1}");
+    const params = [...entry.path.matchAll(/:([A-Za-z0-9_]+)/g)].map(m => ({
+      name: m[1],
+      in: "path",
+      required: true,
+      schema: { type: "string" },
+    }));
+    paths[`/api/v1${oasPath}`] = {
+      ...(paths[`/api/v1${oasPath}`] ?? {}),
       [entry.method]: {
         summary: entry.summary,
+        ...(params.length > 0 ? { parameters: params } : {}),
         responses: {
           "200": {
             description: "OK",

--- a/engine/src/routes/otlp.ts
+++ b/engine/src/routes/otlp.ts
@@ -94,6 +94,19 @@ otlpRouter.post("/v1/traces", async (req: Request, res: Response) => {
     return;
   }
 
+  // A body with NO resourceSpans key at all is not an ExportTraceServiceRequest - a proxy
+  // that unwrapped the envelope, or a hand-rolled client posting {"spans": [...]}. Answering
+  // the OTLP "everything accepted" 200 would drop every span while the exporter reads green -
+  // the same silent-drop failure the content-type gate above already closes for its dimension.
+  // A genuinely empty {"resourceSpans": []} stays a 200: that IS a valid empty export.
+  const hasEnvelope =
+    parsed !== null &&
+    typeof parsed === "object" &&
+    ("resourceSpans" in (parsed as object) || "resource_spans" in (parsed as object));
+  if (!hasEnvelope) {
+    res.status(400).json({ error: "body carried no resourceSpans - not an ExportTraceServiceRequest" });
+    return;
+  }
   const spans = normalizeExportRequest(parsed);
   if (spans.length > MAX_SPANS_PER_EXPORT) {
     res.status(413).json({

--- a/engine/src/storage/db.ts
+++ b/engine/src/storage/db.ts
@@ -1171,6 +1171,7 @@ export function bootstrapSqlite(sqlite: SqliteHandle): { freshInstall: boolean }
     ["outcome_reports", "ALTER TABLE outcome_reports ADD COLUMN is_negative INTEGER NOT NULL DEFAULT 0"],
     ["projects", "ALTER TABLE projects ADD COLUMN topics_enabled INTEGER NOT NULL DEFAULT 0"],
     ["projects", "ALTER TABLE projects ADD COLUMN coherence_sweep_enabled INTEGER NOT NULL DEFAULT 1"],
+    // dead column (kept in DDL, absent from drizzle by design - see the note below)
     ["projects", "ALTER TABLE projects ADD COLUMN disabled_builtin_patterns TEXT"],
     // Scorer opt-in flip: built-ins used to be on-by-default with a disabled list; now nothing
     // runs unless listed here. The old column is left in place (ignored) rather than migrated -
@@ -2470,6 +2471,12 @@ export async function bootstrapPostgres(pool: Pool): Promise<{ freshInstall: boo
     ALTER TABLE datasets ADD COLUMN IF NOT EXISTS code_scorers JSONB;
     ALTER TABLE evaluation_settings ADD COLUMN IF NOT EXISTS code_scorers JSONB;
     ALTER TABLE evaluation_run_results ADD COLUMN IF NOT EXISTS code_scorer_results JSONB;
+    ALTER TABLE traces ADD COLUMN IF NOT EXISTS span_kind TEXT;
+    ALTER TABLE traces ADD COLUMN IF NOT EXISTS source TEXT;
+    ALTER TABLE auth_account ADD COLUMN IF NOT EXISTS issuer TEXT;
+    ALTER TABLE auth_invitation ADD COLUMN IF NOT EXISTS created_at TIMESTAMP;
+    UPDATE session_scores SET judge_model = 'unknown' WHERE judge_model IS NULL;
+    ALTER TABLE session_scores ALTER COLUMN judge_model SET NOT NULL;
     ALTER TABLE traces ADD COLUMN IF NOT EXISTS agent_id TEXT;
     ALTER TABLE traces ADD COLUMN IF NOT EXISTS project_id TEXT;
     ALTER TABLE agents ADD COLUMN IF NOT EXISTS project_id TEXT;

--- a/engine/src/storage/migrationParity.test.ts
+++ b/engine/src/storage/migrationParity.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// The bug class this pins: a column migration added to the sqlite list without its Postgres
+// ADD COLUMN IF NOT EXISTS twin. Three of those shipped (auth_account.issuer - a hard BOOT
+// CRASH on upgraded pg installs because a later backfill UPDATEs the column - plus
+// auth_invitation.created_at and traces.span_kind/source, which 500'd invites and every trace
+// read). auth/schemaParity.test.ts compares drizzle schemas only; nothing compared the two
+// migration lists until this did.
+const source = readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), "db.ts"), "utf8");
+
+const sqliteMigrations = new Set(
+  [...source.matchAll(/\["(\w+)", "ALTER TABLE \w+ ADD COLUMN (\w+)/g)].map(m => `${m[1]}.${m[2]}`)
+);
+const pgMigrations = new Set(
+  [...source.matchAll(/ALTER TABLE (\w+) ADD COLUMN IF NOT EXISTS (\w+)/g)].map(m => `${m[1]}.${m[2]}`)
+);
+
+describe("column-migration dialect parity", () => {
+  it("every sqlite column migration has a Postgres ADD COLUMN IF NOT EXISTS twin", () => {
+    const missing = [...sqliteMigrations].filter(entry => !pgMigrations.has(entry));
+    expect(missing, `sqlite migrations with no pg twin: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("sanity: both lists are non-trivially populated", () => {
+    expect(sqliteMigrations.size).toBeGreaterThan(50);
+    expect(pgMigrations.size).toBeGreaterThan(50);
+  });
+});

--- a/engine/src/storage/schema.pg.ts
+++ b/engine/src/storage/schema.pg.ts
@@ -449,7 +449,7 @@ export const usageEvents = pgTable("usage_events", {
   model: text("model"),
   organizationId: text("organization_id"),
   projectId: text("project_id"),
-  createdAt: timestamp("created_at", { mode: "date" }).notNull(),
+  createdAt: timestamp("created_at", { mode: "date", withTimezone: true }).notNull(),
 });
 
 // See schema.sqlite.ts's gateResults for the full comment.
@@ -471,7 +471,7 @@ export const gateResults = pgTable("gate_results", {
 // Append-only audit trail - see schema.sqlite.ts's auditEvents comment for the contract.
 export const auditEvents = pgTable("audit_events", {
   id: text("id").primaryKey(),
-  createdAt: timestamp("created_at", { mode: "date" }).notNull(),
+  createdAt: timestamp("created_at", { mode: "date", withTimezone: true }).notNull(),
   actor: text("actor").notNull(),
   actorType: text("actor_type").notNull(),
   action: text("action").notNull(),
@@ -501,7 +501,7 @@ export const sessionScores = pgTable("session_scores", {
   driftSpanId: text("drift_span_id"),
   findings: jsonb("findings"),
   spanCount: integer("span_count").notNull(),
-  judgeModel: text("judge_model").notNull(),
+  judgeModel: text("judge_model").notNull().notNull(),
   createdAt: timestamp("created_at", { mode: "date" }).notNull(),
   projectId: text("project_id"),
 });
@@ -700,38 +700,6 @@ export const authInvitations = pgTable("auth_invitation", {
   inviterId: text("inviter_id").notNull(),
 });
 
-export type PgSchema = {
-  projects: typeof projects;
-  traces: typeof traces;
-  agents: typeof agents;
-  datasets: typeof datasets;
-  evaluationSettings: typeof evaluationSettings;
-  evaluationRuns: typeof evaluationRuns;
-  evaluationRunResults: typeof evaluationRunResults;
-  datasetVersions: typeof datasetVersions;
-  evaluationSettingsVersions: typeof evaluationSettingsVersions;
-  playgroundRuns: typeof playgroundRuns;
-  monitorSignalFeedback: typeof monitorSignalFeedback;
-  monitorPatterns: typeof monitorPatterns;
-  monitorProfiles: typeof monitorProfiles;
-  monitorSignals: typeof monitorSignals;
-  monitorEvents: typeof monitorEvents;
-  monitorClassifications: typeof monitorClassifications;
-  insightCaseEmbeddings: typeof insightCaseEmbeddings;
-  monitorOnlineEvaluators: typeof monitorOnlineEvaluators;
-  customEvaluators: typeof customEvaluators;
-  agentConnectors: typeof agentConnectors;
-  outcomeReports: typeof outcomeReports;
-  sessionScores: typeof sessionScores;
-  toolSchemas: typeof toolSchemas;
-  toolSchemaVersions: typeof toolSchemaVersions;
-  prompts: typeof prompts;
-  promptVersions: typeof promptVersions;
-  portabilityModels: typeof portabilityModels;
-  evaluationAnalyses: typeof evaluationAnalyses;
-  appSettings: typeof appSettings;
-};
-
 // See schema.sqlite.ts's reviewQueueItems for the full comment.
 export const reviewQueueItems = pgTable("review_queue_items", {
   id: text("id").primaryKey(),
@@ -779,7 +747,7 @@ export const pairwiseComparisons = pgTable("pairwise_comparisons", {
   flipped: boolean("flipped").notNull().default(false),
   justification: text("justification"),
   judgeModel: text("judge_model"),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+  createdAt: timestamp("created_at", { mode: "date" }).notNull(),
 });
 
 // See schema.sqlite.ts's playgroundProfiles for the full comment.
@@ -790,8 +758,8 @@ export const playgroundProfiles = pgTable("playground_profiles", {
   description: text("description"),
   promptId: text("prompt_id"),
   config: jsonb("config").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+  createdAt: timestamp("created_at", { mode: "date" }).notNull(),
+  updatedAt: timestamp("updated_at", { mode: "date" }).notNull(),
 });
 
 // Per-minute metric rollups - see schema.sqlite.ts's monitorRollups for the full comment.

--- a/engine/src/storage/schema.sqlite.ts
+++ b/engine/src/storage/schema.sqlite.ts
@@ -1080,38 +1080,6 @@ export const authInvitations = sqliteTable("auth_invitation", {
   inviterId: text("inviter_id").notNull(),
 });
 
-export type SqliteSchema = {
-  projects: typeof projects;
-  traces: typeof traces;
-  agents: typeof agents;
-  datasets: typeof datasets;
-  evaluationSettings: typeof evaluationSettings;
-  evaluationRuns: typeof evaluationRuns;
-  evaluationRunResults: typeof evaluationRunResults;
-  datasetVersions: typeof datasetVersions;
-  evaluationSettingsVersions: typeof evaluationSettingsVersions;
-  playgroundRuns: typeof playgroundRuns;
-  monitorPatterns: typeof monitorPatterns;
-  monitorSignalFeedback: typeof monitorSignalFeedback;
-  monitorProfiles: typeof monitorProfiles;
-  monitorSignals: typeof monitorSignals;
-  monitorEvents: typeof monitorEvents;
-  monitorClassifications: typeof monitorClassifications;
-  insightCaseEmbeddings: typeof insightCaseEmbeddings;
-  monitorOnlineEvaluators: typeof monitorOnlineEvaluators;
-  customEvaluators: typeof customEvaluators;
-  agentConnectors: typeof agentConnectors;
-  outcomeReports: typeof outcomeReports;
-  sessionScores: typeof sessionScores;
-  toolSchemas: typeof toolSchemas;
-  toolSchemaVersions: typeof toolSchemaVersions;
-  prompts: typeof prompts;
-  promptVersions: typeof promptVersions;
-  portabilityModels: typeof portabilityModels;
-  evaluationAnalyses: typeof evaluationAnalyses;
-  appSettings: typeof appSettings;
-};
-
 // Human-review queue for traces that did NOT raise a signal - the "annotation queue" half of
 // review. Signals arrive here implicitly (Review's signal stream); rows in THIS table are traces
 // a human asked for (source "manual") or an automation rule sampled (source "rule"), so a

--- a/engine/src/test/contract.integration.test.ts
+++ b/engine/src/test/contract.integration.test.ts
@@ -173,13 +173,47 @@ describe("wire contract", () => {
     expect(parsed.entities.map(e => e.entity)).toContain("traces");
   });
 
-  it("GET /openapi.json publishes every contract entry", async () => {
+  it("GET /openapi.json publishes every contract entry in OpenAPI path templating", async () => {
     const res = await engine.json("/api/v1/openapi.json", { apiKey: null });
     expect(res.status).toBe(200);
-    const doc = res.body as { paths: Record<string, unknown>; components: { schemas: Record<string, unknown> } };
+    const doc = res.body as {
+      paths: Record<string, Record<string, { parameters?: { name: string; in: string }[] }>>;
+      components: { schemas: Record<string, unknown> };
+    };
     for (const entry of WIRE_CONTRACT) {
-      expect(doc.paths[`/api/v1${entry.path}`], entry.path).toBeDefined();
+      // {id}, never :id - generators treat Express syntax as a literal segment (guaranteed 404
+      // clients), and each templated segment must be declared as a required path parameter.
+      const oasPath = `/api/v1${entry.path.replace(/:([A-Za-z0-9_]+)/g, "{$1}")}`;
+      expect(doc.paths[oasPath], entry.path).toBeDefined();
       expect(doc.components.schemas[entry.name], entry.name).toBeDefined();
+      const wantedParams = [...entry.path.matchAll(/:([A-Za-z0-9_]+)/g)].map(m => m[1]);
+      if (wantedParams.length > 0) {
+        const op = doc.paths[oasPath]![entry.method]!;
+        expect((op.parameters ?? []).map(param => param.name).sort(), entry.path).toEqual([...wantedParams].sort());
+      }
+    }
+  });
+
+  it("every contracted route is actually mounted (no tautological coverage)", async () => {
+    // The document is derived from WIRE_CONTRACT, so asserting the document alone proves
+    // nothing. This drives each path live with placeholder ids: any status is fine EXCEPT
+    // Express's route-less 404 shape - a renamed handler must fail here, not in a consumer.
+    for (const entry of WIRE_CONTRACT) {
+      const livePath = `/api/v1${entry.path.replace(/:([A-Za-z0-9_]+)/g, "probe-missing")}`;
+      const init =
+        entry.method === "post"
+          ? { method: "POST", body: JSON.stringify({}), headers: { "content-type": "application/json" } }
+          : entry.method === "put"
+            ? { method: "PUT", body: JSON.stringify({}), headers: { "content-type": "application/json" } }
+            : undefined;
+      const res = await engine.json(livePath, { apiKey: key, ...(init ?? {}) });
+      const body = res.body as { message?: string; error?: string } | null;
+      // A resource-level 404 ({error: "... not found"}) proves the route IS mounted; only the
+      // global handler's route-less shape ({statusCode, message}) means the path went nowhere.
+      const routeMissing = Boolean(
+        res.status === 404 && !body?.error && (body?.message === "Not found" || body?.message?.startsWith("Cannot "))
+      );
+      expect(routeMissing, `${entry.method.toUpperCase()} ${entry.path} -> ${res.status} ${JSON.stringify(body).slice(0, 120)}`).toBe(false);
     }
   });
 });

--- a/engine/src/test/judgeScorers.integration.test.ts
+++ b/engine/src/test/judgeScorers.integration.test.ts
@@ -329,6 +329,10 @@ describe("camelCase ingest aliases (wire-casing unification)", () => {
       sessionId: "camel-session",
       spanId: "camel-span-1",
       latencyMs: 42,
+      inputTokens: 11,
+      outputTokens: 7,
+      cacheReadTokens: 3,
+      cacheWriteTokens: 2,
     }));
     expect(res.status).toBe(200);
     const body = res.body as { trace_id: string; traceId: string };
@@ -336,10 +340,22 @@ describe("camelCase ingest aliases (wire-casing unification)", () => {
     expect(body.traceId).toBe(body.trace_id);
 
     const detail = await api(`/ingest/traces/${body.traceId}`);
-    const trace = detail.body as { sessionId?: string; latencyMs?: number; spanId?: string };
+    const trace = detail.body as {
+      sessionId?: string;
+      latencyMs?: number;
+      spanId?: string;
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+    };
     expect(trace.sessionId).toBe("camel-session");
     expect(trace.latencyMs).toBe(42);
     expect(trace.spanId).toBe("camel-span-1");
+    expect(trace.inputTokens).toBe(11);
+    expect(trace.outputTokens).toBe(7);
+    expect(trace.cacheReadTokens).toBe(3);
+    expect(trace.cacheWriteTokens).toBe(2);
   });
 });
 


### PR DESCRIPTION
<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
