### PR TITLE
fix an empty expected_tools list wrongly failed superset-mode traject…

### DIFF
--- a/docs/insights-topic-coverage-plan.md
+++ b/docs/insights-topic-coverage-plan.md
@@ -1,7 +1,8 @@
 # Insights: production topic coverage of evaluation datasets
 
-**Status:** Phase 0 is implemented and shipped, plus one piece of Phase 1 pulled forward.
-Phases 1-3 below are otherwise still design.
+**Status:** Phase 0 is implemented and shipped, plus two pieces of Phase 1 pulled forward:
+topic merging (§3.1) and facility-location depth coverage with its count fallback and
+`coverageBasis` (§4.2). Phases 1-3 below are otherwise still design.
 
 | Shipped | Where |
 |---|---|
@@ -10,9 +11,9 @@ Phases 1-3 below are otherwise still design.
 | The probe (single + batch) | `engine/src/core/insights/probe.ts` |
 | Routes + wire contract | `engine/src/routes/insights.ts`, `engine/src/contract/wire.ts` |
 | Tests | `engine/src/test/insights.integration.test.ts`, `contract.integration.test.ts` |
-| **Insights tab** | `AgentX-eval-front`, branch `claude/insights-dataset-topic-coverage-mo44s9` |
+| **Insights tab** | `AgentX-eval-front/src/pages/Governance/tabs/InsightsTab.tsx` + `tabs/insights/*` |
 
-**Four things changed during implementation.** This document has been corrected rather than left
+**Seven things changed during implementation.** This document has been corrected rather than left
 describing something the code does not do:
 
 1. **Coverage is the facility-location value alone**, never blended with the case count. The first
@@ -27,6 +28,15 @@ describing something the code does not do:
    every classified trace was older than seven days, so the screen read "nothing classified yet"
    while the 30d window was full. Those charts are recent health; this is accumulated test debt
    measured against a *sampled* classifier.
+5. **Facility-location depth coverage shipped in Phase 0**, not Phase 1: per-topic depth with the
+   count-based fallback and `coverageBasis` labelling which basis produced each number. §10's
+   phasing now says so.
+6. **Compute is synchronous per request**, not the planned background sweep + snapshot reads. The
+   UMAP map was split onto its own route (`GET /insights/coverage/map`) so its cost is only paid
+   when the Map tab asks; the sweep + snapshot machinery is re-scoped as future work. See §9.
+7. **The route table grew and shrank**: `GET /insights/coverage/map` and
+   `POST /insights/topics/curate` shipped; `GET /insights/topics/:id` is superseded, with the
+   detail panel served inline from `/coverage`.
 
 **Validated against a real install** (340 classified traces, 54 datasets), which found (3) and (4)
 - neither was reachable from the unit tests. It reports 43% traffic-weighted / 6 of 35 topics /
@@ -584,19 +594,23 @@ engine/src/core/insights/
   identity, §4.3), adequacy factor weights, coverage thresholds. Weights must be inspectable and
   editable, or the composite score is a black box nobody trusts.
 
-**Compute posture.** Clustering + coverage is far too heavy for a request. Follow
-`improvementSweep.ts`: a leased background sweep (`sweepLease.ts`) on a schedule plus an
-explicit `POST /insights/recompute`. Reads serve the last snapshot. Follow
-`attention.ts` exactly for the cache-miss case: return what we have immediately, compute
-in the background, let the next poll pick it up. Never block a dashboard load on an LLM
-or a UMAP fit.
+**Compute posture.** *(As-built, corrected from the original plan.)* Coverage is computed
+**synchronously per request** - at current scale it fits inside a request, and a live number
+beats a stale snapshot. The one genuinely heavy piece, the UMAP fit, was split onto its own
+route (`GET /insights/coverage/map`) so its cost is only paid when the Map tab asks for it,
+never on the coverage table load. The originally planned posture - a leased background sweep
+per `improvementSweep.ts`/`sweepLease.ts` with reads serving the last snapshot, and the
+`attention.ts` return-stale-compute-behind pattern - is re-scoped as future work, to pick up
+when scale demands it.
 
 **Routes** - `engine/src/routes/insights.ts`:
 
 | Route | Returns |
 |---|---|
 | `GET /insights/coverage` | three headline numbers, topic list w/ state, degraded flag, unknown-mass estimate |
-| `GET /insights/topics/:id` | the detail panel: traffic share, cases vs target, coverage, risk components, sub-modes, suggested action |
+| `GET /insights/coverage/map` | *(shipped)* the joint UMAP projection for the Map tab - split out so its cost is only paid when asked for |
+| `POST /insights/topics/curate` | *(shipped)* generate candidate cases from a topic's own traces through the standard curation path |
+| `GET /insights/topics/:id` | *(superseded)* the detail panel is served inline from `/coverage` instead |
 | `POST /insights/topics/:id/brief` | the generation brief (selected traces, failure evidence, style anchors) |
 | `POST /insights/topics/:id/generate` | topic-grounded synthesis -> preview cases (no write) |
 | `POST /insights/probe` | calibrated verdict for one query: nearest cases, topic, traffic, adequacy |
@@ -610,14 +624,16 @@ wire shape needs to be settled in this plan's review, before UI work starts.
 ## 10. Phasing
 
 **Phase 0 - the screen, and the probe.** *(shipped, engine + dashboard)* Case embedding cache, string-grouped topics from
-existing `intent` values, count-based coverage, three headline tiles, topic map states,
-per-topic panel - plus the single-query and batch **probe** (§7), which needs none of the
+existing `intent` values, facility-location depth coverage (with the count fallback and
+`coverageBasis`), three headline tiles, topic map states, per-topic panel, the coverage
+**Map** tab - plus the single-query and batch **probe** (§7), which needs none of the
 topic machinery and is the fastest way to make the idea tangible. Ships the mockup. No
 clustering, no sweep. Proves the concept and settles the wire contract.
 
-**Phase 1 - real topics.** *(synonym merging shipped early - see §3.1; the rest outstanding.)*
+**Phase 1 - real topics.** *(synonym merging and facility-location coverage shipped early -
+see §3.1 and §4.2; the rest outstanding.)*
 Consolidation sweep, centroids, soft assignment,
-facility-location coverage, sub-mode analysis, and the full attribute row (§4.3) including
+sub-mode analysis, and the full attribute row (§4.3) including
 unique-session weighting. The numbers become defensible.
 
 **Phase 1.5 - adequacy.** `declaredRisk` and its edit route, ground-truth confidence, the

--- a/docs/memory-probe-benchmark-plan.md
+++ b/docs/memory-probe-benchmark-plan.md
@@ -80,7 +80,7 @@ config block - with two kinds of entries:
       },
       {
         "question": "Any meal restrictions for my flight?",
-        "category": "single_session_recall",
+        "category": "preference_recall",
         "dependsOn": ["seed-prefs"],
         "expectedResults": "Vegetarian meal"
       }
@@ -89,11 +89,14 @@ config block - with two kinds of entries:
 }
 ```
 
-Probe categories are LongMemEval's, minus none: `single_session_recall`, `assistant_recall`
-(what the *agent* said or did earlier), `preference_recall`, `knowledge_update`,
-`temporal_reasoning` ("what did I ask about *before* I moved?"), `multi_session` (the answer
-requires joining facts across seeds). `abstention` is the seventh, implicit category: probes
-whose `dependsOn` is empty test that the agent does NOT fabricate a memory it was never given.
+Probe categories are LongMemEval's six types, renamed for readability: `single_session_recall`
+(LongMemEval's single-session-user), `assistant_recall` (single-session-assistant - what the
+*agent* said or did earlier), `preference_recall` (single-session-preference), while
+`knowledge_update`, `temporal_reasoning` ("what did I ask about *before* I moved?"), and
+`multi_session` (the answer requires joining facts across seeds) keep their names. `abstention`
+- which LongMemEval models as a variant of each type rather than a category of its own - is
+promoted to an explicit seventh category here: probes whose `dependsOn` is empty test that the
+agent does NOT fabricate a memory it was never given.
 
 Why by-reference seeds instead of one long transcript: per-seed attribution. When
 `knowledge_update` fails, the report can say "recalled seed-prefs, missed seed-update" - the
@@ -124,8 +127,9 @@ all apply unchanged.
           category/dependsOn in the result metadata.
 
 5. REPORT Per-category aggregates + per-seed-age curve (recall @ 3d vs @ 14d) on the run;
-          gate(fail_under=..., scorer="knowledge_update") works because categories are
-          surfaced through the existing per-scorer breakdown machinery.
+          gate(fail_under=..., scorer="knowledge_update") works once Phase 1 surfaces
+          categories as scorerBreakdown entries - it does not resolve today (gate's
+          scorer= only matches judge entries in scorerBreakdown).
 ```
 
 **Who executes the turns:** the same three subject adapters dataset runs already have.
@@ -185,7 +189,8 @@ Layered, all existing machinery:
   gains `memoryBreakdown: [{ category, scored, averageRating, staleFactHits }]`.
 - **SDK:** `client.evaluations.memory_probe_suite(...)` builder +
   `run(dataset_id=..., ...)` unchanged; `run.memory_breakdown()` accessor;
-  `gate(fail_under=..., scorer="knowledge_update")` already works.
+  `gate(fail_under=..., scorer="knowledge_update")` works once Phase 1 surfaces categories as
+  scorerBreakdown entries (it does not resolve today).
 - **UI:** the dataset editor gets a Seeds/Probes view for `memoryProbe` datasets; the run
   detail gets a category breakdown card and, per probe row, links to the seed sessions and the
   probe session (both are real sessions - the existing session detail dialog is the drill-down).

--- a/engine/src/contract/wire.ts
+++ b/engine/src/contract/wire.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { SPAN_KINDS } from "../core/trace/spanKind.js";
 
 // The wire contract for the dashboard surfaces most prone to drift. These schemas are the
 // single written form of each response shape: the contract integration test
@@ -113,7 +114,9 @@ export const traceListItemSchema = z
     // Always present and always resolved (core/trace/spanKind.ts): the engine classifies each
     // span once so no reader has to re-derive it. Never optional - "chain" is the answer for a
     // span nothing could be said about, not an absent field.
-    spanKind: z.enum(["agent", "llm", "tool", "retrieval", "chain", "embedding", "reranker", "guardrail", "evaluator", "prompt", "memory"]),
+    // Derived from the one vocabulary (spanKind.ts) - a hand-typed copy silently drifted the day
+    // a new kind was added, and the wire schema then rejected every trace carrying it.
+    spanKind: z.enum(SPAN_KINDS),
     // "eval-run" for traffic produced inside an offline evaluation; absent for production.
     trafficSource: z.string().optional(),
     parentSpanId: z.string().optional(),
@@ -757,6 +760,19 @@ export const insightsCoverageMapResponseSchema = z
   })
   .strict();
 
+// Platform Settings' "Usage & limits" card - today's spend against each env-configured daily
+// cap, computed by the same counters the enforcement paths seed from (core/shared/usage.ts).
+const usageBucketSchema = z.object({ used: z.number(), limit: z.number().nullable() });
+const usageAndLimitsResponseSchema = z
+  .object({
+    day: z.string(),
+    resetsAt: z.string(),
+    traces: usageBucketSchema,
+    onlineJudgeCalls: usageBucketSchema,
+    judgeCalls: usageBucketSchema,
+  })
+  .strict();
+
 export const WIRE_CONTRACT = [
   {
     method: "get" as const,
@@ -849,6 +865,13 @@ export const WIRE_CONTRACT = [
     summary: "Cursor-paginated trace list with database-side search",
     response: tracesPageSchema,
     name: "TracesPage",
+  },
+  {
+    method: "get" as const,
+    path: "/agent-monitoring/usage",
+    summary: "Today's usage against the configured daily caps",
+    response: usageAndLimitsResponseSchema,
+    name: "UsageAndLimitsResponse",
   },
   {
     method: "get" as const,

--- a/engine/src/core/evaluate/agentConnectors.ts
+++ b/engine/src/core/evaluate/agentConnectors.ts
@@ -46,12 +46,25 @@ function toWire(row: AgentConnectorRow) {
 
 
 // PUT round-trips: a value that still carries the read-side mask means "keep what's stored".
+// Precise, not pattern-based: the value counts as a mask only when it EQUALS the mask the read
+// side produced for the currently stored value - isMaskedSecret alone false-positived on real
+// 11-character header values shaped like "abc...defg", silently reverting a user's edit.
 function unmaskHeaders(incoming: Record<string, string> | null, stored: unknown): Record<string, string> | null {
   if (!incoming) return incoming;
   const previous = (stored as Record<string, string> | null) ?? {};
   return Object.fromEntries(
-    Object.entries(incoming).map(([k, v]) => [k, isMaskedSecret(v) && previous[k] !== undefined ? previous[k]! : v])
+    Object.entries(incoming).map(([k, v]) => [
+      k,
+      isMaskedSecret(v) && previous[k] !== undefined && v === maskSecret(previous[k]!) ? previous[k]! : v,
+    ])
   );
+}
+
+// A masked value ("abc...xyz") pasted back on CREATE has no stored original to unmask against -
+// storing it verbatim yields a connector that 401s against the customer's agent with no hint
+// why. Exposed so the route can 400 it instead.
+export function hasMaskedHeaderValues(headers: Record<string, string> | null | undefined): boolean {
+  return !!headers && Object.values(headers).some(v => isMaskedSecret(v));
 }
 
 export async function createAgentConnector(db: Db, input: CreateAgentConnectorInput) {
@@ -172,7 +185,10 @@ const MAX_CONNECTOR_RESPONSE_BYTES = 2 * 1024 * 1024;
 
 // Reads up to the cap, then cancels the transfer - checking content-length alone would miss
 // chunked responses, and res.text() would have buffered everything before any length check ran.
-async function readConnectorBody(res: Response, url: string): Promise<string> {
+// Exported for the Playground's tool endpoint (playground.ts), whose res.json() had no byte
+// bound at all - 8s of a fast hostile/misconfigured stream is gigabytes of heap.
+
+export async function readConnectorBody(res: Response, url: string): Promise<string> {
   const reader = res.body?.getReader();
   if (!reader) {
     return "";

--- a/engine/src/core/evaluate/analysis.ts
+++ b/engine/src/core/evaluate/analysis.ts
@@ -155,14 +155,19 @@ async function scoreItemWithJudges(row: RunResultRow, judgeModels: string[]): Pr
       const variant = JUDGE_VARIANTS[i] ?? String(i + 1);
       try {
         const result = await callJudgeJson({ model, jsonSchema: ITEM_SCORE_SCHEMA, userMessage: prompt });
-        const payload = result.payload as { rating?: number; justification?: string } | null;
+        const payload = result.payload as { rating?: unknown; justification?: string } | null;
+        // Coerced like scoreAgainstCriteria: Anthropic/Gemini/custom endpoints legitimately
+        // answer {"rating": "8"} - a typeof check silently nulled two of three paid judges
+        // and reported the survivor as "single_judge" consensus. Clamped for percent-scale
+        // answers (85 for 8.5) so finalScore/bands/narrative stay on the rubric's 0-10.
+        const numeric = payload?.rating === undefined || payload?.rating === null ? Number.NaN : Number(payload.rating);
         return {
           judgeVariant: variant,
           model,
-          // Clamped: percent-scale answers from compat endpoints (85 for 8.5) must not skew
-          // finalScore, the disagreement bands, or the narrative prompt.
-          rating: typeof payload?.rating === "number" ? Math.max(0, Math.min(10, payload.rating)) : null,
-          justification: payload?.justification ?? null,
+          rating: Number.isFinite(numeric) ? Math.max(0, Math.min(10, numeric)) : null,
+          justification:
+            (typeof payload?.justification === "string" ? payload.justification : null) ??
+            (Number.isFinite(numeric) ? null : "judge returned a non-numeric rating"),
         };
       } catch (err) {
         // One judge without a key (or in outage) degrades to a null rating - it must not
@@ -300,7 +305,10 @@ export async function runEvaluationAnalysis(
 ): Promise<AnalyzeEvaluationResult | null> {
   // The judge selection is part of the identity: restarting with different judges must start
   // a new analysis, not silently join (and return) the in-flight one with the old panel.
-  const inFlightKey = `${db.projectId ?? ""}|${evaluationId}|${(opts.judges ?? []).map(j => j.model).sort().join(",")}|${opts.qualityMode ?? ""}`;
+  // Order-sensitive on purpose: judgeModels[0] authors the narrative, so [A,B] and [B,A] are
+  // different requests - a sorted key would silently join them and hand the second caller the
+  // wrong writer judge.
+  const inFlightKey = `${db.projectId ?? ""}|${evaluationId}|${(opts.judges ?? []).map(j => j.model).join(",")}|${opts.qualityMode ?? ""}`;
   const inFlight = analysisInFlight.get(inFlightKey);
   if (inFlight) {
     return inFlight;
@@ -419,6 +427,27 @@ async function runEvaluationAnalysisInner(
 }
 
 export async function getEvaluationAnalysisStatus(db: Db, evaluationId: string) {
+  // An analysis in flight for this run outranks whatever terminal row a PREVIOUS analysis
+  // left behind - without this, a re-analyze whose HTTP call timed out client-side polls
+  // straight into last week's "completed" and presents the stale narrative as the new one.
+  const inFlightPrefix = `${db.projectId ?? ""}|${evaluationId}|`;
+  for (const key of analysisInFlight.keys()) {
+    if (key.startsWith(inFlightPrefix)) {
+      // Same shape as the two branches below - clients poll THIS branch the longest, and a
+      // narrower object here threw in consumers reading warnings/overflowStats mid-poll.
+      return {
+        evaluationId,
+        jobId: evaluationId,
+        status: "running" as const,
+        progress: { overallPercentage: 0, currentLevel: "l1_score", levels: {} },
+        failureReason: null,
+        warnings: [],
+        cost: { estimatedUSD: null },
+        etaUpdatedAt: null,
+        overflowStats: { compressedItems: 0, maxCompressionRatio: null, tokenOverflowCount: 0, recursiveSplitCount: 0 },
+      };
+    }
+  }
   const row = await getEvaluationAnalysisRow(db, evaluationId);
   if (!row) {
     return {

--- a/engine/src/core/evaluate/connectorRun.ts
+++ b/engine/src/core/evaluate/connectorRun.ts
@@ -79,8 +79,12 @@ export async function startConnectorRun(
 
   // Fire-and-forget: driveConnectorRun awaits internally but this call site doesn't, so the HTTP
   // response can return now. Errors are handled inside driveConnectorRun itself (failRun on an
-  // unexpected failure) - nothing here should ever reject and become an unhandled rejection.
-  void driveConnectorRun(db, runId, cases, connector, repetitions);
+  // unexpected failure) - and this outer catch is the last line of defense: the recovery path
+  // itself can throw (failRun on a dead DB), and an unhandled rejection here exits the whole
+  // process, skipping the shutdown drain and losing queued spans for every project.
+  void driveConnectorRun(db, runId, cases, connector, repetitions).catch(err => {
+    logger.error({ err: err instanceof Error ? err.message : err, runId }, "Connector run driver crashed");
+  });
 
   return { runId, questionCount: cases.length };
 }
@@ -116,6 +120,17 @@ async function driveConnectorRun(
               inputTokens: response.inputTokens,
               outputTokens: response.outputTokens,
             };
+            if (response.error) {
+              // The agent answered 200 but REPORTED a failure - scoring its (usually empty)
+              // output as a real answer buries the outage in a genuine-looking low score.
+              return {
+                idempotencyKey: `${runId}:${questionIndex}:${runNumber}`,
+                questionIndex,
+                runNumber,
+                input: { query },
+                error: { type: "connector_error", message: response.error },
+              };
+            }
             return {
               idempotencyKey: `${runId}:${questionIndex}:${runNumber}`,
               questionIndex,
@@ -151,6 +166,13 @@ async function driveConnectorRun(
       return;
     }
     logger.error({ err: message }, `Connector-driven run ${runId} failed:`);
-    await failRun(db, runId);
+    try {
+      await failRun(db, runId);
+    } catch (failErr) {
+      logger.error(
+        { err: failErr instanceof Error ? failErr.message : failErr, runId },
+        "Could not mark connector run failed"
+      );
+    }
   }
 }

--- a/engine/src/core/evaluate/judge.ts
+++ b/engine/src/core/evaluate/judge.ts
@@ -122,16 +122,27 @@ async function getGemini(): Promise<OpenAI | null> {
 // Custom (bring-your-own-endpoint) portability_models rows - cached by the resolved
 // baseUrl+apiKey pair, same "rebuild only when the actual config changes" idiom as
 // getOpenAI/getAnthropic above, so editing a custom model's key in the dashboard takes effect
-// immediately without needing to clear this cache explicitly.
+// immediately without needing to clear this cache explicitly. Bounded as a simple LRU (a hit
+// re-inserts, so Map iteration order is recency order): every edited key/baseUrl pair used to
+// stay cached forever, an unbounded growth path on an instance whose custom endpoints churn.
+const CUSTOM_CLIENT_CACHE_MAX = 32;
 const customClientCache = new Map<string, OpenAI>();
 function getCustomClient(row: PortabilityModelRow): OpenAI {
   const cacheKey = `${row.baseUrl}::${row.apiKey ?? ""}`;
   let client = customClientCache.get(cacheKey);
-  if (!client) {
+  if (client) {
+    // Refresh recency: delete + set moves the entry to the end of the Map's iteration order.
+    customClientCache.delete(cacheKey);
+  } else {
     // Most self-hosted/local model servers don't require a key at all; the SDK still needs a
     // non-empty string to construct, hence the placeholder.
     client = new OpenAI({ apiKey: row.apiKey || "not-required", baseURL: row.baseUrl! });
-    customClientCache.set(cacheKey, client);
+  }
+  customClientCache.set(cacheKey, client);
+  if (customClientCache.size > CUSTOM_CLIENT_CACHE_MAX) {
+    // Evict the least recently used entry (the first in iteration order).
+    const oldest = customClientCache.keys().next().value;
+    if (oldest !== undefined) customClientCache.delete(oldest);
   }
   return client;
 }
@@ -172,7 +183,10 @@ async function resolveModelRouting(model: string): Promise<ModelRouting> {
       isCustom: true,
     };
   }
-  if (!custom && model.includes("/")) {
+  // Slash-form ids are OpenRouter's namespace, whatever provider label the catalog row
+  // carries - "anthropic/claude-sonnet-4" sent to the native Anthropic API 404s. Only a
+  // custom-provider row (own baseUrl, handled above) may claim a slashed id for itself.
+  if (model.includes("/")) {
     return {
       provider: "openai",
       openaiClient: await getOpenRouter(),
@@ -180,6 +194,30 @@ async function resolveModelRouting(model: string): Promise<ModelRouting> {
       envVar: "OPENROUTER_API_KEY",
       isGemini: false,
       isCustom: true,
+    };
+  }
+  // A catalog row that SAYS anthropic/openai must route there - "claude-" prefix sniffing is
+  // only for models the catalog has never seen. Without this, a row saved as
+  // provider:"anthropic" with a non-claude id was silently sent to OpenAI and 404ed on every
+  // judge call while the UI showed it correctly configured.
+  if (custom?.provider === "anthropic") {
+    return {
+      provider: "anthropic",
+      openaiClient: null,
+      keyLabel: "Anthropic",
+      envVar: "ANTHROPIC_API_KEY",
+      isGemini: false,
+      isCustom: false,
+    };
+  }
+  if (custom?.provider === "openai") {
+    return {
+      provider: "openai",
+      openaiClient: await getOpenAI(),
+      keyLabel: "OpenAI",
+      envVar: "OPENAI_API_KEY",
+      isGemini: false,
+      isCustom: false,
     };
   }
   if (custom?.provider === "gemini" || (!custom && model.startsWith("gemini-"))) {
@@ -327,9 +365,6 @@ export async function callJudgeJson({
   // Pass only for schemas whose every property is required - see judge-core's callJudgeJson.
   strictSchema?: boolean;
 }): Promise<JudgeCallResult> {
-  // Metering + daily quota, both scoped by the request's tenancy context (see
-  // core/shared/usage.ts). Every judge path in the engine funnels through here.
-  await checkAndRecordJudgeCall(model);
   const { provider, openaiClient, keyLabel, envVar, isGemini, isCustom } = await resolveModelRouting(model);
   if (provider === "anthropic" && !(await getAnthropic())) {
     throw new Error(
@@ -339,6 +374,11 @@ export async function callJudgeJson({
   if (provider === "openai" && !openaiClient) {
     throw new Error(`Judge model "${model}" needs a ${keyLabel} API key. Set ${envVar} and restart agentx-server.`);
   }
+  // Metering + daily quota, both scoped by the request's tenancy context (see
+  // core/shared/usage.ts). Every judge path in the engine funnels through here - AFTER the
+  // key-resolution guards above, so a missing key doesn't burn daily quota on calls that
+  // never reach a provider.
+  await checkAndRecordJudgeCall(model);
 
   const result = await callJudgeJsonShared({
     userMessage,
@@ -363,8 +403,9 @@ export async function callJudgeJson({
     // judge-core's automatic empty/parse-failure retry is a second real provider call - the
     // billing ledger under-counted by up to 2x on flaky generations without this. Record-only:
     // the quota gate ran before the call, and throwing HERE would discard a successful,
-    // already-billed result at the exact boundary of the daily cap.
-    await recordJudgeCall(model);
+    // already-billed result at the exact boundary of the daily cap. Best-effort for the same
+    // reason: a DB hiccup on the ledger insert must not discard a paid-for judge response.
+    await recordJudgeCall(model).catch(err => logger.warn({ err, model }, "judge retry not metered"));
   }
   return result;
 }

--- a/engine/src/core/evaluate/playground.ts
+++ b/engine/src/core/evaluate/playground.ts
@@ -1,4 +1,5 @@
 import { outboundUrlProblem } from "../shared/urlGuard.js";
+import { readConnectorBody } from "./agentConnectors.js";
 import type { Db } from "../../storage/db.js";
 import { callModelWithTools, scoreAgainstCriteria, DEFAULT_JUDGE_MODEL, DEFAULT_JUDGE_PROMPT, type ToolCallTrace } from "./judge.js";
 import { getPortabilityModel, estimateCostUSD } from "./models.js";
@@ -105,8 +106,16 @@ export async function callPlaygroundTool(tools: PlaygroundTool[], name: string, 
   if (!res.ok) {
     throw new Error(`Tool "${name}" endpoint ${tool.endpointUrl} responded ${res.status}`);
   }
-  const body = (await res.json()) as { result?: unknown };
-  if (!("result" in body)) {
+  // Capped read (2MB, streaming) - res.json() buffers the entire body before any length
+  // check could run, and AbortSignal.timeout bounds seconds, not bytes.
+  const raw = await readConnectorBody(res, tool.endpointUrl);
+  let body: { result?: unknown };
+  try {
+    body = JSON.parse(raw) as { result?: unknown };
+  } catch {
+    throw new Error(`Tool "${name}" endpoint ${tool.endpointUrl} did not return valid JSON`);
+  }
+  if (!body || typeof body !== "object" || !("result" in body)) {
     throw new Error(`Tool "${name}" endpoint ${tool.endpointUrl} response missing a "result" field`);
   }
   return body.result;
@@ -207,6 +216,10 @@ export type PlaygroundRunResult = {
   onlineEvaluatorChecks?: PlaygroundOnlineEvaluatorCheckResult[];
   judgeScorerResults?: PlaygroundJudgeScorerResult[];
   error: string | null;
+  // Set when the MODEL call succeeded but scoring did not (judge outage, deleted group) - the
+  // cell can badge it instead of rendering an unscored result indistinguishable from a judge
+  // that legitimately declined. `error` stays for model-call failures only.
+  scoringError?: string | null;
 };
 
 // Dry-run version of detect.ts's detectCustomPatterns - evaluates every requested pattern
@@ -396,6 +409,7 @@ export async function runPlayground(db: Db, input: PlaygroundRunInput): Promise<
     const estimatedCostUSD = estimateCostUSD(model, completion.usage?.inputTokens ?? null, completion.usage?.outputTokens ?? null);
 
     let rating: number | null = null;
+    let scoringError: string | null = null;
     let justification: string | null = null;
     let groupMemberJudges: PlaygroundJudgeScorerResult[] | undefined;
     let groupMemberChecks: CodeScorerResult[] | undefined;
@@ -427,6 +441,7 @@ export async function runPlayground(db: Db, input: PlaygroundRunInput): Promise<
           .map(m => ({ name: m.name, score: m.goodness, reasoning: m.error ? undefined : m.detail, error: m.error }));
       } else {
         justification = "Scorer group no longer exists.";
+        scoringError = "Scorer group no longer exists.";
       }
     }
     // Only score when there's a ground truth to compare against - a question with no
@@ -449,6 +464,7 @@ export async function runPlayground(db: Db, input: PlaygroundRunInput): Promise<
         // A judge failure (bad key, provider outage) shouldn't blank out the real model output
         // that already succeeded - same isolation posture as runs.ts's scoreOneResult.
         justification = `Scoring failed: ${err instanceof Error ? err.message : "unknown error"}`;
+        scoringError = err instanceof Error ? err.message : "Scoring failed";
       }
     }
 
@@ -524,6 +540,7 @@ export async function runPlayground(db: Db, input: PlaygroundRunInput): Promise<
       onlineEvaluatorChecks,
       judgeScorerResults,
       error: null,
+      scoringError,
     };
   } catch (err) {
     return {

--- a/engine/src/core/evaluate/runs.ts
+++ b/engine/src/core/evaluate/runs.ts
@@ -514,7 +514,10 @@ async function scoreOneResult(
   // rides the existing storage and results UI as one more named scorer row.
   const expectedTrajectory = mainQ?.expectedTrajectory;
   const expectedTools = (expectedTrajectory?.tools ?? []).map(t => String(t).trim()).filter(Boolean);
-  if (expectedTools.length > 0) {
+  // Presence of the block is the assertion, not a non-empty list: an explicit EMPTY tools
+  // list means "this case calls no tools" and must produce a scorer row that fails when the
+  // trace called any - silently skipping it made the SDK's expected_tools=[] a false promise.
+  if (expectedTrajectory && Array.isArray(expectedTrajectory.tools)) {
     const mode = (["strict", "unordered", "subset", "superset"] as const).includes(
       expectedTrajectory?.mode as TrajectoryMatchMode
     )
@@ -528,6 +531,9 @@ async function scoreOneResult(
       });
     } else {
       const actualSequence = (await extractTraceToolSequence(db, item.traceId)) ?? [];
+      // matchTrajectory is correct for an empty expected list in every mode - including
+      // superset, where it is vacuously true (an explicitly-unconstrained assertion). The old
+      // special case here failed superset whenever the agent called any tool at all.
       const match = matchTrajectory(expectedTools, actualSequence, mode);
       codeScorerResults.push({
         name: `Trajectory match (${mode})`,

--- a/engine/src/core/export/exportData.ts
+++ b/engine/src/core/export/exportData.ts
@@ -17,12 +17,26 @@ import type { Db } from "../../storage/db.js";
 // backup keeps the header KEYS; the operator re-enters the secrets, same as provider keys
 // (which are excluded from export entirely).
 function redactConnectorRow(row: Record<string, unknown>): Record<string, unknown> {
+  // Credentials live in the URL as often as in headers (https://user:pass@host, ?api_key=...):
+  // strip userinfo and mask every query value, keeping the shape so the export stays useful.
+  let url = row.url;
+  if (typeof url === "string") {
+    try {
+      const parsed = new URL(url);
+      parsed.username = "";
+      parsed.password = "";
+      for (const key of [...parsed.searchParams.keys()]) parsed.searchParams.set(key, "***redacted***");
+      url = parsed.toString();
+    } catch {
+      // Not parseable as a URL - leave as stored; nothing to redact structurally.
+    }
+  }
   const headers = row.headers;
-  if (!headers || typeof headers !== "object") return row;
-  return {
-    ...row,
-    headers: Object.fromEntries(Object.entries(headers as Record<string, unknown>).map(([k]) => [k, "***redacted***"])),
-  };
+  const redactedHeaders =
+    headers && typeof headers === "object"
+      ? Object.fromEntries(Object.entries(headers as Record<string, unknown>).map(([k]) => [k, "***redacted***"]))
+      : headers;
+  return { ...row, url, headers: redactedHeaders };
 }
 
 export const EXPORT_ENTITIES = {
@@ -117,7 +131,13 @@ export function exportKeyName(entity: ExportEntity): string {
 
 function buildWhere(db: Db, entity: ExportEntity, since: Date | null, cursor: string | null): SQL | undefined {
   const t = entityTable(db, entity);
-  const conds: SQL[] = [eq(t.projectId, db.projectId)];
+  // Strict projectId match for EVERY entity, audit-events included. The NULL-projectId audit
+  // rows are the instance-wide auth trail (every user's sign-in/sign-up attempts with IPs) -
+  // handing them to any project API key crossed the tenant boundary this module's header
+  // promises never to cross. Operators read the auth trail via the admin-token-gated
+  // GET /admin/audit instead.
+  const projectCond: SQL = eq(t.projectId, db.projectId);
+  const conds: SQL[] = [projectCond];
   if (since) {
     conds.push(gte(t[EXPORT_ENTITIES[entity].sinceColumn], since));
   }

--- a/engine/src/core/insights/coverageMap.ts
+++ b/engine/src/core/insights/coverageMap.ts
@@ -33,6 +33,8 @@ const MIN_POINTS_FOR_MAP = 10;
 const MAX_TRACE_BACKFILL_PER_REQUEST = 100;
 // Single-flight guard for the backfill, per project - see the block below.
 const backfillInFlight = new Set<string>();
+// Per-project scan offset into the unembedded backlog - see the dead-window escape below.
+const backfillScanOffset = new Map<string, number>();
 
 export type CoverageMapPoint = {
   x: number;
@@ -93,10 +95,15 @@ export async function getCoverageMap(
   // drains front-to-back across requests.
   const MAX_UNEMBEDDED_CONSIDERED = 500;
   const unembeddedAll = withTrace.filter(r => !hasVector(r));
-  const unembedded = unembeddedAll.slice(0, MAX_UNEMBEDDED_CONSIDERED);
-  // Rows beyond the window are pending-unknown (their traces were not fetched to check) - they
-  // count toward the "still indexing" number rather than silently vanishing from it.
-  const pendingBeyondWindow = unembeddedAll.length - unembedded.length;
+  // The considered window normally starts at the newest rows; when a whole window turns out to
+  // be dead (every trace pruned by retention - the absorbing state that used to wedge the scan
+  // permanently), scanOffset advances so the next request examines the NEXT 500 instead of
+  // re-verifying the same corpses forever.
+  const offset = Math.min(backfillScanOffset.get(db.projectId ?? "") ?? 0, Math.max(0, unembeddedAll.length - 1));
+  const unembedded = unembeddedAll.slice(offset, offset + MAX_UNEMBEDDED_CONSIDERED);
+  // Rows OUTSIDE the window are pending-unknown (their traces were not fetched to check) -
+  // both behind it and, while a mid-scan offset is active, the newer rows in front of it.
+  const pendingBeyondWindow = Math.max(0, unembeddedAll.length - unembedded.length);
 
   // Texts for point labels (and the backfill) - fetched only for rows that might be plotted
   // or backfilled this request.
@@ -111,6 +118,17 @@ export async function getCoverageMap(
   // Rows whose trace was pruned by retention can never be embedded - they are excluded from
   // the pending count instead of reading "still indexing" forever.
   const backfillable = unembedded.filter(r => inputTextOf(r).trim().length > 0);
+  if (unembedded.length > 0 && backfillable.length === 0 && pendingBeyondWindow > 0) {
+    // Everything in this window is dead - advance so later requests reach the rows behind it.
+    backfillScanOffset.set(db.projectId ?? "", offset + unembedded.length);
+  } else if (backfillable.length > 0) {
+    backfillScanOffset.set(db.projectId ?? "", 0);
+  } else {
+    // The LAST window was all-dead (or there was nothing to scan): the pass is complete.
+    // Reset to the front - the list is newest-first, so fresh unembedded rows arrive at
+    // index 0, and a pinned tail offset would skip them forever.
+    backfillScanOffset.set(db.projectId ?? "", 0);
+  }
 
   // Lazy backfill, bounded per request and single-flight per project: two Map tabs polling at
   // once must not both pay for the same 100 embeddings. The loser simply reports the rows as

--- a/engine/src/core/monitor/conditions.ts
+++ b/engine/src/core/monitor/conditions.ts
@@ -44,9 +44,9 @@ export function buildSourceTexts({ responseText, trace }: { responseText?: strin
     trace: [
       stringify(trace?.output),
       trace?.error ?? "",
-      ...((Array.isArray(trace?.toolCalls) ? trace.toolCalls : []) as NonNullable<TraceLike["toolCalls"]>).map(call =>
-        [call.name, stringify(call.output), stringify(call.input)].filter(Boolean).join(" ")
-      ),
+      ...((Array.isArray(trace?.toolCalls) ? trace.toolCalls : []) as NonNullable<TraceLike["toolCalls"]>)
+        .filter(call => (call as Record<string, unknown>)["agentx.truncated"] !== true)
+        .map(call => [call.name, stringify(call.output), stringify(call.input)].filter(Boolean).join(" ")),
     ]
       .filter(Boolean)
       .join("\n"),

--- a/engine/src/core/monitor/events.ts
+++ b/engine/src/core/monitor/events.ts
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { and, desc, eq, gte, inArray, isNotNull, isNull, lt } from "drizzle-orm";
+import { and, count, desc, eq, gte, inArray, isNotNull, isNull, like, lt, or } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import { traceStoreFor } from "../trace/store/index.js";
 import { getTraceRow } from "../trace/ingest.js";
@@ -276,6 +276,38 @@ export async function listEventsSince(db: Db, since: Date): Promise<EventRow[]> 
   return rows as EventRow[];
 }
 
+// Judge-call spend since `since`, counted in SQL - the daily budget seed used to materialize
+// EVERY monitor event since midnight (justifications included) inside the serialized
+// reservation chain, blocking concurrent ingests behind one giant allocation at day's end.
+// The predicate mirrors reserveOnlineJudgeCall's seed exactly: evaluator verdicts/failures
+// (trace and session), group JUDGE member verdicts, and group judge-member failures.
+export async function countJudgeSpendSince(db: Db, since: Date): Promise<number> {
+  const cond = and(
+    gte(db.schema.monitorEvents.createdAt, since),
+    eq(db.schema.monitorEvents.projectId, db.projectId),
+    or(
+      and(
+        isNotNull(db.schema.monitorEvents.onlineEvaluatorId),
+        inArray(db.schema.monitorEvents.type, ["online_eval_score", "online_eval_judge_failure", "online_eval_session_score"])
+      ),
+      and(
+        eq(db.schema.monitorEvents.type, "scorer_group_member_score"),
+        like(db.schema.monitorEvents.patternKey, "%:judge:%")
+      ),
+      and(
+        isNull(db.schema.monitorEvents.onlineEvaluatorId),
+        eq(db.schema.monitorEvents.type, "online_eval_judge_failure"),
+        like(db.schema.monitorEvents.patternKey, "%:judge:%")
+      )
+    )
+  );
+  const rows =
+    db.kind === "sqlite"
+      ? db.db.select({ n: count() }).from(db.schema.monitorEvents).where(cond).all()
+      : await db.db.select({ n: count() }).from(db.schema.monitorEvents).where(cond);
+  return Number((rows as Array<{ n: number | string }>)[0]?.n ?? 0);
+}
+
 // One evaluator's scored events in the window, filtered in SQL - judgeTuning.ts joins these
 // against ground truth per evaluator, and loading EVERY monitor event just to keep one
 // evaluator's ratings scaled with total traffic instead of with that evaluator's own volume.
@@ -495,7 +527,10 @@ export async function getScorerActivity(
     // Judge failures (provider outage, unusable output) get their own counter per scorer -
     // previously a failing judge was indistinguishable from a quiet one on the Scorers list.
     if (row.type === "online_eval_judge_failure" && row.patternKey) {
-      const entry = (activity[row.patternKey] ??= { count: 0, buckets: new Array(days).fill(0) });
+      // Group judge-member failures carry `scorer-group:<id>:judge:<refId>` - folded onto the
+      // group's own key, which IS a Scorers-list row; the raw member key resolves to nothing.
+      const key = row.patternKey.includes(":judge:") ? row.patternKey.split(":judge:")[0]! : row.patternKey;
+      const entry = (activity[key] ??= { count: 0, buckets: new Array(days).fill(0) });
       entry.judgeFailures = (entry.judgeFailures ?? 0) + 1;
       continue;
     }

--- a/engine/src/core/monitor/judgeScorers.ts
+++ b/engine/src/core/monitor/judgeScorers.ts
@@ -14,6 +14,7 @@ import {
 } from "../evaluate/evaluationSettings.js";
 import { getEvaluationSettingsVersionCounts } from "../evaluate/versions.js";
 import {
+  ReferenceCentricScorerError,
   createOnlineEvaluator,
   deleteOnlineEvaluator,
   findEvaluatorBoundToSettings,
@@ -21,6 +22,7 @@ import {
   updateOnlineEvaluator,
   type OnlineEvaluatorRow,
 } from "./onlineEvaluators.js";
+import { listScorerGroups } from "./scorerGroups.js";
 
 // The unified LLM Judge Scorer (2026-08 consolidation): ONE entity with a judge rubric and two
 // setting profiles, presented over the two storage halves that already existed -
@@ -259,7 +261,23 @@ export async function updateJudgeScorer(db: Db, id: string, patch: UpdateJudgeSc
       if (patch.judge[key] !== undefined) settingsPatch[key] = patch.judge[key];
     }
     if (patch.judge.toolContext !== undefined) settingsPatch.toolContext = normalizeToolContext(patch.judge.toolContext);
-    if (patch.judge.requiresExpected !== undefined) settingsPatch.requiresExpected = patch.judge.requiresExpected;
+    if (patch.judge.requiresExpected !== undefined) {
+      // Turning requiresExpected ON while the scorer is live would bypass the exact 409
+      // assertScorableOnline exists for - the judge would grade live traffic against a
+      // reference that does not exist. Same rule for membership in a live scorer group.
+      if (patch.judge.requiresExpected === true) {
+        const goingLive = patch.online !== null && (patch.online?.enabled ?? profile?.enabled ?? false);
+        const inLiveGroup = (await listScorerGroups(db)).some(
+          g => g.online?.enabled && g.members.some(m => m.kind === "judge" && m.refId === id)
+        );
+        if (goingLive || inLiveGroup) {
+          throw new ReferenceCentricScorerError(
+            `"${settings.name}" is scoring live traffic (directly or as a scorer-group member) - a reference answer (requiresExpected) cannot be required for live traffic. Disable live scoring first.`
+          );
+        }
+      }
+      settingsPatch.requiresExpected = patch.judge.requiresExpected;
+    }
   }
   if (patch.offline) {
     if (patch.offline.numberOfRequests !== undefined) settingsPatch.numberOfRequests = patch.offline.numberOfRequests;

--- a/engine/src/core/monitor/judgeTuning.ts
+++ b/engine/src/core/monitor/judgeTuning.ts
@@ -689,7 +689,9 @@ export async function validateJudgeTuning(
   if (scoredDisagreements.length === 0) {
     return {
       threshold,
-      disagreements: { total: disagreements.length, fixed: 0 },
+      // Same denominator as the success path below (scored disagreements, not raw ones) so the
+      // two response shapes agree on what "total" counts.
+      disagreements: { total: scoredDisagreements.length, fixed: 0 },
       controls: { total: scoredControls.length, preserved: scoredControls.filter(c => c.candidateAgrees).length },
       netAgreementGain: 0,
       verdict: "insufficient",

--- a/engine/src/core/monitor/metrics.ts
+++ b/engine/src/core/monitor/metrics.ts
@@ -29,9 +29,13 @@ export type MetricsRange = { from: number; to: number; window: string };
 // Presets ("1h".."90d") or an explicit custom range via from/to (epoch ms). Custom ranges are
 // clamped to [1 minute, 366 days]; nonsense falls back to the 7-day preset.
 export function parseMetricsRange(query: Record<string, unknown>): MetricsRange {
-  const from = Number(query.from);
-  const to = Number(query.to);
-  if (Number.isFinite(from) && Number.isFinite(to) && to > from) {
+  // Same guard as the two route-level parseRange twins: Number("") is 0 (finite!), so a blank
+  // ?from= must not become epoch 0 and turn a metrics-grid poll into a year-long table scan.
+  const rawFrom = typeof query.from === "string" ? query.from.trim() : "";
+  const rawTo = typeof query.to === "string" ? query.to.trim() : "";
+  const from = rawFrom === "" ? Number.NaN : Number(rawFrom);
+  const to = rawTo === "" ? Number.NaN : Number(rawTo);
+  if (Number.isFinite(from) && Number.isFinite(to) && from > 0 && to > from) {
     const clampedFrom = Math.max(from, to - 366 * 24 * HOUR);
     return { from: clampedFrom, to: Math.max(to, clampedFrom + 60_000), window: "custom" };
   }
@@ -230,8 +234,6 @@ export async function getMonitorMetrics(
   // span that states no kind and carries no tool calls of its own - it is the weakest of the
   // three rules that used to live here, and it misattributes any span that happens to share a
   // tool's name. The classifier (core/trace/spanKind.ts) is consulted first.
-  const toolNames = new Set<string>();
-  for (const row of filtered) for (const tc of toolCallList(row.toolCalls)) toolNames.add(tc.name);
 
   const pricingModels = await listPortabilityModels(db);
   const pricingById = new Map<string, PortabilityModel>();
@@ -293,12 +295,6 @@ export async function getMonitorMetrics(
       bucket.spansTool++;
     } else if (kind === "retrieval") {
       bucket.spansRetrieval++;
-    } else if (kind === "chain" && row.parentSpanId && toolNames.has(row.name)) {
-      // The name set really is a LAST resort now (see its comment): only a span the classifier
-      // could say nothing about ("chain") falls back to name matching. It previously overrode
-      // stated retrieval/memory kinds AND disagreed with rollups.ts, so the same span counted
-      // as retrieval on the unfiltered dashboard and as tool the moment a filter was applied.
-      bucket.spansTool++;
     } else {
       // "memory" (and every other minor kind) deliberately counts as other for now - the
       // bucket columns are wire shape, and a dedicated memory metric belongs to the memory

--- a/engine/src/core/monitor/onlineEvaluators.ts
+++ b/engine/src/core/monitor/onlineEvaluators.ts
@@ -3,7 +3,7 @@ import { and, eq } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import { scoreAgainstCriteria, DEFAULT_JUDGE_PROMPT, DEFAULT_JUDGE_MODEL } from "../evaluate/judge.js";
 import { matchesAgentScope, passesSampleRate } from "./routing.js";
-import { recordEvent, listEventsSince } from "./events.js";
+import { countJudgeSpendSince, recordEvent, listEventsSince } from "./events.js";
 import { upsertSignal } from "./signals.js";
 import {
   cloneEvaluationSettings,
@@ -333,19 +333,12 @@ export async function reserveOnlineJudgeCall(db: Db): Promise<boolean> {
     let entry = onlineJudgeSpend.get(key);
     if (!entry || entry.day !== day) {
       const midnight = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-      const rows = await listEventsSince(db, midnight);
-      // Approximate judge calls made today: per-trace and per-session evaluator verdicts and
-      // failures, plus scorer-group JUDGE member verdicts (their patternKey embeds the member
-      // kind - pattern/custom members cost no judge call and are excluded). Restart-resistant:
-      // without the group terms, a mid-day restart re-seeded 0 and handed the cap out twice.
-      const spent = rows.filter(
-        r =>
-          (r.onlineEvaluatorId &&
-            (r.type === "online_eval_score" ||
-              r.type === "online_eval_judge_failure" ||
-              r.type === "online_eval_session_score")) ||
-          (r.type === "scorer_group_member_score" && r.patternKey.includes(":judge:"))
-      ).length;
+      // Approximate judge calls made today, counted in SQL (countJudgeSpendSince mirrors this
+      // seed's predicate): evaluator verdicts and failures (trace and session), group JUDGE
+      // member verdicts, and group judge-member failures. Pattern/custom members cost no judge
+      // call and are excluded. Restart-resistant: without the group terms, a mid-day restart
+      // re-seeded 0 and handed the cap out twice.
+      const spent = await countJudgeSpendSince(db, midnight);
       entry = { day, count: spent };
       onlineJudgeSpend.set(key, entry);
     }

--- a/engine/src/core/monitor/outcomeCalibration.ts
+++ b/engine/src/core/monitor/outcomeCalibration.ts
@@ -1,4 +1,4 @@
-import { eq, gte, and, inArray } from "drizzle-orm";
+import { desc, eq, gte, and, inArray } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import type { MonitoringWindow } from "./events.js";
 import type { OutcomeReportRow } from "../outcomes/outcomeReports.js";
@@ -140,8 +140,8 @@ export async function getJudgeCalibration(db: Db, window: MonitoringWindow): Pro
   const cond = and(gte(db.schema.outcomeReports.reportedAt, since), eq(db.schema.outcomeReports.projectId, db.projectId));
   const reports = (
     db.kind === "sqlite"
-      ? db.db.select().from(db.schema.outcomeReports).where(cond).limit(50_000).all()
-      : await db.db.select().from(db.schema.outcomeReports).where(cond).limit(50_000)
+      ? db.db.select().from(db.schema.outcomeReports).where(cond).orderBy(desc(db.schema.outcomeReports.reportedAt)).limit(50_000).all()
+      : await db.db.select().from(db.schema.outcomeReports).where(cond).orderBy(desc(db.schema.outcomeReports.reportedAt)).limit(50_000)
   ) as OutcomeReportRow[];
 
   let noVerdict = 0;
@@ -180,9 +180,16 @@ export async function getJudgeCalibration(db: Db, window: MonitoringWindow): Pro
   );
   const reviewLabels = (
     db.kind === "sqlite"
-      ? db.db.select().from(db.schema.reviewQueueItems).where(reviewCond).limit(50_000).all()
-      : await db.db.select().from(db.schema.reviewQueueItems).where(reviewCond).limit(50_000)
-  ) as { traceId: string; label: string | null }[];
+      // Newest first, THEN capped: an unordered LIMIT keeps arbitrary rows, so the newest
+      // re-review could fall outside the fetched set and a superseded label would win.
+      ? db.db.select().from(db.schema.reviewQueueItems).where(reviewCond).orderBy(desc(db.schema.reviewQueueItems.reviewedAt)).limit(50_000).all()
+      : await db.db.select().from(db.schema.reviewQueueItems).where(reviewCond).orderBy(desc(db.schema.reviewQueueItems.reviewedAt)).limit(50_000)
+  ) as { traceId: string; label: string | null; reviewedAt: Date | null }[];
+  // Deterministic order: a bare SELECT's row order is unspecified, and "whichever row happened
+  // to come back first" used to decide which of two labels on the same trace was tallied.
+  // Sorted ascending so the per-trace loop below lands on the LATEST label - the same
+  // latest-reviewedAt-wins keying judgeTuning's calibration evidence uses.
+  reviewLabels.sort((a, b) => (a.reviewedAt?.getTime() ?? 0) - (b.reviewedAt?.getTime() ?? 0));
 
   const eventsByTrace = await listEventsByTrace(db, [
     ...new Set([
@@ -210,13 +217,21 @@ export async function getJudgeCalibration(db: Db, window: MonitoringWindow): Pro
     tally(await resolveAgentxVerdict(db, report, eventsByTrace), report.isNegative);
   }
 
-  let reviewLabelCount = 0;
+  // One label per trace, LATEST reviewedAt wins (the ascending sort above makes the last write
+  // the newest) - a re-review supersedes the earlier verdict, matching judgeTuning.ts's
+  // latest-wins keying. Outcome reports still outrank sampled labels: talliedTraces already
+  // holds every report-covered trace by the time this runs.
+  const latestLabelByTrace = new Map<string, "good" | "bad">();
   for (const item of reviewLabels) {
     if (item.label !== "good" && item.label !== "bad") continue;
-    if (talliedTraces.has(item.traceId)) continue;
-    talliedTraces.add(item.traceId);
+    latestLabelByTrace.set(item.traceId, item.label);
+  }
+  let reviewLabelCount = 0;
+  for (const [traceId, label] of latestLabelByTrace) {
+    if (talliedTraces.has(traceId)) continue;
+    talliedTraces.add(traceId);
     reviewLabelCount++;
-    tally(await resolveAgentxVerdict(db, { traceId: item.traceId } as OutcomeReportRow, eventsByTrace), item.label === "bad");
+    tally(await resolveAgentxVerdict(db, { traceId } as OutcomeReportRow, eventsByTrace), label === "bad");
   }
 
   const comparedCount = truePositive + trueNegative + falsePositive + falseNegative;

--- a/engine/src/core/monitor/scorerGroups.ts
+++ b/engine/src/core/monitor/scorerGroups.ts
@@ -259,6 +259,21 @@ const GATE_FLOOR = 0.5;
 // produces NO score - renormalizing the survivors would report a confident blend computed
 // from a recipe the operator never configured.
 export const BUDGET_EXHAUSTED_ERROR = "Online judge budget exhausted";
+export const SCORER_MISSING_ERROR = "Scorer no longer exists";
+
+// Judge members that RESERVED a budget slot and then failed to score - the spend happened, so
+// the restart-time budget seed must see a failure event for each. Members that never reserved
+// (deleted ref, budget refusal itself) are excluded; both callers share this one definition so
+// the two scopes cannot drift apart again.
+export function spentFailedJudgeMembers(members: MemberScore[]): MemberScore[] {
+  return members.filter(
+    m =>
+      m.kind === "judge" &&
+      m.goodness === null &&
+      m.error !== SCORER_MISSING_ERROR &&
+      m.error !== BUDGET_EXHAUSTED_ERROR
+  );
+}
 
 export function aggregateGroupScore(members: MemberScore[]): { score: number | null; gatedBy: string | null } {
   const gated = members.find(m => m.gate && m.goodness !== null && m.goodness < GATE_FLOOR);
@@ -337,7 +352,7 @@ async function scoreJudgeMember(
   const base = { kind: member.kind, refId: member.refId, weight: member.weight, gate: member.gate };
   const settings = await getEvaluationSettingsRow(db, member.refId);
   if (!settings) {
-    return { ...base, name: member.refId, goodness: null, detail: "-", error: "Scorer no longer exists" };
+    return { ...base, name: member.refId, goodness: null, detail: "-", error: SCORER_MISSING_ERROR };
   }
   const name = settings.name ?? member.refId;
   // Lazily, per call actually made - see BUDGET_EXHAUSTED_ERROR's comment.
@@ -505,6 +520,23 @@ export async function runScorerGroupsOnline(
         },
         { reserveOnlineBudget: true }
       );
+      // Judge members that reserved a slot and failed still SPENT the call - recorded before
+      // the score-null bail below, because a full judge outage is exactly the case where the
+      // aggregate is null and exactly the spend the restart-time budget seed must not miss.
+      for (const member of spentFailedJudgeMembers(result.members)) {
+        await recordEvent(db, {
+          signalId: null,
+          patternKey: `scorer-group:${group.id}:judge:${member.refId}`,
+          type: "online_eval_judge_failure",
+          severity: "low",
+          polarity: "score",
+          agentId: ctx.agentId,
+          traceId: ctx.traceId,
+          onlineEvaluatorId: null,
+          rating: null,
+          justification: member.error ?? "Judge member failed",
+        });
+      }
       if (result.score === null) continue;
       const justification = describeGroupScore(result, result.members);
 

--- a/engine/src/core/monitor/scriptScorer.ts
+++ b/engine/src/core/monitor/scriptScorer.ts
@@ -40,12 +40,10 @@ export type ScriptScorerResult = {
   error?: string;
 };
 
-// What a scorer sees per span: the trace-detail wire fields plus a derived `type`, classified
-// from what the span actually recorded (heuristic, documented in the dialog placeholder):
-//   "llm" - a model is recorded on the span
-//   "tool" - tool calls are recorded (and no model)
-//   "retrieval" - metadata.kind === "retrieval" (the SDK's retrieval-span marker)
-//   "span" - anything else
+// What a scorer sees per span: the trace-detail wire fields plus a derived `type` - the
+// engine-wide span kind (core/trace/spanKind.ts): a stated span_kind wins, else the fallback
+// ladder ("llm" for a span with a model, "tool" for recorded tool calls, "retrieval"/"memory"
+// from the kind marker or name, "chain" for anything else).
 export type ScorerSpan = {
   span_id: string | null;
   parent_span_id: string | null;
@@ -134,14 +132,17 @@ export async function loadScorerSpans(db: Db, traceId: string | null): Promise<S
     span_id: (span.spanId ?? span.span_id ?? null) as string | null,
     parent_span_id: (span.parentSpanId ?? span.parent_span_id ?? null) as string | null,
     name: String(span.name ?? ""),
-    type: ((): string => {
-      const metadata = span.metadata as { kind?: unknown } | null | undefined;
-      if (metadata && metadata.kind === "retrieval") return "retrieval";
-      if (span.model) return "llm";
-      const calls = span.toolCalls ?? span.tool_calls;
-      if (Array.isArray(calls) && calls.length > 0) return "tool";
-      return "span";
-    })(),
+    // The ONE classifier (core/trace/spanKind.ts) - this used to be a second, pre-unification
+    // ladder that ignored the stated spanKind and emitted the retired word "span", so one
+    // spans[] array handed to a scorer mixed two vocabularies depending on tree position.
+    type: resolveSpanKind({
+      spanKind: span.spanKind ?? span.span_kind,
+      metadata: span.metadata,
+      name: (span.name ?? null) as string | null,
+      model: (span.model ?? null) as string | null,
+      toolCalls: span.toolCalls ?? span.tool_calls,
+      parentSpanId: (span.parentSpanId ?? span.parent_span_id ?? null) as string | null,
+    }),
     input: span.input ?? null,
     output: span.output ?? null,
     error: (span.error ?? null) as string | null,

--- a/engine/src/core/monitor/sessionScores.ts
+++ b/engine/src/core/monitor/sessionScores.ts
@@ -49,11 +49,18 @@ function buildSpanLine(span: SpanWire, index: number, includeToolLines = true): 
   const output = span.output !== undefined ? truncate(extractText(span.output), MAX_TEXT_PER_SPAN) : "";
   if (input) parts.push(`  input: ${input}`);
   // toolContext="none": the judge sees the conversation, not the plumbing.
-  if (includeToolLines && Array.isArray(span.toolCalls) && span.toolCalls.length > 0) {
-    const names = span.toolCalls
-      .map(t => (t && typeof t === "object" && "name" in t ? String((t as { name: unknown }).name) : "unknown"))
-      .join(", ");
-    parts.push(`  tools called: ${names}`);
+  if (includeToolLines && Array.isArray(span.toolCalls)) {
+    // The ingest cap's {"agentx.truncated": true} marker is bookkeeping, not a call - rendered
+    // as "unknown" it invited "called an unknown tool" findings from the session judge.
+    const realCalls = span.toolCalls.filter(
+      t => !(t && typeof t === "object" && (t as Record<string, unknown>)["agentx.truncated"] === true)
+    );
+    if (realCalls.length > 0) {
+      const names = realCalls
+        .map(t => (t && typeof t === "object" && "name" in t ? String((t as { name: unknown }).name) : "unknown"))
+        .join(", ");
+      parts.push(`  tools called: ${names}`);
+    }
   }
   if (output) parts.push(`  output: ${output}`);
   if (span.error) parts.push(`  ERROR: ${truncate(span.error, MAX_TEXT_PER_SPAN)}`);

--- a/engine/src/core/monitor/sessionSweep.ts
+++ b/engine/src/core/monitor/sessionSweep.ts
@@ -25,9 +25,11 @@ import {
   scoreCustomMember,
   aggregateGroupScore,
   BUDGET_EXHAUSTED_ERROR,
+  spentFailedJudgeMembers,
   describeGroupScore,
   type MemberScore,
   type ScorerGroupRow,
+  SCORER_MISSING_ERROR,
 } from "./scorerGroups.js";
 import { reserveOnlineJudgeCall } from "./onlineEvaluators.js";
 import { getProfileRow } from "./profiles.js";
@@ -413,7 +415,7 @@ export async function scoreSessionWithGroup(
     if (member.kind === "judge") {
       const settings = await getEvaluationSettingsRow(db, member.refId);
       if (!settings) {
-        members.push({ ...base, name: member.refId, goodness: null, detail: "-", error: "Scorer no longer exists" });
+        members.push({ ...base, name: member.refId, goodness: null, detail: "-", error: SCORER_MISSING_ERROR });
         continue;
       }
       const name = settings.name ?? member.refId;
@@ -497,19 +499,33 @@ function passesSessionSample(sessionId: string, scorerId: string, rate: number):
 // stuck sessions cannot starve every healthy one. In-process on purpose - a restart retrying
 // sooner is harmless; the map exists only to stop steady-state starvation.
 const RETRY_BACKOFF_MS = 10 * 60_000;
-const failedAttempts = new Map<string, number>();
+const MAX_BACKOFF_ENTRIES = 50_000;
+const failedAttempts = new Map<string, { first: number; last: number }>();
 const attemptKey = (projectId: string | null, patternKey: string, sessionId: string) =>
   `${projectId ?? ""}|${patternKey}|${sessionId}`;
 const inBackoff = (key: string): boolean => {
-  const last = failedAttempts.get(key);
-  return last !== undefined && Date.now() - last < RETRY_BACKOFF_MS;
+  const entry = failedAttempts.get(key);
+  return entry !== undefined && Date.now() - entry.last < RETRY_BACKOFF_MS;
 };
-// Entries for permanently-failing pairs would otherwise accumulate forever; anything older
-// than a day is no longer backing anything off and can go.
+const recordFailedAttempt = (key: string): void => {
+  const now = Date.now();
+  const entry = failedAttempts.get(key);
+  failedAttempts.set(key, { first: entry?.first ?? now, last: now });
+  if (failedAttempts.size > MAX_BACKOFF_ENTRIES) {
+    // Hard cap: evict the oldest insertion (Map iteration order) rather than growing without
+    // bound on an operator-widened 30d candidate window full of stuck sessions.
+    const oldest = failedAttempts.keys().next().value;
+    if (oldest !== undefined) failedAttempts.delete(oldest);
+  }
+};
+// Evict on FIRST-seen age: a pair that keeps failing refreshes `last` every backoff interval,
+// so a last-failure cutoff never fires while the session stays in the candidate window - the
+// entry would live as long as the failure does. A day after the first failure it goes
+// regardless; if the pair is still failing, re-adding one entry per day is free.
 function purgeStaleBackoffs(): void {
   const cutoff = Date.now() - 24 * 60 * 60_000;
-  for (const [key, ts] of failedAttempts) {
-    if (ts < cutoff) failedAttempts.delete(key);
+  for (const [key, entry] of failedAttempts) {
+    if (entry.first < cutoff) failedAttempts.delete(key);
   }
 }
 
@@ -525,7 +541,9 @@ export async function sweepSessionsOnce(options: { projectId?: string | null } =
   const allProjects = options.projectId ? listed.filter(project => project.id === options.projectId) : listed;
   // Rotate the starting project each tick so the shared MAX_JUDGED_PER_SWEEP budget reaches
   // every project over time instead of being eaten by whichever lists first.
-  const offset = allProjects.length > 0 ? sweepTick++ % allProjects.length : 0;
+  // The rotation cursor belongs to the instance-wide interval tick - a project-scoped manual
+  // sweep advancing it would bias which projects the shared budget reaches.
+  const offset = options.projectId ? 0 : allProjects.length > 0 ? sweepTick++ % allProjects.length : 0;
   const projects = [...allProjects.slice(offset), ...allProjects.slice(0, offset)];
   let judged = 0;
 
@@ -573,6 +591,11 @@ export async function sweepSessionsOnce(options: { projectId?: string | null } =
         if (!passesSessionSample(session.sessionId, evaluator.id, evaluator.sampleRate)) continue;
         const retryKey = attemptKey(db.projectId, kind, session.sessionId);
         if (inBackoff(retryKey)) continue;
+        // One budget slot per session judging, same pool as trace-scope scoring and group
+        // members - without this the sweep judged for free while the restart seed COUNTED its
+        // events, so a restart double-charged the day in the other direction. The explicit
+        // per-session Re-run route stays unmetered (a human click, like the playground).
+        if (!(await reserveOnlineJudgeCall(db))) continue;
 
         // Count the ATTEMPT, not the verdict: judge spend happens whether or not a usable
         // rating comes back, and a cap that only counts successes is unbounded during an
@@ -583,7 +606,7 @@ export async function sweepSessionsOnce(options: { projectId?: string | null } =
           if (!verdict) {
             // No spans (pruned mid-tick) - back off like any failed attempt so the race
             // cannot consume a tick slot every 60s.
-            failedAttempts.set(retryKey, Date.now());
+            recordFailedAttempt(retryKey);
             continue;
           }
           if (verdict.rating === null) {
@@ -606,7 +629,7 @@ export async function sweepSessionsOnce(options: { projectId?: string | null } =
               justification: "Judge returned no usable verdict for this session",
               sessionId: session.sessionId,
             });
-            failedAttempts.set(retryKey, Date.now());
+            recordFailedAttempt(retryKey);
             continue;
           }
           failedAttempts.delete(retryKey);
@@ -681,7 +704,7 @@ export async function sweepSessionsOnce(options: { projectId?: string | null } =
         } catch (err) {
           // Isolated per session+evaluator, same posture as every other detector loop - one
           // failing judge call (missing key, provider outage) never blocks the rest of the sweep.
-          failedAttempts.set(retryKey, Date.now());
+          recordFailedAttempt(retryKey);
           logger.error(
             { err },
             `Session sweep: evaluator "${evaluator.name}" failed on session ${session.sessionId}`
@@ -709,8 +732,28 @@ export async function sweepSessionsOnce(options: { projectId?: string | null } =
         try {
           const result = await scoreSessionWithGroup(db, group, session.sessionId);
           if (!result) {
-            failedAttempts.set(retryKey, Date.now());
+            recordFailedAttempt(retryKey);
             continue;
+          }
+          // Judge members that reserved a slot and failed still SPENT the call - recorded
+          // before the score-null bail below, because a full judge outage is exactly the case
+          // where the aggregate is null and exactly the spend the restart-time budget seed
+          // must not miss. Members that never reserved (deleted ref, budget refusal) are
+          // excluded by the shared helper.
+          for (const member of spentFailedJudgeMembers(result.members)) {
+            await recordEvent(db, {
+              signalId: null,
+              patternKey: `${kind}:judge:${member.refId}`,
+              type: "online_eval_judge_failure",
+              severity: "low",
+              polarity: "score",
+              agentId: session.agentId,
+              traceId: result.anchorTraceId,
+              onlineEvaluatorId: null,
+              rating: null,
+              justification: member.error ?? "Judge member failed",
+              sessionId: session.sessionId,
+            });
           }
           if (result.score === null) {
             // No member produced a score (judge outage, deleted refs). Same posture as the
@@ -731,7 +774,7 @@ export async function sweepSessionsOnce(options: { projectId?: string | null } =
               justification: result.justification,
               sessionId: session.sessionId,
             });
-            failedAttempts.set(retryKey, Date.now());
+            recordFailedAttempt(retryKey);
             continue;
           }
           failedAttempts.delete(retryKey);
@@ -803,7 +846,7 @@ export async function sweepSessionsOnce(options: { projectId?: string | null } =
             });
           }
         } catch (err) {
-          failedAttempts.set(retryKey, Date.now());
+          recordFailedAttempt(retryKey);
           logger.error(
             { err },
             `Session sweep: scorer group "${group.name}" failed on session ${session.sessionId}`
@@ -818,20 +861,31 @@ export async function sweepSessionsOnce(options: { projectId?: string | null } =
 }
 
 let sweepTimer: NodeJS.Timeout | null = null;
-let sweeping = false;
+// In-flight sweep scopes. "*" is the interval's whole-instance sweep and conflicts with
+// everything; a project id conflicts only with itself - so project A's manual sweep never
+// tells project B "skipped". The global tick DOES defer while any manual sweep runs (third
+// clause below): a whole-instance pass would double-judge the very project a manual sweep is
+// mid-way through, and the tick retries in 60s anyway. The narrow race where the tick wins
+// the lease and then finds a just-started manual sweep abandons that lease; it self-heals
+// because the holder id can re-take its own lease next tick.
+const sweepingScopes = new Set<string>();
+const GLOBAL_SWEEP = "*";
+const scopeConflicts = (scope: string): boolean =>
+  sweepingScopes.has(GLOBAL_SWEEP) || sweepingScopes.has(scope) || (scope === GLOBAL_SWEEP && sweepingScopes.size > 0);
 
-// The route's entry point: scoped to one project, and serialized against both the interval
-// sweep and other manual invocations - N concurrent sweeps all pass the freshness check
-// before any inserts, judging the same sessions N times on the caller's bill.
+// The route's entry point: scoped to one project, and serialized against the interval sweep
+// and same-project manual invocations - N concurrent sweeps of one project all pass the
+// freshness check before any inserts, judging the same sessions N times on the caller's bill.
 export async function runManualSweep(projectId: string | null): Promise<{ judged: number; skipped?: boolean }> {
-  if (sweeping) {
+  const scope = projectId ?? GLOBAL_SWEEP;
+  if (scopeConflicts(scope)) {
     return { judged: 0, skipped: true };
   }
-  sweeping = true;
+  sweepingScopes.add(scope);
   try {
     return await sweepSessionsOnce({ projectId });
   } finally {
-    sweeping = false;
+    sweepingScopes.delete(scope);
   }
 }
 
@@ -842,18 +896,21 @@ export function startSessionSweep(): void {
     return;
   }
   sweepTimer = setInterval(() => {
-    if (sweeping) return; // a slow judge round must not stack a second concurrent sweep
-    sweeping = true;
-    // The lease is the cross-REPLICA version of the `sweeping` flag above: N engines sharing one
-    // database elect one sweeper per tick instead of all judging the same idle sessions. TTL
-    // covers a worst-case round (MAX_JUDGED_PER_SWEEP slow judge calls) so a crashed holder's
-    // lease times out on its own. The manual /session-sweep/run route bypasses this on purpose.
+    if (scopeConflicts(GLOBAL_SWEEP)) return; // a slow round must not stack a second sweep
+    // The lease is the cross-REPLICA guard: N engines sharing one database elect one sweeper
+    // per tick instead of all judging the same idle sessions. TTL covers a worst-case round so
+    // a crashed holder's lease times out on its own. The scope is claimed only AFTER the lease
+    // is won - claiming before it meant a lost-lease tick still refused manual sweeps for its
+    // duration. The manual route bypasses the lease on purpose (single-project, user-invoked).
     acquireSweepLease(getDb(), "session-sweep", 5 * 60_000)
-      .then(acquired => (acquired ? sweepSessionsOnce() : null))
-      .catch((err: unknown) => logger.error({ err }, "Session sweep failed"))
-      .finally(() => {
-        sweeping = false;
-      });
+      .then(acquired => {
+        if (!acquired || scopeConflicts(GLOBAL_SWEEP)) return null;
+        sweepingScopes.add(GLOBAL_SWEEP);
+        return sweepSessionsOnce().finally(() => {
+          sweepingScopes.delete(GLOBAL_SWEEP);
+        });
+      })
+      .catch((err: unknown) => logger.error({ err }, "Session sweep failed"));
   }, SWEEP_INTERVAL_MS);
   // Never keep the process alive just for the sweep - Ctrl+C shuts down cleanly without an
   // explicit clearInterval in the signal handler.

--- a/engine/src/core/settings/appSettings.ts
+++ b/engine/src/core/settings/appSettings.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import type { Db } from "../../storage/db.js";
 import { isMultiTenant } from "../../auth/mode.js";
 import { currentTenancy } from "../../auth/requestContext.js";
+import { maskSecret } from "../shared/maskSecret.js";
 
 // LLM provider keys. Single-tenant modes use one instance-wide row ("default"). Multi-tenant
 // (AGENTX_MULTI_TENANT=true, the cloud posture) resolves a per-organization row instead -
@@ -38,6 +39,16 @@ export async function consolidateAppSettingsSingleton(db: Db): Promise<void> {
       : await db.db.select().from(db.schema.appSettings)
   ) as Array<Record<string, unknown> & { id: string }>;
   const pretenders = rows.filter(r => r.id !== "default" && !r.id.startsWith("org:"));
+  // A legacy shared "org:none" sentinel row (written before orgless writes were refused) is
+  // unowned cross-tenant state - never merged anywhere, only removed.
+  const orgNone = rows.find(r => r.id === "org:none");
+  if (orgNone) {
+    if (db.kind === "sqlite") {
+      db.db.delete(db.schema.appSettings).where(eq(db.schema.appSettings.id, "org:none")).run();
+    } else {
+      await db.db.delete(db.schema.appSettings).where(eq(db.schema.appSettings.id, "org:none"));
+    }
+  }
   if (pretenders.length === 0) return;
   const existingDefault = rows.find(r => r.id === "default");
   const FLAGS = [
@@ -48,6 +59,11 @@ export async function consolidateAppSettingsSingleton(db: Db): Promise<void> {
     "openaiApiKey",
     "anthropicApiKey",
     "geminiApiKey",
+    // Every key/selection column must be here: consolidation DELETES the pretender rows, so a
+    // column missing from this list is silently destroyed (openrouter keys and the platform
+    // model were lost exactly this way before these two lines existed).
+    "openrouterApiKey",
+    "platformModel",
   ] as const;
   const merged: Record<string, unknown> = { ...(existingDefault ?? { id: "default", updatedAt: new Date() }) };
   for (const pretender of pretenders) {
@@ -107,6 +123,16 @@ export async function getAppSettings(db: Db): Promise<AppSettings> {
 
 // Empty string is treated the same as clearing the key (not stored as "", which a later
 // `if (key)` truthiness check would still treat as falsy-but-present - nicer to just store null).
+// Thrown when a multi-tenant request with no organization tries to WRITE provider keys: the
+// read path fails closed (the "org:none" sentinel matches no real row), but a write used to
+// CREATE that sentinel row - one shared key row that every orgless tenant then read and
+// billed against, leaking the first writer's key to the rest. Routes map this to a 409.
+export class OrglessSettingsWriteError extends Error {
+  constructor() {
+    super("Claim this project into an organization before configuring LLM keys.");
+  }
+}
+
 export async function updateAppSettings(
   db: Db,
   patch: {
@@ -117,12 +143,21 @@ export async function updateAppSettings(
     platformModel?: string | null;
   }
 ): Promise<AppSettings> {
+  if (isMultiTenant() && !currentTenancy().organizationId) {
+    throw new OrglessSettingsWriteError();
+  }
   const existing = await getRow(db);
+  // The GET returns keys as maskSecret(key); the settings form round-trips the whole object,
+  // so an untouched field arrives as that exact masked string. Storing it would replace the
+  // real key with its 11-character display form - every judge call then 401s at the provider
+  // while "configured" still reads true. An echo of the CURRENT key's mask means "unchanged".
+  const keepIfMaskedEcho = (incoming: string | null | undefined, stored: string | null | undefined) =>
+    incoming && stored && incoming === maskSecret(stored) ? stored : incoming || null;
   const next: AppSettings = {
-    openaiApiKey: "openaiApiKey" in patch ? patch.openaiApiKey || null : (existing?.openaiApiKey ?? null),
-    anthropicApiKey: "anthropicApiKey" in patch ? patch.anthropicApiKey || null : (existing?.anthropicApiKey ?? null),
-    geminiApiKey: "geminiApiKey" in patch ? patch.geminiApiKey || null : (existing?.geminiApiKey ?? null),
-    openrouterApiKey: "openrouterApiKey" in patch ? patch.openrouterApiKey || null : (existing?.openrouterApiKey ?? null),
+    openaiApiKey: "openaiApiKey" in patch ? keepIfMaskedEcho(patch.openaiApiKey, existing?.openaiApiKey) : (existing?.openaiApiKey ?? null),
+    anthropicApiKey: "anthropicApiKey" in patch ? keepIfMaskedEcho(patch.anthropicApiKey, existing?.anthropicApiKey) : (existing?.anthropicApiKey ?? null),
+    geminiApiKey: "geminiApiKey" in patch ? keepIfMaskedEcho(patch.geminiApiKey, existing?.geminiApiKey) : (existing?.geminiApiKey ?? null),
+    openrouterApiKey: "openrouterApiKey" in patch ? keepIfMaskedEcho(patch.openrouterApiKey, existing?.openrouterApiKey) : (existing?.openrouterApiKey ?? null),
     platformModel: "platformModel" in patch ? patch.platformModel || null : (existing?.platformModel ?? null),
   };
   const row = { id: settingsRowId(), ...next, updatedAt: new Date() };

--- a/engine/src/core/shared/traceQuota.ts
+++ b/engine/src/core/shared/traceQuota.ts
@@ -1,0 +1,39 @@
+import type { Db } from "../../storage/db.js";
+import { traceStoreFor } from "../trace/store/index.js";
+
+// Serialized daily root-trace reservation, the trace-side sibling of
+// onlineEvaluators.ts's reserveOnlineJudgeCall. A bare check-then-act against the store let N
+// concurrent exporters all read 9,900/10,000 and land 5,000 roots past the cap - the exact
+// burst a per-day quota exists for. The counter is in-process per project, seeded once per
+// UTC day from the store's own root count (same UTC boundary as the judge budget, so the two
+// caps release together instead of hours apart across timezones).
+//
+// Deliberate slack, documented rather than hidden: a reservation is spent even if the insert
+// later dedupes or fails, and multiple replicas each hold their own counter seeded from the
+// shared store - so the cap is enforced per replica between seeds. Both err toward admitting
+// slightly FEWER traces than the cap, never more per process.
+const rootSpend = new Map<string, { day: string; count: number }>();
+let reservationChain: Promise<void> = Promise.resolve();
+
+export async function reserveTraceRoots(db: Db, roots: number, quota: number): Promise<boolean> {
+  if (roots <= 0) return true;
+  let granted = false;
+  const reserve = async () => {
+    const now = new Date();
+    const day = now.toISOString().slice(0, 10);
+    const key = db.projectId ?? "";
+    let entry = rootSpend.get(key);
+    if (!entry || entry.day !== day) {
+      const utcMidnight = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+      const used = await traceStoreFor(db).countRoots(utcMidnight);
+      entry = { day, count: used };
+      rootSpend.set(key, entry);
+    }
+    if (entry.count + roots > quota) return;
+    entry.count += roots;
+    granted = true;
+  };
+  reservationChain = reservationChain.then(reserve, reserve);
+  await reservationChain;
+  return granted;
+}

--- a/engine/src/core/shared/usage.ts
+++ b/engine/src/core/shared/usage.ts
@@ -1,4 +1,6 @@
-import { and, eq, gte, sql } from "drizzle-orm";
+import { and, eq, gte, isNull, sql } from "drizzle-orm";
+import { traceStoreFor } from "../trace/store/index.js";
+import { countJudgeSpendSince } from "../monitor/events.js";
 import { nanoid } from "nanoid";
 import { getDb, type Db } from "../../storage/db.js";
 import { currentTenancy } from "../../auth/requestContext.js";
@@ -20,13 +22,19 @@ export class QuotaExceededError extends Error {
 }
 
 function dayStart(): Date {
+  // UTC, matching the online-judge budget's boundary (onlineEvaluators.ts) - two daily caps
+  // releasing hours apart on non-UTC hosts read as one being stuck.
   const now = new Date();
-  now.setHours(0, 0, 0, 0);
-  return now;
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
 }
 
 function judgeQuota(): number | null {
   const raw = Number(process.env.AGENTX_QUOTA_JUDGE_CALLS_PER_DAY || 0);
+  return raw > 0 ? raw : null;
+}
+
+function onlineJudgeQuota(): number | null {
+  const raw = Number(process.env.AGENTX_QUOTA_ONLINE_JUDGE_CALLS_PER_DAY || 0);
   return raw > 0 ? raw : null;
 }
 
@@ -35,10 +43,18 @@ export function traceQuota(): number | null {
   return raw > 0 ? raw : null;
 }
 
-async function countJudgeCallsToday(db: Db, organizationId: string | null): Promise<number> {
+// `scope` null = whole instance (single-tenant); otherwise the count is confined to that
+// organization's rows - and an orgless multi-tenant request (a bare project key with no
+// organization) counts only the other orgless rows via IS NULL, rather than omitting the
+// predicate and metering one project's traffic against every tenant's combined spend.
+async function countJudgeCallsToday(db: Db, scope: { organizationId: string | null } | null): Promise<number> {
   const conditions = [eq(db.schema.usageEvents.kind, "judge_call"), gte(db.schema.usageEvents.createdAt, dayStart())];
-  if (organizationId) {
-    conditions.push(eq(db.schema.usageEvents.organizationId, organizationId));
+  if (scope) {
+    conditions.push(
+      scope.organizationId
+        ? eq(db.schema.usageEvents.organizationId, scope.organizationId)
+        : isNull(db.schema.usageEvents.organizationId)
+    );
   }
   const cond = and(...conditions);
   const rows =
@@ -72,12 +88,15 @@ export async function checkAndRecordJudgeCall(model: string | null): Promise<voi
   const { organizationId = null, projectId = null } = currentTenancy();
   const quota = judgeQuota();
   if (quota !== null) {
-    const scopeOrg = isMultiTenant() ? organizationId : null;
-    const used = await countJudgeCallsToday(db, scopeOrg);
+    const multiTenant = isMultiTenant();
+    const used = await countJudgeCallsToday(db, multiTenant ? { organizationId } : null);
     if (used >= quota) {
+      // Orgless multi-tenant requests are counted against the orgless bucket, not the whole
+      // instance - so the message says "project", not "organization".
+      const scopeNote = multiTenant ? (organizationId ? " for this organization" : " for this project") : "";
       throw new QuotaExceededError(
-        `Daily judge-call quota reached (${quota}/day${isMultiTenant() ? " for this organization" : ""}). ` +
-          "Quota resets at midnight; raise AGENTX_QUOTA_JUDGE_CALLS_PER_DAY to change the ceiling."
+        `Daily judge-call quota reached (${quota}/day${scopeNote}). ` +
+          "Quota resets at midnight UTC; raise AGENTX_QUOTA_JUDGE_CALLS_PER_DAY to change the ceiling."
       );
     }
   }
@@ -97,6 +116,38 @@ export async function checkAndRecordJudgeCall(model: string | null): Promise<voi
 }
 
 // Admin overview helper: per-org judge calls in the trailing 24h.
+// The read-only "Usage & limits" wire (Platform Settings card + GET /agent-monitoring/usage):
+// today's spend against each daily cap, computed by the SAME counters the enforcement paths
+// seed from - the card can never disagree with the thing that actually says no. Limits are
+// env-configured (unset = unlimited = null); editing them stays a deployment decision on
+// purpose - these are cost-control levers, not per-user settings.
+export type UsageAndLimits = {
+  day: string;
+  resetsAt: string;
+  traces: { used: number; limit: number | null };
+  onlineJudgeCalls: { used: number; limit: number | null };
+  judgeCalls: { used: number; limit: number | null };
+};
+
+export async function getUsageAndLimits(db: Db): Promise<UsageAndLimits> {
+  const start = dayStart();
+  const resetsAt = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+  const multiTenant = isMultiTenant();
+  const { organizationId = null } = currentTenancy();
+  const [tracesUsed, onlineUsed, judgeUsed] = await Promise.all([
+    traceStoreFor(db).countRoots(start),
+    countJudgeSpendSince(db, start),
+    countJudgeCallsToday(db, multiTenant ? { organizationId } : null),
+  ]);
+  return {
+    day: start.toISOString().slice(0, 10),
+    resetsAt: resetsAt.toISOString(),
+    traces: { used: tracesUsed, limit: traceQuota() },
+    onlineJudgeCalls: { used: onlineUsed, limit: onlineJudgeQuota() },
+    judgeCalls: { used: judgeUsed, limit: judgeQuota() },
+  };
+}
+
 export async function judgeCallsSince(db: Db, since: Date): Promise<Map<string | null, number>> {
   const cond = and(eq(db.schema.usageEvents.kind, "judge_call"), gte(db.schema.usageEvents.createdAt, since));
   // Grouped count in SQL: an instance doing millions of judge calls a day must not ship every

--- a/engine/src/core/trace/ingest.ts
+++ b/engine/src/core/trace/ingest.ts
@@ -151,7 +151,14 @@ export function capPayloadField(value: unknown): unknown {
     }
     return [...kept, { "agentx.truncated": true, dropped: value.length - kept.length }];
   }
-  return { "agentx.truncated": true, preview: serialized.slice(0, MAX_FIELD_CHARS) };
+  // Preserve a legacy metadata.kind statement through truncation - resolveSpanKind reads it,
+  // and losing it silently reclassified pre-column retrieval spans to "chain" (dropping them
+  // from the RAG judges' {context}).
+  const statedKind =
+    value && typeof value === "object" && typeof (value as { kind?: unknown }).kind === "string"
+      ? { kind: (value as { kind: string }).kind }
+      : {};
+  return { "agentx.truncated": true, ...statedKind, preview: serialized.slice(0, MAX_FIELD_CHARS) };
 }
 
 // Platform label (the platform-agnostic tracing story): producers send any string - an SDK

--- a/engine/src/core/trace/spanKind.test.ts
+++ b/engine/src/core/trace/spanKind.test.ts
@@ -106,6 +106,10 @@ describe("memory span kind", () => {
   it("memory is NOT retrieval: recalled state never feeds the RAG judges' {context}", () => {
     expect(isRetrievalSpan({ spanKind: "memory" })).toBe(false);
     expect(isRetrievalSpan({ name: "Memory recall" })).toBe(false);
+    // A memory op wearing a retrieval verb classifies as memory, matching the alias table.
+    expect(resolveSpanKind({ name: "retrieve_memories" })).toBe("memory");
+    expect(isRetrievalSpan({ name: "retrieval_of_user_memories" })).toBe(false);
+    expect(resolveSpanKind({ name: "retrieve_documents" })).toBe("retrieval");
   });
 });
 

--- a/engine/src/core/trace/spanKind.ts
+++ b/engine/src/core/trace/spanKind.ts
@@ -78,7 +78,10 @@ const ALIASES: Record<string, SpanKind> = {
   add_memory: "memory",
   get_memory: "memory",
   recall: "memory",
-  // MLflow's own vocabulary for the rest.
+  // MLflow's own vocabulary for the rest (CHAT_MODEL is its chat-model span type); OTel's
+  // GenAI semconv adds generate_content for Gemini/Vertex instrumentation.
+  chat_model: "llm",
+  generate_content: "llm",
   llm: "llm",
   parser: "chain",
   // LangSmith's "chain" and MLflow's "CHAIN"/"UNKNOWN" are both "some step in the middle".
@@ -132,7 +135,12 @@ export function resolveSpanKind(span: SpanKindInput): SpanKind {
   // integrations emit, and the Execution Timeline depended on that literal string until now.
   const name = span.name ?? "";
   if (/^llm call/i.test(name)) return "llm";
-  if (/^retriev/i.test(name)) return "retrieval";
+  // "retrieve_memories" is a MEMORY op wearing a retrieval verb - the alias table already
+  // folds memory_retrieval onto memory, and the name ladder must agree, or recalled user
+  // state rides into the RAG judges' {context} via isRetrievalSpan. Word-matched, not
+  // stem-matched: "Retrieval: memoranda index" is a knowledge lookup whose chunks must NOT
+  // be silently dropped from {context}.
+  if (/^retriev/i.test(name)) return /memor(y|ies)/i.test(name) ? "memory" : "retrieval";
   if (/^memory/i.test(name)) return "memory";
   // Everything else is a step in the middle. Note this is where the timeline used to say "tool",
   // which is how an unrecognized span got drawn as a tool call it never was.
@@ -154,6 +162,9 @@ export const toolCallList = (raw: unknown): { name: string; failed: boolean }[] 
   if (!Array.isArray(raw)) return [];
   return raw
     .filter((tc): tc is Record<string, unknown> => !!tc && typeof tc === "object")
+    // The ingest cap appends an {"agentx.truncated": true, dropped: n} marker into oversized
+    // arrays - it is bookkeeping, not a successful call to a tool named "tool".
+    .filter(tc => tc["agentx.truncated"] !== true)
     .map(tc => ({
       name: typeof tc.name === "string" ? tc.name : "tool",
       failed: tc.success === false,

--- a/engine/src/core/trace/store/sqlTraceStore.ts
+++ b/engine/src/core/trace/store/sqlTraceStore.ts
@@ -141,8 +141,8 @@ export class SqlTraceStore implements TraceStore {
     // arbitrary subset - callers sort again, but they can only sort what they received.
     const rows =
       db.kind === "sqlite"
-        ? db.db.select().from(db.schema.traces).where(cond).orderBy(asc(db.schema.traces.createdAt)).limit(5000).all()
-        : await db.db.select().from(db.schema.traces).where(cond).orderBy(asc(db.schema.traces.createdAt)).limit(5000);
+        ? db.db.select().from(db.schema.traces).where(cond).orderBy(asc(db.schema.traces.createdAt), asc(db.schema.traces.startedAt)).limit(5000).all()
+        : await db.db.select().from(db.schema.traces).where(cond).orderBy(asc(db.schema.traces.createdAt), asc(db.schema.traces.startedAt)).limit(5000);
     return rows as TraceRow[];
   }
 

--- a/engine/src/core/trace/trajectory.test.ts
+++ b/engine/src/core/trace/trajectory.test.ts
@@ -47,3 +47,28 @@ describe("matchTrajectory", () => {
     expect(matchTrajectory(["a"], [], "strict").reasoning).toContain("no tool calls");
   });
 });
+
+describe("truncation marker exclusion", () => {
+  it("the ingest cap's bookkeeping row is not a tool named 'unknown'", async () => {
+    // extractTraceToolSequence consumers score subset/strict checks - a marker row mapped to
+    // "unknown" failed every one of them on large traces. Simulate the stored shape directly.
+    const calls = [
+      { name: "search", success: true },
+      { "agentx.truncated": true, dropped: 40 },
+    ] as Record<string, unknown>[];
+    const names = calls.filter(tc => tc["agentx.truncated"] !== true).map(tc => String(tc.name ?? "unknown"));
+    expect(names).toEqual(["search"]);
+  });
+
+  it("an empty expected list is vacuously true under superset, and requires an empty actual elsewhere", () => {
+    // Regression: a caller-side special case used to fail superset whenever the agent called
+    // any tool at all - an explicitly-unconstrained assertion scored 0 on every result.
+    expect(matchTrajectory([], ["search", "send"], "superset").matched).toBe(true);
+    expect(matchTrajectory([], [], "superset").matched).toBe(true);
+    expect(matchTrajectory([], ["search"], "strict").matched).toBe(false);
+    expect(matchTrajectory([], [], "strict").matched).toBe(true);
+    expect(matchTrajectory([], ["search"], "unordered").matched).toBe(false);
+    expect(matchTrajectory([], ["search"], "subset").matched).toBe(false);
+  });
+});
+

--- a/engine/src/core/trace/trajectory.ts
+++ b/engine/src/core/trace/trajectory.ts
@@ -138,7 +138,11 @@ export async function extractTraceToolSequence(db: Db, traceId: string): Promise
   const root = (await traceStoreFor(db).getById(traceId)) as { toolCalls: unknown } | undefined;
   if (!root) return null;
   if (!Array.isArray(root.toolCalls)) return [];
-  return (root.toolCalls as { name?: unknown }[]).map(tc => String(tc.name ?? "unknown"));
+  // The ingest cap's {"agentx.truncated": true} marker is bookkeeping, not a call - mapped to
+  // "unknown" it failed every subset/strict trajectory check on large traces.
+  return (root.toolCalls as Record<string, unknown>[])
+    .filter(tc => tc["agentx.truncated"] !== true)
+    .map(tc => String(tc.name ?? "unknown"));
 }
 
 function normalizeNames(names: string[]): string[] {

--- a/engine/src/otel/attributes.test.ts
+++ b/engine/src/otel/attributes.test.ts
@@ -108,6 +108,22 @@ describe("keyValueListToRecord", () => {
     ).toEqual({ dup: "second" });
   });
 
+  it("treats a wire attribute named __proto__ as an ordinary own key", () => {
+    // On a plain object this key would rewire the record's prototype instead of landing as data;
+    // the null-prototype record keeps it inert.
+    const record = keyValueListToRecord([
+      { key: "__proto__", value: { stringValue: "evil" } },
+      { key: "constructor", value: { stringValue: "also-data" } },
+      { key: "gen_ai.request.model", value: { stringValue: "gpt-4o" } },
+    ]);
+    expect(record["__proto__"]).toBe("evil");
+    expect(record["constructor"]).toBe("also-data");
+    expect(record["gen_ai.request.model"]).toBe("gpt-4o");
+    expect(Object.keys(record).sort()).toEqual(["__proto__", "constructor", "gen_ai.request.model"]);
+    // The global Object prototype is untouched.
+    expect(({} as Record<string, unknown>).evil).toBeUndefined();
+  });
+
   it("tolerates a null entry in the list", () => {
     expect(() => keyValueListToRecord([null as never, { key: "k", value: { stringValue: "v" } }])).not.toThrow();
     expect(keyValueListToRecord([null as never, { key: "k", value: { stringValue: "v" } }])).toEqual({ k: "v" });

--- a/engine/src/otel/attributes.ts
+++ b/engine/src/otel/attributes.ts
@@ -49,7 +49,11 @@ export function anyValueToJs(av: WireAnyValue | undefined): unknown {
 }
 
 export function keyValueListToRecord(kvs: WireKeyValue[] | undefined): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
+  // Null prototype: attribute keys are caller-controlled wire data, and on a plain object a key
+  // named "__proto__" would not become an own property - it would silently rewire the record's
+  // prototype (or be dropped), shadowing every later lookup. With no prototype at all, every
+  // key is just a key.
+  const out: Record<string, unknown> = Object.create(null);
   for (const kv of kvs ?? []) {
     if (typeof kv?.key === "string") {
       out[kv.key] = anyValueToJs(kv.value);

--- a/engine/src/otel/mapping.test.ts
+++ b/engine/src/otel/mapping.test.ts
@@ -209,6 +209,41 @@ describe("reconstructParentToolCalls", () => {
     expect(outer.tool_calls).toEqual(call("outer"));
   });
 
+  it("folds a tool span nested under another tool span into the non-tool root above both", () => {
+    const root: IngestTraceInput = { name: "agent", span_id: "root" };
+    const outer: IngestTraceInput = { name: "outer", span_id: "outer", parent_span_id: "root", tool_calls: call("outer") };
+    const inner: IngestTraceInput = { name: "inner", span_id: "inner", parent_span_id: "outer", tool_calls: call("inner") };
+
+    reconstructParentToolCalls([root, outer, inner]);
+
+    expect(root.tool_calls).toEqual([...call("outer"), ...call("inner")]);
+    expect(outer.tool_calls).toEqual(call("outer"));
+  });
+
+  it("falls back to the nearest non-tool ancestor when the topmost reachable span is a tool", () => {
+    // The batch's top is itself a tool span (its own parent arrived in an earlier export):
+    // the nested tool's call used to fold nowhere - now it lands on the non-tool span between.
+    const topTool: IngestTraceInput = { name: "top", span_id: "top", tool_calls: call("top") };
+    const mid: IngestTraceInput = { name: "llm", span_id: "mid", parent_span_id: "top" };
+    const inner: IngestTraceInput = { name: "inner", span_id: "inner", parent_span_id: "mid", tool_calls: call("inner") };
+
+    reconstructParentToolCalls([topTool, mid, inner]);
+
+    expect(mid.tool_calls).toEqual(call("inner"));
+    expect(topTool.tool_calls).toEqual(call("top"));
+  });
+
+  it("still folds nowhere when every reachable ancestor is a tool span", () => {
+    const topTool: IngestTraceInput = { name: "top", span_id: "top", tool_calls: call("top") };
+    const midTool: IngestTraceInput = { name: "mid", span_id: "mid", parent_span_id: "top", tool_calls: call("mid") };
+    const inner: IngestTraceInput = { name: "inner", span_id: "inner", parent_span_id: "mid", tool_calls: call("inner") };
+
+    reconstructParentToolCalls([topTool, midTool, inner]);
+
+    expect(topTool.tool_calls).toEqual([...call("top")]);
+    expect(midTool.tool_calls).toEqual(call("mid"));
+  });
+
   it("terminates on a parent cycle instead of looping forever", () => {
     const a: IngestTraceInput = { name: "a", span_id: "a", parent_span_id: "b" };
     const b: IngestTraceInput = { name: "b", span_id: "b", parent_span_id: "a" };

--- a/engine/src/otel/mapping.ts
+++ b/engine/src/otel/mapping.ts
@@ -309,7 +309,8 @@ export function otelSpanToIngestInput(span: NormalizedSpan): IngestTraceInput {
 }
 
 // Second pass over a mapped batch: fold each tool-call span's one-element tool_calls summary up
-// into its ROOT ancestor within the batch - the root, specifically, because that's the one span
+// into its ROOT ancestor within the batch (or, when that top is itself a tool span, the nearest
+// non-tool ancestor) - the root, specifically, because that's the one span
 // Monitor checks (child spans are skipped by default, see routes/otlp.ts) and the one the
 // dashboard's Tool quality column and Tool Schema evidence gathering read, the same place the
 // SDK's trace_tool_call dual-writes its flat summary. This is what makes all three work for OTel
@@ -329,20 +330,29 @@ export function reconstructParentToolCalls(candidates: IngestTraceInput[]): void
     bySpanId.set(candidate.span_id, candidate);
     if (candidate.tool_calls && candidate.tool_calls.length > 0) toolSpanIds.add(candidate.span_id);
   }
+  const isToolSpan = (s: IngestTraceInput | undefined): boolean => Boolean(s?.span_id && toolSpanIds.has(s.span_id));
   for (const candidate of candidates) {
     if (!candidate.span_id || !toolSpanIds.has(candidate.span_id) || !candidate.parent_span_id) continue;
     // Walk to the topmost ancestor reachable within the batch, cycle-guarded; a missing parent
-    // ends the walk at the highest span that did arrive.
+    // ends the walk at the highest span that did arrive. Along the way, remember the NEAREST
+    // non-tool ancestor: when the topmost reachable ancestor is itself a tool span (a tool
+    // nested under another tool at the top of what arrived), the call folds there instead of
+    // nowhere - previously such a span's call vanished from the flat summary entirely.
     let top = bySpanId.get(candidate.parent_span_id);
+    let nearestNonTool = isToolSpan(top) ? undefined : top;
     const visited = new Set<string>([candidate.span_id]);
     while (top?.parent_span_id && top.span_id && !visited.has(top.span_id)) {
       visited.add(top.span_id);
       const next = bySpanId.get(top.parent_span_id);
       if (!next) break;
       top = next;
+      if (!nearestNonTool && !isToolSpan(top)) nearestNonTool = top;
     }
-    if (!top || top === candidate) continue;
-    if (top.span_id && toolSpanIds.has(top.span_id)) continue;
-    top.tool_calls = [...(top.tool_calls ?? []), ...candidate.tool_calls!.map(call => ({ ...call }))];
+    // Never fold one tool span into another: the topmost non-tool target wins (the span Monitor
+    // checks), falling back to the nearest non-tool ancestor when the top is a tool span. A
+    // chain that is tool spans all the way up folds nowhere.
+    const target = isToolSpan(top) ? nearestNonTool : top;
+    if (!target || target === candidate) continue;
+    target.tool_calls = [...(target.tool_calls ?? []), ...candidate.tool_calls!.map(call => ({ ...call }))];
   }
 }

--- a/engine/src/otel/normalize.ts
+++ b/engine/src/otel/normalize.ts
@@ -32,7 +32,10 @@ function idToHex(value: unknown): string | null {
     return null;
   }
   if ((value.length === 32 || value.length === 16) && /^[0-9a-fA-F]+$/.test(value)) {
-    return value.toLowerCase();
+    // All-zero is OTLP's encoding of "no id" (several producers emit it explicitly for "no
+    // parent"). Accepting it made every root span a child instance-wide - empty Live Traces,
+    // zeroed rollups - and folded unrelated traffic into one "000...0" session.
+    return /^0+$/.test(value) ? null : value.toLowerCase();
   }
   // Strict base64 charset check before decoding: Buffer.from silently skips invalid characters,
   // so a garbage id would decode to garbage hex instead of being rejected as no id at all.
@@ -43,7 +46,8 @@ function idToHex(value: unknown): string | null {
   if (!/^[A-Za-z0-9+/]+={0,2}$/.test(standard)) {
     return null;
   }
-  return Buffer.from(standard, "base64").toString("hex");
+  const hex = Buffer.from(standard, "base64").toString("hex");
+  return /^0+$/.test(hex) ? null : hex;
 }
 
 // A handful of real-world JSON producers emit snake_case (the literal .proto field names) instead

--- a/engine/src/routes/agentMonitoringDashboard.ts
+++ b/engine/src/routes/agentMonitoringDashboard.ts
@@ -1,4 +1,5 @@
 import rateLimitMiddleware from "express-rate-limit";
+import { getUsageAndLimits } from "../core/shared/usage.js";
 import type { Request, Response } from "express";
 import { asyncRouter } from "./asyncRouter.js";
 import { getDb, type Db } from "../storage/db.js";
@@ -101,7 +102,7 @@ import {
   deletePortabilityModel,
   testCustomModelConnection,
 } from "../core/evaluate/models.js";
-import { getAppSettings, updateAppSettings } from "../core/settings/appSettings.js";
+import { OrglessSettingsWriteError, getAppSettings, updateAppSettings } from "../core/settings/appSettings.js";
 import { getModelCatalog } from "../core/settings/modelCatalog.js";
 import { DEFAULT_JUDGE_MODEL } from "../core/evaluate/judge.js";
 import {
@@ -699,6 +700,13 @@ agentMonitoringDashboardRouter.get("/sessions", async (req: Request, res: Respon
 // Manual trigger for the idle-session sweep (core/monitor/sessionSweep.ts) - the production path
 // is the 60s interval started at boot; this exists for tests and demos that shouldn't have to
 // wait a tick.
+// Read-only usage vs. the daily caps (Platform Settings' "Usage & limits" card). Computed by
+// the same counters the enforcement paths seed from - see core/shared/usage.ts. Limits are
+// env-configured and deliberately NOT writable here.
+agentMonitoringDashboardRouter.get("/usage", async (req: Request, res: Response) => {
+  res.status(200).json(await getUsageAndLimits(scopedDb(req)));
+});
+
 agentMonitoringDashboardRouter.post("/session-sweep/run", async (req: Request, res: Response) => {
   // Scoped to the caller's project (a key must not spend other tenants' budgets) and
   // serialized - a concurrent sweep returns { judged: 0, skipped: true } instead of
@@ -741,6 +749,22 @@ agentMonitoringDashboardRouter.get("/online-evaluators", async (req: Request, re
   res.status(200).json({ evaluators });
 });
 
+// The legacy online-evaluator routes write the same row the judge-scorer online section does,
+// and were the one entry point still passing sampleRate/severity/idleSeconds through as bare
+// casts - idleSeconds: 1 (or "abc" as a sampleRate) went straight to the sweep. Same bounds as
+// judgeScorerOnlineSchema; kept separate because this body mixes in name/evaluationSettingsId.
+const onlineEvaluatorBodySchema = z
+  .object({
+    sampleRate: z.number().min(0).max(1).optional(),
+    scopeMode: z.enum(["all", "selected"]).optional(),
+    enabled: z.boolean().optional(),
+    alertThreshold: z.number().min(0).max(10).nullable().optional(),
+    severity: z.enum(["low", "medium", "high", "critical"]).optional(),
+    scope: z.enum(["trace", "session"]).optional(),
+    idleSeconds: z.number().int().min(0).max(86400).optional(),
+  })
+  .strip();
+
 agentMonitoringDashboardRouter.post("/online-evaluators", async (req: Request, res: Response) => {
   const body = req.body ?? {};
   if (typeof body.name !== "string" || !body.name.trim()) {
@@ -751,18 +775,23 @@ agentMonitoringDashboardRouter.post("/online-evaluators", async (req: Request, r
     res.status(400).json({ error: "evaluationSettingsId is required" });
     return;
   }
+  const parsedOnline = onlineEvaluatorBodySchema.safeParse(body);
+  if (!parsedOnline.success) {
+    res.status(400).json({ error: parsedOnline.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ") });
+    return;
+  }
   try {
     const evaluator = await createOnlineEvaluator(scopedDb(req), {
       name: body.name,
       evaluationSettingsId: body.evaluationSettingsId,
-      sampleRate: body.sampleRate,
-      scopeMode: body.scopeMode,
+      sampleRate: parsedOnline.data.sampleRate,
+      scopeMode: parsedOnline.data.scopeMode,
       agentIds: await resolveAgentIds(scopedDb(req), body.agentIds),
-      enabled: body.enabled,
-      alertThreshold: body.alertThreshold,
-      severity: body.severity,
-      scope: typeof body.scope === "string" ? body.scope : undefined,
-      idleSeconds: typeof body.idleSeconds === "number" ? body.idleSeconds : undefined,
+      enabled: parsedOnline.data.enabled,
+      alertThreshold: parsedOnline.data.alertThreshold,
+      severity: parsedOnline.data.severity,
+      scope: parsedOnline.data.scope,
+      idleSeconds: parsedOnline.data.idleSeconds,
     });
     res.status(201).json({ evaluator });
   } catch (err) {
@@ -784,18 +813,23 @@ agentMonitoringDashboardRouter.put("/online-evaluators/:evaluatorId", async (req
     res.status(400).json({ error: "evaluationSettingsId must be a non-empty string" });
     return;
   }
+  const parsedOnline = onlineEvaluatorBodySchema.safeParse(body);
+  if (!parsedOnline.success) {
+    res.status(400).json({ error: parsedOnline.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ") });
+    return;
+  }
   try {
     const evaluator = await updateOnlineEvaluator(scopedDb(req), req.params.evaluatorId!, {
       name: body.name,
       evaluationSettingsId: body.evaluationSettingsId,
-      sampleRate: body.sampleRate,
-      scopeMode: body.scopeMode,
+      sampleRate: parsedOnline.data.sampleRate,
+      scopeMode: parsedOnline.data.scopeMode,
       agentIds: await resolveAgentIds(scopedDb(req), body.agentIds),
-      enabled: body.enabled,
-      alertThreshold: body.alertThreshold,
-      severity: body.severity,
-      scope: typeof body.scope === "string" ? body.scope : undefined,
-      idleSeconds: typeof body.idleSeconds === "number" ? body.idleSeconds : undefined,
+      enabled: parsedOnline.data.enabled,
+      alertThreshold: parsedOnline.data.alertThreshold,
+      severity: parsedOnline.data.severity,
+      scope: parsedOnline.data.scope,
+      idleSeconds: parsedOnline.data.idleSeconds,
     });
     if (!evaluator) {
       res.status(404).json({ error: "Online evaluator not found" });
@@ -832,12 +866,33 @@ agentMonitoringDashboardRouter.delete("/online-evaluators/:evaluatorId", async (
 // client.monitor.judge_scorers use. camelCase only, per the project's wire convention.
 // ---------------------------------------------------------------------------
 
-function parseOnlineSection(body: Record<string, unknown>): { ok: true; online: JudgeScorerOnlineInput | null | undefined } | { ok: false } {
+// Validated like the scorer-group online schema below - a bare cast let idleSeconds: 1 (or
+// 10000000) straight through to the sweep, re-judging conversations after a second of quiet
+// on the operator's own LLM key.
+const judgeScorerOnlineSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    sampleRate: z.number().min(0).max(1).optional(),
+    scopeMode: z.enum(["all", "selected"]).optional(),
+    agentIds: z.array(z.string().min(1).max(200)).max(200).optional(),
+    alertThreshold: z.number().min(0).max(10).nullable().optional(),
+    severity: z.enum(["low", "medium", "high", "critical"]).optional(),
+    scope: z.enum(["trace", "session"]).optional(),
+    // Floor 0, matching the scorer-group schema: idleSeconds delays the FIRST judging after
+    // quiet, and the freshness check already guarantees at most one judging per new activity -
+    // 0 means "score as soon as the sweep sees it idle", the demo/test posture, not a flood.
+    idleSeconds: z.number().int().min(0).max(86400).optional(),
+  })
+  .strip();
+
+function parseOnlineSection(body: Record<string, unknown>): { ok: true; online: JudgeScorerOnlineInput | null | undefined } | { ok: false; error?: string } {
   const online = body.online;
   if (online === undefined) return { ok: true, online: undefined };
   if (online === null) return { ok: true, online: null };
   if (typeof online !== "object" || Array.isArray(online)) return { ok: false };
-  return { ok: true, online: online as JudgeScorerOnlineInput };
+  const parsed = judgeScorerOnlineSchema.safeParse(online);
+  if (!parsed.success) return { ok: false, error: parsed.error.issues[0]?.message };
+  return { ok: true, online: parsed.data as JudgeScorerOnlineInput };
 }
 
 // ---- Scorer groups (core/monitor/scorerGroups.ts) --------------------------------------------
@@ -1133,7 +1188,10 @@ agentMonitoringDashboardRouter.delete(
 
 // Generates the report - one real LLM call over the group's evidence, so this is explicit and
 // billed, never implicit.
-const generateReportSchema = z.object({ model: z.string().min(1).optional() }).strict();
+// .strip(), not .strict(): validateBody's own contract is that unknown keys are stripped so
+// legacy/pinning clients keep working - the SDK sends workspaceId on every body it posts, and
+// this was the one schema in the codebase that hard-400ed on it.
+const generateReportSchema = z.object({ model: z.string().min(1).optional() }).strip();
 
 agentMonitoringDashboardRouter.post(
   "/improvement-groups/:id/report",
@@ -1844,7 +1902,12 @@ agentMonitoringDashboardRouter.post("/portability/models", async (req: Request, 
     res.status(409).json({ error: `A model with id "${body.id}" already exists` });
     return;
   }
-  const model = await createPortabilityModel(scopedDb(req), {
+  // Model ids are one global namespace (primary key across tenants), but the list above is
+  // tenant-filtered - a cross-tenant clash used to die on the raw PK violation as a 500 that
+  // also confirmed the id existed elsewhere. Catch it and answer the same neutral 409.
+  let model;
+  try {
+    model = await createPortabilityModel(scopedDb(req), {
     id: body.id,
     provider: body.provider,
     label: body.label,
@@ -1856,6 +1919,13 @@ agentMonitoringDashboardRouter.post("/portability/models", async (req: Request, 
     baseUrl: typeof body.baseUrl === "string" ? body.baseUrl : null,
     apiKey: typeof body.apiKey === "string" ? body.apiKey : null,
   });
+  } catch (err) {
+    if (err instanceof Error && /unique|constraint|duplicate/i.test(err.message)) {
+      res.status(409).json({ error: `A model with id "${body.id}" already exists` });
+      return;
+    }
+    throw err;
+  }
   res.status(201).json({ model });
 });
 
@@ -2038,7 +2108,16 @@ agentMonitoringDashboardRouter.put("/settings/llm-keys", async (req: Request, re
   if ("openrouterApiKey" in body) {
     patch.openrouterApiKey = typeof body.openrouterApiKey === "string" ? body.openrouterApiKey : null;
   }
-  const settings = await updateAppSettings(getDb(), patch);
+  let settings;
+  try {
+    settings = await updateAppSettings(getDb(), patch);
+  } catch (err) {
+    if (err instanceof OrglessSettingsWriteError) {
+      res.status(409).json({ error: err.message });
+      return;
+    }
+    throw err;
+  }
   res.status(200).json({
     llm: {
       openai: { configured: !!settings.openaiApiKey, masked: settings.openaiApiKey ? maskSecret(settings.openaiApiKey) : null },

--- a/engine/src/routes/auditTap.ts
+++ b/engine/src/routes/auditTap.ts
@@ -14,7 +14,7 @@ import { logger } from "../log.js";
 //    is bulk egress - GET /export/* is exactly what a security team wants in the log.
 //  - Values are NOT recorded: bodies carry scripts, keys, and passwords, so a mutation's
 //    summary keeps the field NAMES that were sent plus a human-recognizable `name`, never
-//    the values. The auth tap keeps only the attempted email (the identity claim itself).
+//    the values. The auth tap records no body-derived fields at all (see auditAuthTap).
 //
 // Recording is fire-and-forget on 'finish': an audit failure never fails the request.
 
@@ -33,7 +33,6 @@ const TRANSIENT_MARKERS = [
   "/dry-run",
   "/generate-regex",
   "/coherence-check",
-  "/session-sweep",
   "/suggest-",
   "/estimate",
   "/test-connection",
@@ -189,8 +188,7 @@ export function auditControlPlaneTap(req: Request, res: Response, next: NextFunc
 }
 
 // Auth events: mounted BEFORE better-auth's handler (and before express.json - better-auth
-// reads the raw stream itself), so the body is sniffed passively from 'data' events, capped,
-// and only the attempted email is kept. Failed and successful attempts both land, with status.
+// reads the raw stream itself). Failed and successful attempts both land, with status.
 const AUTH_ACTIONS: [RegExp, string][] = [
   [/\/sign-in\b/, "auth.sign-in"],
   [/\/sign-up\b/, "auth.sign-up"],
@@ -207,35 +205,21 @@ export function auditAuthTap(req: Request, res: Response, next: NextFunction): v
     return;
   }
   const action = match[1];
-  let sniffed = "";
-  if (req.method === "POST") {
-    req.on("data", chunk => {
-      if (sniffed.length < 8192) {
-        sniffed += String(chunk);
-      }
-    });
-  }
+  // The request body is deliberately NOT read here, not even passively: better-auth consumes
+  // the raw stream itself, and attaching a 'data' listener flips the stream into flowing mode
+  // before better-auth gets to it - one middleware-ordering refactor away from draining the
+  // body and breaking sign-in instance-wide. The event therefore records without the attempted
+  // email; the attempt itself (action, status, ip, timing) is what the trail needs.
   res.on("finish", () => {
     void (async () => {
-      let email: string | null = null;
-      try {
-        const parsed = JSON.parse(sniffed || "{}");
-        if (typeof parsed.email === "string") {
-          email = parsed.email.slice(0, 200);
-        }
-      } catch {
-        // body wasn't JSON (or was truncated) - the event still records without an email
-      }
       await recordAuditEvent(getDb(), {
-        actor: email ?? "anonymous",
-        // A successful attempt with an email IS that user acting; anything else stays anonymous
-        // (failed attempts are the rows a security review reads most closely).
-        actorType: email && res.statusCode < 400 ? "user" : "anonymous",
+        actor: "anonymous",
+        actorType: "anonymous",
         action,
         method: req.method,
         path: req.originalUrl.split("?")[0] ?? req.path,
         status: res.statusCode,
-        summary: email ? { email } : null,
+        summary: null,
         ip: req.ip ?? null,
       });
     })().catch((err: unknown) => logger.error({ err }, "Auth audit tap failed (request unaffected)"));

--- a/engine/src/routes/evaluateDashboard.ts
+++ b/engine/src/routes/evaluateDashboard.ts
@@ -53,6 +53,7 @@ import {
 } from "../core/evaluate/runs.js";
 import {
   createAgentConnector,
+  hasMaskedHeaderValues,
   listAgentConnectorsWire,
   updateAgentConnector,
   deleteAgentConnector,
@@ -576,6 +577,12 @@ evaluateDashboardRouter.post("/agent-connectors", async (req: Request, res: Resp
   const headerProblem = connectorHeaderProblem(body.headers);
   if (headerProblem) {
     res.status(400).json({ error: headerProblem });
+    return;
+  }
+  if (hasMaskedHeaderValues(body.headers && typeof body.headers === "object" ? body.headers : null)) {
+    res.status(400).json({
+      error: "One or more header values look masked (\"abc...xyz\") - paste the real secret; masked placeholders only round-trip on update, where the stored original exists.",
+    });
     return;
   }
   const connector = await createAgentConnector(scopedDb(req), {

--- a/engine/src/routes/exportData.ts
+++ b/engine/src/routes/exportData.ts
@@ -24,12 +24,36 @@ import {
 // that could corrupt engine-owned invariants (dedupe, id uniqueness, derived agent rows).
 export const exportRouter = asyncRouter();
 
-exportRouter.get("/", async (req: Request, res: Response) => {
-  const db = scopedDb(req);
-  const entities = [];
-  for (const entity of Object.keys(EXPORT_ENTITIES) as ExportEntity[]) {
-    entities.push({ entity, rows: await countExportRows(db, entity), path: `/api/v1/export/${entity}` });
+// `?since=` parsing shared by both handlers. Returns undefined (after answering 400) when the
+// value is present but not a date.
+function parseSince(req: Request, res: Response): Date | null | undefined {
+  if (typeof req.query.since === "string" && req.query.since) {
+    const since = new Date(req.query.since);
+    if (Number.isNaN(since.getTime())) {
+      res.status(400).json({ error: "since must be an ISO-8601 date" });
+      return undefined;
+    }
+    return since;
   }
+  return null;
+}
+
+exportRouter.get("/", async (req: Request, res: Response) => {
+  // `?since=` works on the manifest too, so an incremental pull can see what a `?since=`
+  // stream will actually contain before fetching it.
+  const since = parseSince(req, res);
+  if (since === undefined) {
+    return;
+  }
+  const db = scopedDb(req);
+  // Counts are independent reads - run them concurrently rather than one entity at a time.
+  const entities = await Promise.all(
+    (Object.keys(EXPORT_ENTITIES) as ExportEntity[]).map(async entity => ({
+      entity,
+      rows: await countExportRows(db, entity, since),
+      path: `/api/v1/export/${entity}`,
+    }))
+  );
   res.status(200).json({ generatedAt: new Date().toISOString(), format: "ndjson", entities });
 });
 
@@ -39,13 +63,9 @@ exportRouter.get("/:entity", async (req: Request, res: Response) => {
     res.status(404).json({ error: `Unknown export entity "${entity}"`, entities: Object.keys(EXPORT_ENTITIES) });
     return;
   }
-  let since: Date | null = null;
-  if (typeof req.query.since === "string" && req.query.since) {
-    since = new Date(req.query.since);
-    if (Number.isNaN(since.getTime())) {
-      res.status(400).json({ error: "since must be an ISO-8601 date" });
-      return;
-    }
+  const since = parseSince(req, res);
+  if (since === undefined) {
+    return;
   }
   const db = scopedDb(req);
   res.status(200);

--- a/engine/src/routes/ingest.ts
+++ b/engine/src/routes/ingest.ts
@@ -12,13 +12,10 @@ import {
 import { runMonitorCheck } from "../core/monitor/detect.js";
 import { evaluateTraceAgainst } from "../core/evaluate/runs.js";
 import { traceQuota } from "../core/shared/usage.js";
+import { reserveTraceRoots } from "../core/shared/traceQuota.js";
 import type { Db } from "../storage/db.js";
 
-async function countTracesToday(db: Db): Promise<number> {
-  const dayStart = new Date();
-  dayStart.setHours(0, 0, 0, 0);
-  return traceStoreFor(db).countRoots(dayStart);
-}
+
 import { runOnlineEvaluators } from "../core/monitor/onlineEvaluators.js";
 import { traceStoreFor } from "../core/trace/store/index.js";
 import { runCustomEvaluators } from "../core/monitor/customEvaluators.js";
@@ -48,10 +45,11 @@ ingestRouter.post("/traces", async (req: Request, res: Response) => {
   // already-counted interaction ride free - the quota is about interactions, not tree size.
   const quota = traceQuota();
   if (quota !== null && !parsed.data.parent_span_id) {
-    const used = await countTracesToday(scopedDb(req));
-    if (used >= quota) {
+    // Reserved, not check-then-acted: concurrent ingests must not all read "one slot left"
+    // and each take it - see core/shared/traceQuota.ts.
+    if (!(await reserveTraceRoots(scopedDb(req), 1, quota))) {
       res.status(429).json({
-        error: `Daily trace quota reached (${quota}/day for this project). Quota resets at midnight; raise AGENTX_QUOTA_TRACES_PER_DAY to change the ceiling.`,
+        error: `Daily trace quota reached (${quota}/day for this project). Quota resets at midnight UTC; raise AGENTX_QUOTA_TRACES_PER_DAY to change the ceiling.`,
       });
       return;
     }

--- a/engine/src/routes/otlp.ts
+++ b/engine/src/routes/otlp.ts
@@ -1,9 +1,14 @@
 import type { Request, Response } from "express";
+import { reserveTraceRoots } from "../core/shared/traceQuota.js";
 import express from "express";
 import { asyncRouter } from "./asyncRouter.js";
 import { scopedDb } from "../auth/apiKey.js";
 import { ingestTraceSchema, beginIngestTraceQueued, type IngestTraceInput, type QueuedIngestResult } from "../core/trace/ingest.js";
 import { runMonitorCheck } from "../core/monitor/detect.js";
+import { traceQuota } from "../core/shared/usage.js";
+import { traceStoreFor } from "../core/trace/store/index.js";
+import type { Db } from "../storage/db.js";
+
 import { runOnlineEvaluators } from "../core/monitor/onlineEvaluators.js";
 import { runScorerGroupsOnline } from "../core/monitor/scorerGroups.js";
 import { runCustomEvaluators } from "../core/monitor/customEvaluators.js";
@@ -58,6 +63,29 @@ const MONITOR_CHILD_SPANS = process.env.AGENTX_MONITOR_CHILD_SPANS === "true";
 // before any span is processed, so a conforming exporter can split and resend without dupes.
 const MAX_SPANS_PER_EXPORT = 5000;
 
+// Counts spans straight off the parsed envelope, BEFORE normalizeExportRequest allocates a
+// NormalizedSpan (attributes record included) per span - materializing 100k spans just to
+// refuse them is exactly the amplification the cap exists to prevent. Handles both wire key
+// spellings, like the envelope check below; anything shaped too strangely to count here still
+// hits the post-normalize backstop.
+function countWireSpans(parsed: Record<string, unknown>): number {
+  const resourceSpans = parsed.resourceSpans ?? parsed.resource_spans;
+  if (!Array.isArray(resourceSpans)) return 0;
+  let n = 0;
+  for (const rs of resourceSpans) {
+    if (!rs || typeof rs !== "object") continue;
+    const rec = rs as Record<string, unknown>;
+    const scopeSpans = rec.scopeSpans ?? rec.scope_spans;
+    if (!Array.isArray(scopeSpans)) continue;
+    for (const ss of scopeSpans) {
+      if (!ss || typeof ss !== "object") continue;
+      const spans = (ss as Record<string, unknown>).spans;
+      if (Array.isArray(spans)) n += spans.length;
+    }
+  }
+  return n;
+}
+
 otlpRouter.post("/v1/traces", async (req: Request, res: Response) => {
   const isProtobuf = Boolean(req.is("application/x-protobuf"));
   // Any other content type leaves req.body an empty object, which reads here as a valid export of
@@ -107,7 +135,16 @@ otlpRouter.post("/v1/traces", async (req: Request, res: Response) => {
     res.status(400).json({ error: "body carried no resourceSpans - not an ExportTraceServiceRequest" });
     return;
   }
+  // Cap enforced on the raw envelope first, before normalization materializes anything.
+  const wireSpanCount = countWireSpans(parsed);
+  if (wireSpanCount > MAX_SPANS_PER_EXPORT) {
+    res.status(413).json({
+      error: `too many spans in one export (${wireSpanCount} > ${MAX_SPANS_PER_EXPORT}) - nothing was ingested, split the batch and resend`,
+    });
+    return;
+  }
   const spans = normalizeExportRequest(parsed);
+  // Backstop for envelope shapes countWireSpans couldn't walk.
   if (spans.length > MAX_SPANS_PER_EXPORT) {
     res.status(413).json({
       error: `too many spans in one export (${spans.length} > ${MAX_SPANS_PER_EXPORT}) - nothing was ingested, split the batch and resend`,
@@ -151,6 +188,25 @@ otlpRouter.post("/v1/traces", async (req: Request, res: Response) => {
     }
   }
   reconstructParentToolCalls(candidates);
+
+  // The daily trace quota applies to OTLP roots exactly as it does to SDK ingest - without
+  // this, AGENTX_QUOTA_TRACES_PER_DAY silently meant "SDK traffic only" and an OTel exporter
+  // walked past the cap. Counted once per export (root spans in this batch) and answered as
+  // 429, which OTLP/HTTP exporters treat as retryable-with-backoff.
+  const quota = traceQuota();
+  if (quota !== null) {
+    const incomingRoots = candidates.filter(c => !c.parent_span_id).length;
+    if (incomingRoots > 0) {
+      // Reserved, not check-then-acted - see core/shared/traceQuota.ts.
+      if (!(await reserveTraceRoots(scopedDb(req), incomingRoots, quota))) {
+        res.status(429).setHeader("Retry-After", "60");
+        res.json({
+          error: `Daily trace quota reached (${quota}/day for this project). Quota resets at midnight UTC; raise AGENTX_QUOTA_TRACES_PER_DAY to change the ceiling.`,
+        });
+        return;
+      }
+    }
+  }
 
   // Checked after the span durably lands (queued ingest, ADR-0005): a judge failure must
   // never break OTLP ingestion, and only conflict WINNERS run - an exporter retry that raced

--- a/engine/src/test/audit.integration.test.ts
+++ b/engine/src/test/audit.integration.test.ts
@@ -137,7 +137,7 @@ describe("who can read it, and that nobody can rewrite it", () => {
 });
 
 describe("auth events (enabled mode)", () => {
-  it("records sign-up and sign-in attempts with the attempted email, and failures too", async () => {
+  it("records sign-up and sign-in attempts (failures too) without reading the body", async () => {
     const authEngine = await startEngine({ AGENTX_AUTH: "enabled", AGENTX_ADMIN_TOKEN: ADMIN_TOKEN });
     try {
       const signUp = await authEngine.request("/api/v1/auth/sign-up/email", {
@@ -159,14 +159,16 @@ describe("auth events (enabled mode)", () => {
       const signUps = events.filter(e => e.action === "auth.sign-up");
       const signIns = events.filter(e => e.action === "auth.sign-in");
       expect(signUps.length).toBe(1);
-      expect(signUps[0]!.actor).toBe("owner@example.com");
-      expect(signUps[0]!.actorType).toBe("user");
+      expect(signUps[0]!.status).toBeLessThan(300);
       expect(signIns.length).toBe(1);
       expect(signIns[0]!.status).toBeGreaterThanOrEqual(400);
       expect(signIns[0]!.actorType).toBe("anonymous");
-      // The password must never appear anywhere in the trail.
+      // The auth tap must not read the request body at all (a 'data' listener would flip the
+      // stream into flowing mode under better-auth): no body-derived value - the email
+      // included - may appear anywhere in the trail.
       expect(JSON.stringify(events)).not.toContain("correct-horse-battery");
       expect(JSON.stringify(events)).not.toContain("wrong-password");
+      expect(JSON.stringify([...signUps, ...signIns])).not.toContain("owner@example.com");
     } finally {
       await authEngine.stop();
     }

--- a/engine/src/test/calibrationReviewLabels.test.ts
+++ b/engine/src/test/calibrationReviewLabels.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { nanoid } from "nanoid";
+import { openTestDb, type TestDb } from "./dbHarness.js";
+import { getJudgeCalibration } from "../core/monitor/outcomeCalibration.js";
+import type { Db } from "../storage/db.js";
+
+// Regression: a trace labeled twice in the review queue (a re-review) used to contribute
+// whichever row the database happened to return first - the agreement rate changed between
+// identical requests. The contract now: the LATEST reviewedAt label per trace wins, matching
+// judgeTuning's own latest-wins keying, regardless of row/insert order.
+
+let test: TestDb;
+let db: Db;
+
+const hoursAgo = (h: number) => new Date(Date.now() - h * 60 * 60 * 1000);
+
+async function insertRow(scoped: Db, table: unknown, values: Record<string, unknown>): Promise<void> {
+  if (scoped.kind === "sqlite") {
+    await scoped.db.insert(table as Parameters<typeof scoped.db.insert>[0]).values(values as never);
+  } else {
+    await scoped.db.insert(table as Parameters<typeof scoped.db.insert>[0]).values(values as never);
+  }
+}
+
+/** A failure-polarity monitor event with no evaluator ids: AgentX "flagged" this trace. */
+async function insertFlagEvent(scoped: Db, traceId: string): Promise<void> {
+  await insertRow(scoped, scoped.schema.monitorEvents, {
+    id: nanoid(),
+    projectId: scoped.projectId,
+    signalId: null,
+    patternKey: "trace-error",
+    type: "trace_error",
+    severity: "high",
+    polarity: "failure",
+    agentId: null,
+    traceId,
+    createdAt: hoursAgo(5),
+    onlineEvaluatorId: null,
+    rating: null,
+    justification: null,
+    customEvaluatorId: null,
+    matched: null,
+    score: null,
+    sessionId: null,
+  });
+}
+
+async function insertLabel(scoped: Db, traceId: string, label: "good" | "bad", reviewedAt: Date): Promise<void> {
+  await insertRow(scoped, scoped.schema.reviewQueueItems, {
+    id: nanoid(),
+    projectId: scoped.projectId,
+    traceId,
+    sessionId: null,
+    source: "manual",
+    status: "labeled",
+    label,
+    correctedScore: null,
+    judgeScoreAtQueue: null,
+    note: null,
+    reviewedBy: "tester",
+    reviewedAt,
+    createdAt: hoursAgo(6),
+  });
+}
+
+beforeAll(async () => {
+  test = await openTestDb();
+  db = test.scoped(await test.newProject("Calibration latest-label project"));
+}, 60_000);
+
+afterAll(async () => {
+  await test?.close();
+});
+
+describe("review-label calibration keying", () => {
+  it("tallies the LATEST label per trace, whatever order the rows were written in", async () => {
+    // Trace A: the stale "good" row is inserted FIRST (the order a first-row-wins bug tallies),
+    // then re-reviewed to "bad" later. AgentX flagged the trace, so the latest label agrees.
+    const traceA = nanoid();
+    await insertFlagEvent(db, traceA);
+    await insertLabel(db, traceA, "good", hoursAgo(4));
+    await insertLabel(db, traceA, "bad", hoursAgo(2));
+
+    // Trace B: same history, opposite insertion order - the result must be identical.
+    const traceB = nanoid();
+    await insertFlagEvent(db, traceB);
+    await insertLabel(db, traceB, "bad", hoursAgo(2));
+    await insertLabel(db, traceB, "good", hoursAgo(4));
+
+    const result = await getJudgeCalibration(db, "7d");
+    expect(result.reviewLabelCount).toBe(2);
+    expect(result.comparedCount).toBe(2);
+    // Both traces: flagged + latest label "bad" = agreement (true positive), deterministically.
+    expect(result.agreementRate).toBe(1);
+    expect(result.falsePositiveRate).toBe(0);
+  });
+});

--- a/engine/src/test/cloudOps.integration.test.ts
+++ b/engine/src/test/cloudOps.integration.test.ts
@@ -130,8 +130,18 @@ describe("quotas", () => {
   });
 
   it("caps judge calls per organization and names the quota in the error", async () => {
-    // Quota is 1: the first judge attempt records usage (then fails on the missing LLM key -
-    // fine, spend was committed either way); the second must be refused by the quota itself.
+    // The quota gate runs AFTER the key-resolution guards (a missing key must not burn quota
+    // on a call that never happens), so exercising the quota needs a judge call that gets past
+    // those guards: give Carol's org a present-but-invalid key. Quota is 1: the first attempt
+    // records usage, then fails at the provider (fine - spend was committed before the call);
+    // the second must be refused by the quota itself.
+    const setKey = await engine.request("/api/v1/agent-monitoring/settings/llm-keys", {
+      method: "PUT",
+      body: JSON.stringify({ openaiApiKey: "sk-test-invalid-key-for-quota-test" }),
+      headers: { "content-type": "application/json" },
+      apiKey: carolKey,
+    });
+    expect(setKey.status).toBe(200);
     await engine.json("/api/v1/agent-monitoring/patterns/generate-regex", {
       ...json({ description: "mentions a refund" }),
       apiKey: carolKey,

--- a/engine/src/test/judgeScorers.integration.test.ts
+++ b/engine/src/test/judgeScorers.integration.test.ts
@@ -515,3 +515,27 @@ describe("two grading modes: reference-centric rubrics are offline-only", () => 
     expect(wire.online).toBeNull();
   });
 });
+
+describe("legacy online-evaluator route validation", () => {
+  it("rejects out-of-bounds online fields instead of passing bare casts to the sweep", async () => {
+    // Regression: sampleRate "abc", severity "urgent", idleSeconds -5 all previously reached
+    // createOnlineEvaluator unvalidated - a sub-minute idle or NaN sample silently broke the
+    // sweep's spend controls.
+    const bads = [
+      { sampleRate: "abc" },
+      { severity: "urgent" },
+      { idleSeconds: -5 },
+      { idleSeconds: 1.5 },
+      { alertThreshold: 42 },
+      { scope: "conversation" },
+    ];
+    for (const bad of bads) {
+      const res = await api(
+        "/agent-monitoring/online-evaluators",
+        postJson({ name: "bad", evaluationSettingsId: "nope", ...bad })
+      );
+      expect(res.status, JSON.stringify(bad)).toBe(400);
+    }
+  });
+});
+

--- a/engine/src/test/monitorMetrics.integration.test.ts
+++ b/engine/src/test/monitorMetrics.integration.test.ts
@@ -129,3 +129,12 @@ describe("GET /agent-monitoring/metrics", () => {
     expect(past.facets.agents).toEqual([]);
   });
 });
+
+it("a blank ?from= falls back to the preset window instead of an epoch-0 year scan", async () => {
+  // Number("") is 0 (finite), which used to pass the custom-range guard and turn a cleared
+  // date picker into a 366-day window on every metrics poll.
+  const res = await api("/agent-monitoring/metrics?window=24h&from=&to=1757548800000");
+  expect(res.status).toBe(200);
+  expect((res.body as { window: string }).window).not.toBe("custom");
+});
+

--- a/engine/src/test/scorerGroups.integration.test.ts
+++ b/engine/src/test/scorerGroups.integration.test.ts
@@ -246,6 +246,33 @@ describe("scorer groups", () => {
     expect((after.body as { error: string }).error).toContain("scorer group");
   });
 
+  it("a grandfathered judge cannot ride an online-only PUT past the requiresExpected guard", async () => {
+    // A reference-centric judge (requiresExpected) is fine in an OFFLINE group; the PUT that
+    // newly enables live scoring must validate the STORED members, not just the body.
+    const refJudge = await api(
+      "/agent-monitoring/judge-scorers",
+      postJson({
+        name: "Reference-centric",
+        judge: { evaluationCriteria: "Judge with NICE.", judgeModel: "stub-judge-g", requiresExpected: true },
+      })
+    );
+    expect(refJudge.status).toBe(201);
+    const refId = (refJudge.body as { judgeScorer: { _id: string } }).judgeScorer._id;
+    const group = await api(
+      "/agent-monitoring/scorer-groups",
+      postJson({ name: "Offline ref group", members: [{ kind: "judge", refId, weight: 1 }] })
+    );
+    expect(group.status).toBe(201);
+    const groupId = (group.body as { scorerGroup: { _id: string } }).scorerGroup._id;
+
+    const goLive = await api(`/agent-monitoring/scorer-groups/${groupId}`, {
+      ...postJson({ online: { enabled: true, sampleRate: 1, alertThreshold: 5, severity: "high" } }),
+      method: "PUT",
+    });
+    expect(goLive.status).toBe(400);
+    expect((goLive.body as { error: string }).error).toContain("requiresExpected");
+  });
+
   it("grades a dataset run: weighted blend in the rating column, member verdicts per row", async () => {
     const kindId = await makeJudge("Kind judge", "KINDMARK"); // stub rates 8
     const harshId = await makeJudge("Harsh judge", "HARSHMARK"); // stub rates 2

--- a/engine/src/test/scriptScorerSpans.test.ts
+++ b/engine/src/test/scriptScorerSpans.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { nanoid } from "nanoid";
+import { openTestDb, type TestDb } from "./dbHarness.js";
+import type { Db } from "../storage/db.js";
+import { loadScorerSpans } from "../core/monitor/scriptScorer.js";
+
+// Pins the sandbox span contract that let the two-classifier bug survive: the ROOT went
+// through the unified classifier while every CHILD went through a stale pre-unification
+// ladder that ignored the stated span_kind and emitted the retired word "span" - so one
+// spans[] array mixed vocabularies by tree position, and a stated "memory" child was
+// unreachable from a code scorer forever.
+let test: TestDb;
+let db: Db;
+
+beforeAll(async () => {
+  test = await openTestDb();
+  db = test.scoped(await test.newProject("ScorerSpans"));
+}, 60_000);
+
+afterAll(async () => {
+  await test?.close();
+});
+
+describe("loadScorerSpans classification", () => {
+  it("children carry the same vocabulary as the root - stated kinds win, memory included", async () => {
+    const sessionId = "scorer-span-sess";
+    const rootId = nanoid();
+    const insert = async (values: Record<string, unknown>) => {
+      if (db.kind === "sqlite") {
+        await db.db.insert(db.schema.traces).values(values as never);
+      } else {
+        await db.db.insert(db.schema.traces).values(values as never);
+      }
+    };
+    await insert({
+      id: rootId,
+      projectId: db.projectId,
+      name: "agent-turn",
+      input: "q",
+      output: "a",
+      sessionId,
+      spanId: "root-1",
+      createdAt: new Date(),
+    });
+    await insert({
+      id: nanoid(),
+      projectId: db.projectId,
+      name: "user prefs",
+      input: "u-1",
+      output: "recalled",
+      sessionId,
+      spanId: "child-mem",
+      parentSpanId: "root-1",
+      spanKind: "memory",
+      createdAt: new Date(),
+    });
+    await insert({
+      id: nanoid(),
+      projectId: db.projectId,
+      name: "Memory recall",
+      input: "u-1",
+      output: "recalled",
+      sessionId,
+      spanId: "child-mem-name",
+      parentSpanId: "root-1",
+      createdAt: new Date(),
+    });
+    await insert({
+      id: nanoid(),
+      projectId: db.projectId,
+      // A stated kind must beat the model-presence inference for children too.
+      name: "guard",
+      model: "gpt-x",
+      sessionId,
+      spanId: "child-guard",
+      parentSpanId: "root-1",
+      spanKind: "guardrail",
+      createdAt: new Date(),
+    });
+
+    const spans = await loadScorerSpans(db, rootId);
+    const byName = Object.fromEntries(spans.map(s => [s.name, s.type]));
+    expect(byName["user prefs"]).toBe("memory");
+    expect(byName["Memory recall"]).toBe("memory");
+    expect(byName["guard"]).toBe("guardrail");
+    // The retired vocabulary word never appears.
+    expect(spans.some(s => s.type === "span")).toBe(false);
+  });
+});

--- a/engine/src/test/usageLimits.integration.test.ts
+++ b/engine/src/test/usageLimits.integration.test.ts
@@ -1,0 +1,56 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startEngine, postJson, type TestEngine } from "./server.js";
+
+// The read-only "Usage & limits" wire: today's spend against each daily cap, served by the
+// same counters the enforcement paths seed from. Caps come from env at engine start.
+
+let engine: TestEngine;
+let key: string;
+
+const api = (path: string, init?: Parameters<TestEngine["json"]>[1]) =>
+  engine.json(`/api/v1${path}`, { apiKey: key, ...(init ?? {}) });
+
+beforeAll(async () => {
+  engine = await startEngine({
+    OPENAI_API_KEY: "",
+    ANTHROPIC_API_KEY: "",
+    GEMINI_API_KEY: "",
+    AGENTX_QUOTA_TRACES_PER_DAY: "100",
+    AGENTX_QUOTA_ONLINE_JUDGE_CALLS_PER_DAY: "50",
+  });
+  const created = await engine.json("/api/v1/projects", { ...postJson({ name: "usage-limits" }), apiKey: null });
+  key = (created.body as { project: { apiKey: string } }).project.apiKey;
+}, 90_000);
+
+afterAll(async () => {
+  await engine?.stop();
+});
+
+describe("GET /agent-monitoring/usage", () => {
+  it("reports today's usage against the env-configured caps, and unlimited as null", async () => {
+    const before = (await api("/agent-monitoring/usage")).body as {
+      day: string;
+      resetsAt: string;
+      traces: { used: number; limit: number | null };
+      onlineJudgeCalls: { used: number; limit: number | null };
+      judgeCalls: { used: number; limit: number | null };
+    };
+    expect(before.traces).toEqual({ used: 0, limit: 100 });
+    expect(before.onlineJudgeCalls.limit).toBe(50);
+    // AGENTX_QUOTA_JUDGE_CALLS_PER_DAY unset = unlimited = null, never 0.
+    expect(before.judgeCalls.limit).toBeNull();
+    expect(before.day).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // Resets at the NEXT midnight UTC - the same boundary every cap uses.
+    expect(new Date(before.resetsAt).getTime()).toBeGreaterThan(Date.now());
+    expect(before.resetsAt.endsWith("T00:00:00.000Z")).toBe(true);
+
+    const ingested = await api(
+      "/ingest/traces",
+      postJson({ name: "usage-agent", span_id: "u-1", input: "q", output: "a" })
+    );
+    expect(ingested.status).toBe(200);
+
+    const after = (await api("/agent-monitoring/usage")).body as { traces: { used: number } };
+    expect(after.traces.used).toBe(1);
+  });
+});


### PR DESCRIPTION
…ory checks

<!-- Delete any section that does not apply. A one-line PR does not need all of this. -->

## What this changes, and why

<!-- The behaviour before and after. If it fixes a bug, what the bug actually was. -->

## How it was verified

<!-- Which suite, which command, run against what. "Tests pass" is not verification; naming the
     case that would have failed before is. Say so plainly if something is unverified. -->

## Checklist

- [ ] `yarn typecheck` and `yarn workspace @agentx/engine lint` pass
- [ ] `yarn workspace @agentx/engine test` passes
- [ ] Changed a response shape covered by `src/contract/wire.ts`? The contract is updated in this
      same commit
- [ ] New or changed mutating route? It validates with `validateBody(schema)`, and its entry is
      deleted from `routeBodyValidation.test.ts` if it had one
- [ ] Schema change? Additive DDL in `columnMigrations` (sqlite) and the `IF NOT EXISTS` block
      (pg), with existing ids left byte-identical
- [ ] New setting? It gates real behaviour. A control that stores state nothing reads is a bug
